### PR TITLE
feat(api): add project detail endpoint with param router support

### DIFF
--- a/apps/api/src/controllers/projects.controller.ts
+++ b/apps/api/src/controllers/projects.controller.ts
@@ -1,8 +1,16 @@
 import type { ApiResponse, Project } from '@webapp/types';
-import { ok } from '../lib/http.js';
+import { HttpError, ok } from '../lib/http.js';
 import type { RequestContext } from '../lib/http.js';
-import { listProjects } from '../services/projects.service.js';
+import { getProjectById, listProjects } from '../services/projects.service.js';
 
 export function listProjectsController(_ctx: RequestContext): ApiResponse<Project[]> {
   return ok(listProjects());
+}
+
+export function getProjectController(ctx: RequestContext): ApiResponse<Project> {
+  const id = ctx.params.id;
+  if (!id) throw HttpError.notFound(`No project with id ""`);
+  const project = getProjectById(id);
+  if (!project) throw HttpError.notFound(`No project with id "${id}"`);
+  return ok(project);
 }

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -9,6 +9,7 @@ export interface RequestContext {
   url: URL;
   requestId: string;
   req: IncomingMessage;
+  params: Readonly<Record<string, string>>;
 }
 
 export type RouteHandler = (ctx: RequestContext) => Promise<ApiResponse<unknown>> | ApiResponse<unknown>;
@@ -40,6 +41,24 @@ export function writeJson(
     'X-Request-Id': requestId,
   });
   res.end(JSON.stringify(body));
+}
+
+export class HttpError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details?: unknown;
+
+  constructor(status: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+    this.code = code;
+    if (details !== undefined) this.details = details;
+  }
+
+  static notFound(message: string, details?: unknown): HttpError {
+    return new HttpError(404, 'not_found', message, details);
+  }
 }
 
 export function isHttpMethod(method: string | undefined): method is HttpMethod {

--- a/apps/api/src/lib/router.ts
+++ b/apps/api/src/lib/router.ts
@@ -1,28 +1,115 @@
 import type { HttpMethod, RouteDefinition, RouteHandler } from './http.js';
 
+export interface RouteMatch {
+  handler: RouteHandler;
+  params: Record<string, string>;
+}
+
+interface CompiledRoute {
+  path: string;
+  segments: Array<{ kind: 'literal'; value: string } | { kind: 'param'; name: string }>;
+  handler: RouteHandler;
+}
+
+function compile(path: string): CompiledRoute['segments'] {
+  if (path[0] !== '/') throw new Error(`Route path must start with "/": "${path}"`);
+  if (path === '/') return [];
+  const parts = path.slice(1).split('/');
+  return parts.map((part) => {
+    if (part.startsWith(':')) {
+      const name = part.slice(1);
+      if (!name) throw new Error(`Invalid param in route "${path}"`);
+      return { kind: 'param', name };
+    }
+    return { kind: 'literal', value: part };
+  });
+}
+
+function splitPath(path: string): string[] {
+  if (path === '/') return [];
+  return path.slice(1).split('/');
+}
+
 export class Router {
-  private readonly byMethod = new Map<HttpMethod, Map<string, RouteHandler>>();
+  private readonly literal = new Map<HttpMethod, Map<string, RouteHandler>>();
+  private readonly patterned = new Map<HttpMethod, CompiledRoute[]>();
+  private readonly allPaths = new Set<string>();
 
   register(route: RouteDefinition): void {
-    const methodTable = this.byMethod.get(route.method) ?? new Map<string, RouteHandler>();
-    if (methodTable.has(route.path)) {
-      throw new Error(`Duplicate route ${route.method} ${route.path}`);
+    const segments = compile(route.path);
+    const hasParam = segments.some((s) => s.kind === 'param');
+
+    if (!hasParam) {
+      const table = this.literal.get(route.method) ?? new Map<string, RouteHandler>();
+      if (table.has(route.path)) throw new Error(`Duplicate route ${route.method} ${route.path}`);
+      table.set(route.path, route.handler);
+      this.literal.set(route.method, table);
+    } else {
+      const list = this.patterned.get(route.method) ?? [];
+      if (list.some((r) => r.path === route.path)) {
+        throw new Error(`Duplicate route ${route.method} ${route.path}`);
+      }
+      list.push({ path: route.path, segments, handler: route.handler });
+      this.patterned.set(route.method, list);
     }
-    methodTable.set(route.path, route.handler);
-    this.byMethod.set(route.method, methodTable);
+
+    this.allPaths.add(route.path);
   }
 
   registerAll(routes: RouteDefinition[]): void {
     for (const r of routes) this.register(r);
   }
 
-  match(method: HttpMethod, path: string): RouteHandler | null {
-    return this.byMethod.get(method)?.get(path) ?? null;
+  match(method: HttpMethod, path: string): RouteMatch | null {
+    const literalHit = this.literal.get(method)?.get(path);
+    if (literalHit) return { handler: literalHit, params: {} };
+
+    const patternList = this.patterned.get(method);
+    if (!patternList?.length) return null;
+
+    const requestSegments = splitPath(path);
+    for (const route of patternList) {
+      if (route.segments.length !== requestSegments.length) continue;
+      const params: Record<string, string> = {};
+      let matched = true;
+      for (let i = 0; i < route.segments.length; i++) {
+        const expected = route.segments[i]!;
+        const actual = requestSegments[i]!;
+        if (expected.kind === 'literal') {
+          if (expected.value !== actual) {
+            matched = false;
+            break;
+          }
+        } else {
+          if (!actual) {
+            matched = false;
+            break;
+          }
+          params[expected.name] = decodeURIComponent(actual);
+        }
+      }
+      if (matched) return { handler: route.handler, params };
+    }
+    return null;
   }
 
   hasPath(path: string): boolean {
-    for (const table of this.byMethod.values()) {
-      if (table.has(path)) return true;
+    if (this.allPaths.has(path)) return true;
+    const requestSegments = splitPath(path);
+    for (const list of this.patterned.values()) {
+      for (const route of list) {
+        if (route.segments.length !== requestSegments.length) continue;
+        let ok = true;
+        for (let i = 0; i < route.segments.length; i++) {
+          const expected = route.segments[i]!;
+          const actual = requestSegments[i]!;
+          if (expected.kind === 'literal' && expected.value !== actual) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) return true;
+      }
     }
     return false;
   }

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { env } from '../config/env.js';
 import {
   fail,
+  HttpError,
   isHttpMethod,
   writeJson,
   type RequestContext,
@@ -28,9 +29,9 @@ export async function handleRequest(
     return;
   }
 
-  const handler = router.match(rawMethod, path);
+  const match = router.match(rawMethod, path);
 
-  if (!handler) {
+  if (!match) {
     const status = router.hasPath(path) ? 405 : 404;
     const code = status === 405 ? 'method_not_allowed' : 'not_found';
     const message = status === 405 ? `Method ${rawMethod} not allowed for ${path}` : `No route for ${path}`;
@@ -45,10 +46,17 @@ export async function handleRequest(
     return;
   }
 
-  const ctx: RequestContext = { method: rawMethod, path, url, requestId, req };
+  const ctx: RequestContext = {
+    method: rawMethod,
+    path,
+    url,
+    requestId,
+    req,
+    params: Object.freeze({ ...match.params }),
+  };
 
   try {
-    const result = await handler(ctx);
+    const result = await match.handler(ctx);
     const status = result.ok ? 200 : 400;
     writeJson(res, status, result, requestId);
     logger.info('request handled', {
@@ -59,6 +67,17 @@ export async function handleRequest(
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {
+    if (err instanceof HttpError) {
+      writeJson(res, err.status, fail(err.code, err.message, err.details), requestId);
+      logger.info('request handled', {
+        requestId,
+        method: rawMethod,
+        path,
+        status: err.status,
+        durationMs: Date.now() - startedAt,
+      });
+      return;
+    }
     const message = err instanceof Error ? err.message : 'Unknown error';
     writeJson(res, 500, fail('internal_error', 'Internal server error'), requestId);
     logger.error('request failed', {

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,9 +1,13 @@
 import { healthController } from '../controllers/health.controller.js';
-import { listProjectsController } from '../controllers/projects.controller.js';
+import {
+  getProjectController,
+  listProjectsController,
+} from '../controllers/projects.controller.js';
 import type { RouteDefinition } from '../lib/http.js';
 
 export const routes: RouteDefinition[] = [
   { method: 'GET', path: '/health', handler: healthController },
   { method: 'GET', path: '/v1/health', handler: healthController },
   { method: 'GET', path: '/v1/projects', handler: listProjectsController },
+  { method: 'GET', path: '/v1/projects/:id', handler: getProjectController },
 ];

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -44,3 +44,60 @@ describe('GET /v1/projects', () => {
     expect(body.error.code).toBe('method_not_allowed');
   });
 });
+
+describe('GET /v1/projects/:id', () => {
+  let harness: Harness;
+
+  beforeAll(async () => {
+    harness = await startTestServer();
+  });
+
+  afterAll(async () => {
+    await harness.close();
+  });
+
+  it('returns an ok envelope with the matching project', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/projects/proj-1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+
+    const body = (await res.json()) as ApiResponse<Project>;
+    expect(body.ok).toBe(true);
+    if (!body.ok) throw new Error('expected ok envelope');
+
+    expect(body.data.id).toBe('proj-1');
+    expect(typeof body.data.name).toBe('string');
+    expect(typeof body.data.createdAt).toBe('string');
+    expect(typeof body.data.updatedAt).toBe('string');
+  });
+
+  it('returns 404 not_found envelope for an unknown id', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/projects/does-not-exist`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+
+    const body = (await res.json()) as ApiResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('not_found');
+    expect(body.error.message).toContain('does-not-exist');
+  });
+
+  it('decodes URI-encoded ids', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/projects/${encodeURIComponent('weird id/../x')}`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as ApiResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.message).toContain('weird id/../x');
+  });
+
+  it('rejects non-GET methods for /v1/projects/:id with 405 envelope', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/projects/proj-1`, { method: 'DELETE' });
+    expect(res.status).toBe(405);
+    const body = (await res.json()) as ApiResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('method_not_allowed');
+  });
+});

--- a/apps/api/src/services/projects.service.ts
+++ b/apps/api/src/services/projects.service.ts
@@ -22,3 +22,8 @@ const store: readonly Project[] = Object.freeze([
 export function listProjects(): Project[] {
   return store.map((p) => ({ ...p }));
 }
+
+export function getProjectById(id: string): Project | undefined {
+  const hit = store.find((p) => p.id === id);
+  return hit ? { ...hit } : undefined;
+}

--- a/project-memory/03-current-state.md
+++ b/project-memory/03-current-state.md
@@ -2,28 +2,34 @@
 
 Last verified: 2026-04-21.
 
+> Update (2026-04-21, later): WIP param router landed on `feat/api-project-detail`.
+> `GET /v1/projects/:id` + `HttpError` + tests added. 10/10 API tests pass.
+
 ## Branches
 
 - `main` — stable, pushed.
 - `feat/api-foundation` — origin has one extra commit (`de398ac` — `fix(types): add "type": "module" to fix named ESM exports under Node 24`) not yet in the integration branch. Tiny, isolated to `packages/types/package.json`.
 - `feat/frontend-steps-2-5-6` — shipped to integration.
-- `feat/integration-homepage-projects` — **current**, up-to-date with origin.
+- `feat/integration-homepage-projects` — up-to-date with origin.
+- `feat/api-project-detail` — **current**. Param router + `GET /v1/projects/:id` + `HttpError`.
 
 ## Done
 
 - Monorepo scaffold (pnpm, turbo, tsconfig base, CI stub).
 - Shared types (`@webapp/types`): `Project`, `Workspace`, `ChatWindow`, `AIProvider`, `ApiError`, `ApiResponse<T>`, `HealthStatus`.
 - Backend foundation: env parser, logger, request-id, Router, `handleRequest` middleware, `createApiServer`.
-- Endpoints: `GET /health`, `GET /v1/health`, `GET /v1/projects` (seed store, 2 items).
-- Vitest setup + 6 integration tests (health + projects) passing.
+- Endpoints: `GET /health`, `GET /v1/health`, `GET /v1/projects`, `GET /v1/projects/:id` (seed store, 2 items).
+- Vitest setup + 10 integration tests passing (health + projects list + projects detail + dispatch errors).
+- `HttpError` class in `lib/http.ts`: status-bearing throws → middleware converts to `ApiResponse` envelope.
+- Param router: `:id` compiled segments, `RouteMatch { handler, params }`, `ctx.params` frozen.
 - Frontend UI: AppShell, Panel, Button; Workspace feature (sidebar, canvas, composer, toolbar); Chat feature (ChatWindow, useChatSessions); window creation with presets + inline rename.
 - Frontend data boundary (`lib/data`) mocked.
 - Frontend API client (`lib/api/client`, `lib/api/projects`) + homepage wired to real `GET /v1/projects` with mock fallback + source badge (`api`, `api error`, `mock data`).
 
 ## In progress
 
-- Local uncommitted WIP in working tree on `apps/api/src/lib/http.ts` + `router.ts`: dynamic path params (`:id`). Adds `RequestContext.params` and a compiled-segment matcher to `Router`. Not staged, not stashed. Needs a feature branch + tests before landing.
 - `feat/api-foundation` has a newer commit on origin (`de398ac`) not merged into the integration branch yet.
+- `feat/api-project-detail` not yet pushed; needs PR into `feat/integration-homepage-projects` (or `main`).
 
 ## Blocked / missing
 

--- a/project-memory/04-active-tasks.md
+++ b/project-memory/04-active-tasks.md
@@ -4,11 +4,12 @@ Not a sprint board. Just concrete next actions. Update when you finish or add on
 
 ## Backend
 
-- [ ] Finish param router (`:id`), unstash and land on a feature branch.
-- [ ] `GET /v1/projects/:id` — 404 via `ApiError` envelope on unknown id.
-- [ ] Tests for param router + detail endpoint.
+- [x] Finish param router (`:id`), land on a feature branch (`feat/api-project-detail`).
+- [x] `GET /v1/projects/:id` — 404 via `HttpError` → `fail('not_found', …)` envelope.
+- [x] Tests for param router + detail endpoint (4 new, 10 total, all green).
 - [ ] Decide workspace storage shape; add `GET /v1/projects/:id/workspaces`.
 - [ ] Sync origin `feat/api-foundation` (`de398ac`) into integration branch.
+- [ ] Push `feat/api-project-detail` + open PR.
 
 ## Frontend
 

--- a/project-memory/05-api-map.md
+++ b/project-memory/05-api-map.md
@@ -4,11 +4,12 @@ Base: `http://localhost:<API_PORT|4000>`. Envelope: `ApiResponse<T>` from `@weba
 
 ## Endpoints
 
-| Method | Path           | Controller                  | Service             | Response         |
-|--------|----------------|-----------------------------|---------------------|------------------|
-| GET    | /health        | healthController            | —                   | `HealthStatus`   |
-| GET    | /v1/health     | healthController            | —                   | `HealthStatus`   |
-| GET    | /v1/projects   | listProjectsController      | `listProjects()`    | `Project[]`      |
+| Method | Path               | Controller                  | Service                 | Response         |
+|--------|--------------------|-----------------------------|-------------------------|------------------|
+| GET    | /health            | healthController            | —                       | `HealthStatus`   |
+| GET    | /v1/health         | healthController            | —                       | `HealthStatus`   |
+| GET    | /v1/projects       | listProjectsController      | `listProjects()`        | `Project[]`      |
+| GET    | /v1/projects/:id   | getProjectController        | `getProjectById(id)`    | `Project`        |
 
 All responses:
 
@@ -22,6 +23,7 @@ Status mapping (set by `handle-request`):
 - `ok:false` returned by controller → 400
 - Unknown path → 404 `not_found`
 - Known path, wrong method → 405 `method_not_allowed`
+- Controller throws `HttpError` → custom status + `fail(code, message)` envelope (e.g. 404 `not_found` for unknown resource id).
 - Unhandled throw → 500 `internal_error`
 
 Headers:
@@ -35,7 +37,7 @@ Headers:
 - Controllers: `apps/api/src/controllers/*.controller.ts`
 - Services: `apps/api/src/services/*.service.ts`
 - Envelope helpers (`ok`, `fail`, `writeJson`): `apps/api/src/lib/http.ts`
-- Router: `apps/api/src/lib/router.ts` (literal paths only; param support WIP stashed)
+- Router: `apps/api/src/lib/router.ts` (literal + `:param` segments, returns `RouteMatch { handler, params }`)
 - Middleware: `apps/api/src/middleware/handle-request.ts`
 - Env parser: `apps/api/src/config/env.ts`
 - Server factory: `apps/api/src/lib/server.ts`

--- a/project-memory/07-backend-map.md
+++ b/project-memory/07-backend-map.md
@@ -48,15 +48,15 @@ apps/api/src
 
 ## Sensitive zones
 
-- `lib/router.ts` — path matching; change carefully. Local WIP adds `:param` support.
-- `lib/http.ts` — envelope contract; do not break shape (web depends on it).
+- `lib/router.ts` — path matching; change carefully. Supports `:param` segments (decoded per-segment). `match` returns `RouteMatch { handler, params }`.
+- `lib/http.ts` — envelope contract; do not break shape (web depends on it). Exports `HttpError` for status-bearing throws from controllers.
 - `services/projects.service.ts` — in-memory store; will be swapped for DB. Keep interface narrow.
 - `middleware/handle-request.ts` — global error path; any throw must become a proper `ApiResponse` + status.
 
 ## Tests
 
 - Vitest, integration-style via `server-harness` spinning a real `http.Server` on ephemeral port.
-- 6 tests pass as of 2026-04-18. Run: `pnpm --filter @webapp/api test`.
+- 10 tests pass as of 2026-04-21. Run: `pnpm --filter @webapp/api test`.
 
 ## Env
 

--- a/project-memory/08-recent-changes.md
+++ b/project-memory/08-recent-changes.md
@@ -4,8 +4,10 @@ Newest first. One line per commit. Update at end of a session or via `tools/upda
 
 ## 2026-04-21
 
+- (pending commit on `feat/api-project-detail`) feat(api): `GET /v1/projects/:id` + `HttpError` + param router wiring + 4 new tests.
+- 26c9ad6 docs(memory): add Claude restart workflow note
+- 7cb01aa chore(memory): correct WIP state — working tree, not stash
 - c4ae1ac chore(memory): add project-memory system and refresh tooling
-- Local WIP in working tree (uncommitted, unstashed): dynamic path params in api `Router` + `RequestContext.params` (`apps/api/src/lib/{http,router}.ts`).
 
 ## 2026-04-18
 


### PR DESCRIPTION
## Summary

- add `GET /v1/projects/:id`
- support `:param` routes in router
- carry `params` into request context
- add `HttpError` with proper 404 mapping
- add tests for detail, 404, URI-decoding, 405
- update project memory files to reflect backend progress

## Test plan

- [x] `pnpm --filter @webapp/api typecheck`
- [x] `pnpm --filter @webapp/api test` — 10/10 pass
- [ ] Manual: `curl /v1/projects/proj-1` returns 200, unknown id returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)