### PR TITLE
chore(tooling): adrs, roadmap, env placeholders, e2e scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,15 @@ API_PORT=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 PERPLEXITY_API_KEY=
+
+# ── Observability (prepared — not wired yet) ──────────────────────────────────
+# Error tracking (Sentry). Leave empty to disable.
+# Server DSN (apps/api). See docs/technical/adr/0002-sentry-for-error-tracking.md
+SENTRY_DSN=
+# Browser DSN (apps/web). Safe to expose to the client.
+NEXT_PUBLIC_SENTRY_DSN=
+
+# ── Product analytics (prepared — not wired yet) ──────────────────────────────
+# PostHog. Leave empty to disable. See docs/technical/adr/0003-posthog-deferred.md
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,52 @@ jobs:
 
       - name: Lint
         run: pnpm lint || echo "lint placeholder"
+
+  e2e-smoke:
+    # Non-blocking scaffold. Real UI scenarios land in wave 2 of the tooling
+    # roadmap — see docs/technical/adr/0004-playwright-scaffold-only.md.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: check
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Start API in background (in-memory mode — no DATABASE_URL)
+        run: |
+          pnpm --filter @webapp/api dev > /tmp/api.log 2>&1 &
+          echo $! > /tmp/api.pid
+
+      - name: Wait for API /health
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4000/health > /dev/null; then
+              echo "api is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "api did not come up within 30s" >&2
+          cat /tmp/api.log || true
+          exit 1
+
+      - name: Run smoke test
+        run: pnpm --filter @webapp/e2e test
+
+      - name: Stop API
+        if: always()
+        run: |
+          if [ -f /tmp/api.pid ]; then
+            kill "$(cat /tmp/api.pid)" 2>/dev/null || true
+          fi

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -1,0 +1,37 @@
+# @webapp/e2e
+
+End-to-end test scaffold. **Scaffold only** — real UI scenarios land in wave 2
+of `docs/technical/tooling-roadmap.md`.
+
+## What is here today
+
+- `playwright.config.ts` — minimal config, no browser project.
+- `tests/smoke.spec.ts` — hits `GET /health` over HTTP using Playwright's
+  `request` fixture. No browser binary needed.
+
+## Run locally
+
+```bash
+# 1. Start the API in another terminal
+pnpm --filter @webapp/api dev
+
+# 2. Run the smoke test
+pnpm --filter @webapp/e2e test
+```
+
+Override the target with `E2E_API_URL=http://host:port pnpm -F @webapp/e2e test`.
+
+## CI
+
+Runs in the `e2e-smoke` job of `.github/workflows/ci.yml` with
+`continue-on-error: true`. Non-blocking until wave 2.
+
+## Wave 2
+
+Wave 2 will add:
+
+- Chromium install step in CI.
+- `tests/auth.spec.ts`, `tests/provider-connect.spec.ts`, `tests/chat-send.spec.ts`.
+- Remove `continue-on-error` once green on `main` twice in a row.
+
+See `docs/technical/adr/0004-playwright-scaffold-only.md`.

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@webapp/e2e",
+  "version": "0.1.0",
+  "private": true,
+  "description": "End-to-end smoke + UI scaffold (scaffold only — real scenarios in wave 2)",
+  "scripts": {
+    "test": "playwright test",
+    "test:smoke": "playwright test tests/smoke.spec.ts",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf test-results playwright-report .turbo"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^22.10.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Minimal Playwright scaffold. Wave 1 uses only the `request` fixture
+ * (no browser). Wave 2 will add a `chromium` project and UI specs.
+ *
+ * The API URL can be overridden with E2E_API_URL. Defaults match the
+ * local dev server booted by `pnpm --filter @webapp/api dev`.
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 15_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'list' : 'list',
+  use: {
+    baseURL: process.env.E2E_API_URL ?? 'http://localhost:4000',
+    extraHTTPHeaders: {
+      Accept: 'application/json',
+    },
+  },
+});

--- a/apps/e2e/tests/smoke.spec.ts
+++ b/apps/e2e/tests/smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test — scaffold only.
+ *
+ * Hits the API `/health` endpoint over HTTP. No browser, no UI assertions.
+ * Real UI scenarios (auth, provider-connect, chat-send) land in wave 2.
+ * See docs/technical/adr/0004-playwright-scaffold-only.md
+ */
+test('API /health returns a healthy envelope', async ({ request }) => {
+  const res = await request.get('/health');
+
+  expect(res.status()).toBe(200);
+
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(body.data).toBeTruthy();
+});

--- a/apps/e2e/tsconfig.json
+++ b/apps/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["tests/**/*.ts", "playwright.config.ts"]
+}

--- a/docs/technical/adr/0001-keep-drizzle-postgres.md
+++ b/docs/technical/adr/0001-keep-drizzle-postgres.md
@@ -1,0 +1,37 @@
+# ADR 0001 — Keep Drizzle + Postgres, do not migrate to Supabase
+
+- **Status:** Accepted
+- **Date:** 2026-04-23
+- **Deciders:** X (tech lead)
+
+## Context
+
+`apps/api` uses Drizzle ORM against a local Postgres 16 (via `docker-compose.yml`).
+Three migrations are already applied (`0000..0002`), including `message_provider_metadata`.
+Auth is custom: `src/db/sessions.repo.ts`, `src/db/users.repo.ts`, `src/lib/session-token.ts`,
+`src/lib/cookie.ts`, `src/lib/resolve-user.ts`. Provider API keys are encrypted at rest
+with AES-256-GCM (`src/lib/api-key-cipher.ts`, `PROVIDER_ENCRYPTION_KEY`).
+
+The team discussed adopting Supabase. Supabase brings three things: hosted Postgres,
+Supabase Auth (GoTrue), and Row Level Security primitives.
+
+## Decision
+
+We keep Drizzle + self-hosted Postgres + the current home-rolled cookie-session auth.
+We do **not** migrate to Supabase Auth. We do **not** rewrite repositories against
+the Supabase client.
+
+## Consequences
+
+- Zero churn on a working auth flow, working encryption flow, and a test suite that
+  already exercises the real HTTP surface.
+- We keep full control over the schema and migrations via `drizzle-kit`.
+- Hosting Postgres on Supabase (as a plain managed Postgres provider, via
+  `DATABASE_URL`) remains an option — re-evaluated at deployment time. Tracked in
+  `docs/technical/tooling-roadmap.md` wave 4.
+
+## Rejected alternatives
+
+- **Supabase Auth** — would require rewriting sessions/users/resolve-user, all auth
+  tests, and the provider-connection flow. No product value at this stage.
+- **Prisma** — no incident with Drizzle; migration cost is gratuitous.

--- a/docs/technical/adr/0002-sentry-for-error-tracking.md
+++ b/docs/technical/adr/0002-sentry-for-error-tracking.md
@@ -1,0 +1,48 @@
+# ADR 0002 — Sentry for error tracking (API + web)
+
+- **Status:** Accepted — integration deferred to wave 1 of the tooling roadmap
+- **Date:** 2026-04-23
+- **Deciders:** X (tech lead)
+
+## Context
+
+`apps/api` handles auth, encrypted provider secrets, and proxies calls to three
+upstream LLMs. A silent server error in this path is expensive: a user could lose
+a message, see a cryptic 500, or hit an unreported provider rate limit.
+
+`apps/web` (Next.js 15 App Router, React 19) has no runtime error reporting.
+Today a client-side exception is invisible unless the user screenshots the console.
+
+## Decision
+
+Adopt Sentry for both apps.
+
+- **API** — `@sentry/node`, init at server bootstrap (`apps/api/src/index.ts`),
+  capture from the `internal_error` branch of `src/middleware/handle-request.ts`
+  (already the single centralized error path).
+- **Web** — `@sentry/nextjs`, standard wizard integration.
+
+DSNs are read from `SENTRY_DSN` (server) and `NEXT_PUBLIC_SENTRY_DSN` (client).
+Both are empty by default — Sentry stays disabled in dev and in any env that does
+not set them.
+
+Scope for the first integration:
+
+- Unhandled error capture only.
+- Error sampling 100%; transaction sampling 10% in production, 0% elsewhere.
+- No performance tracing, no session replay, no release health — deferred.
+
+## Consequences
+
+- Additive, non-destructive — zero change to business logic, no new runtime
+  dependency for users who leave the DSN empty.
+- Two small PRs: one per app. Surfaces are disjoint (L owns api, E owns web).
+- Source-maps upload, release tagging, performance and replay are explicit
+  follow-ups, not part of wave 1.
+
+## Rejected alternatives
+
+- **Logs-only (Pino/Winston + hosted log service)** — gives lines, not grouped
+  errors with stack traces and breadcrumbs; poor fit for a multi-provider proxy.
+- **Vercel / Next.js built-in analytics** — covers web only, not the api, and is
+  not an error tracker.

--- a/docs/technical/adr/0003-posthog-deferred.md
+++ b/docs/technical/adr/0003-posthog-deferred.md
@@ -1,0 +1,43 @@
+# ADR 0003 — PostHog: prepared, integration deferred
+
+- **Status:** Accepted — prepared only, no runtime integration in this PR
+- **Date:** 2026-04-23
+- **Deciders:** X (tech lead)
+
+## Context
+
+PostHog would give us product analytics (funnels, retention) and feature flags.
+Both are real needs — but only once we have real users producing real sessions.
+Today the web app is pre-MVP: no signup flow exposed, no users outside the team,
+and the product surface (workspaces, chat windows, provider connections) is still
+moving week to week. Instrumenting moving code produces events whose schema has
+to be thrown away and re-coded.
+
+## Decision
+
+Prepare, do not integrate.
+
+- Reserve env vars in `.env.example`: `NEXT_PUBLIC_POSTHOG_KEY`,
+  `NEXT_PUBLIC_POSTHOG_HOST` (default to `https://eu.i.posthog.com` for GDPR).
+- Document the event naming convention in
+  `docs/technical/tooling-roadmap.md` so the first instrumentation PR is mechanical.
+- No PostHog SDK in `apps/web/package.json`, no provider wrapper, no events.
+
+## Trigger to lift the deferral
+
+When **two** of the following are true, open the wave-3 PR:
+
+1. Signup + login are reachable to non-team users.
+2. The chat-window + message flow has not been reshaped for two consecutive weeks.
+3. A product question requires a funnel we cannot answer from the DB alone.
+
+## Consequences
+
+- Zero runtime cost, zero client bundle impact today.
+- Convention is set now, so the first instrumentation PR does not bikeshed names.
+
+## Rejected alternatives
+
+- **Instrument now with placeholder events** — guarantees a schema rewrite.
+- **Google Analytics / Plausible** — insufficient for product funnels, no feature
+  flags, and we don't need marketing-site analytics.

--- a/docs/technical/adr/0004-playwright-scaffold-only.md
+++ b/docs/technical/adr/0004-playwright-scaffold-only.md
@@ -1,0 +1,50 @@
+# ADR 0004 — Playwright: scaffold only, real scenarios deferred
+
+- **Status:** Accepted — scaffold in this PR, real UI scenarios in wave 2
+- **Date:** 2026-04-23
+- **Deciders:** X (tech lead)
+
+## Context
+
+`apps/api` has solid Vitest coverage over the real HTTP surface (see
+`src/test/server-harness.ts`). `apps/web` has **zero** tests. The product-level
+golden path (signup → connect provider → create workspace → send message)
+crosses both apps and is therefore not covered by anything today.
+
+Playwright is the right tool for that golden path. But writing DOM selectors
+against a frontend that is still being reshaped produces brittle tests that
+block PRs for reasons unrelated to the change under review.
+
+## Decision
+
+Ship a **minimal Playwright scaffold** now, with a single smoke test that hits
+`GET /health` over HTTP — no browser, no UI, no selectors. This proves the
+scaffold is sound (install, config, CI job) and gives wave 2 a zero-day start.
+
+Real UI scenarios are written in wave 2, once the frontend has been stable for
+two consecutive weeks.
+
+## Scaffold shape
+
+- Workspace: `apps/e2e/` (picked up by the existing `apps/*` glob in
+  `pnpm-workspace.yaml`).
+- Dependency: `@playwright/test` only. **No browsers installed** — the smoke
+  test uses Playwright's `request` fixture.
+- One file: `apps/e2e/tests/smoke.spec.ts`.
+- CI job `e2e-smoke`, `continue-on-error: true`. Non-blocking until wave 2.
+
+## Consequences
+
+- Tiny blast radius. No `apps/web/src/**` or `apps/api/src/**` change.
+- When wave 2 lands, it adds files under `apps/e2e/tests/` and optionally
+  installs chromium; it does not have to re-argue the scaffold.
+- The CI job stays green even if someone deletes the smoke test by accident
+  (`continue-on-error: true`), so a broken scaffold cannot block `main`.
+
+## Rejected alternatives
+
+- **Cypress** — heavier install, no first-class `request`-only mode without a
+  browser, and no reason to differ from the rest of the Node toolchain.
+- **Wait until wave 2 to even scaffold** — leaves wave 2 with install + config
+  + CI + first test all in one PR, which is exactly the kind of batch we want
+  to avoid.

--- a/docs/technical/tooling-roadmap.md
+++ b/docs/technical/tooling-roadmap.md
@@ -1,0 +1,98 @@
+# Tooling roadmap
+
+Status of the four external tools discussed (Supabase, PostHog, Sentry, Playwright)
+and the order in which they land. Companion to ADRs 0001–0004.
+
+## Principles
+
+- One tool per wave. No simultaneous big integrations.
+- Additive PRs only. No destructive migration of working subsystems.
+- `apps/api/src/**`, `apps/web/src/**` and `packages/**` are not touched by
+  tooling-foundation work (this PR) — they are touched only by the wave that
+  owns the integration.
+
+## Waves
+
+### Wave 1 — Sentry (now)
+
+Owner split:
+
+- **L** — `apps/api`: `@sentry/node` init in `src/index.ts`, capture from the
+  `internal_error` branch of `src/middleware/handle-request.ts`.
+- **E** — `apps/web`: `@sentry/nextjs` via the official wizard.
+
+DSNs from `SENTRY_DSN` / `NEXT_PUBLIC_SENTRY_DSN`. Empty ⇒ Sentry disabled.
+Scope: unhandled errors only. Performance tracing, session replay, release
+health, source-maps upload — **not** in wave 1.
+
+Exit criteria: a deliberately-thrown error in api and in web appears in Sentry
+under the correct project, with a request id on the api side.
+
+### Wave 2 — Playwright real scenarios (when frontend has been stable 2 weeks)
+
+Scaffold already exists in `apps/e2e/` (this PR). Wave 2 adds:
+
+- Chromium browser install step in the `e2e-smoke` CI job.
+- Three UI specs covering the golden path:
+  - `auth.spec.ts` — signup, login, logout, `me`.
+  - `provider-connect.spec.ts` — add OpenAI key, live connection test passes.
+  - `chat-send.spec.ts` — create workspace → create chat window → send a
+    message → assistant reply persists with provider metadata.
+- Flip `continue-on-error` off once the three specs are green on `main` twice
+  in a row.
+
+### Wave 3 — PostHog real instrumentation (when product is live)
+
+Triggered by ADR 0003 criteria. Scope of the first PR:
+
+- `@posthog/node` in api (server-side events for auth, provider connections).
+- `posthog-js` in web, initialized behind `NEXT_PUBLIC_POSTHOG_KEY`.
+- First batch of events (see convention below).
+- One feature flag, round-tripped through the UI to validate the wiring.
+
+### Wave 4 — Supabase as managed Postgres (deployment-time decision only)
+
+Evaluated **only** as a hosted Postgres provider via `DATABASE_URL`. Not as
+Supabase Auth, not as a replacement for Drizzle, not for RLS. ADR 0001 stands.
+Decision point: when the app moves off the local `docker-compose.yml` Postgres
+toward a hosted environment.
+
+---
+
+## Instrumentation convention (applies to wave 1 and wave 3)
+
+### Event names — `snake_case`, verb first
+
+Good: `user_signed_up`, `provider_connection_created`, `message_sent`,
+`workspace_opened`, `chat_window_created`.
+
+Bad: `UserSignedUp`, `signup`, `new_message`, `click_button_42`.
+
+### Event properties — `camelCase`
+
+Good: `{ provider: 'openai', workspaceId: 'ws_…', chatWindowId: 'cw_…' }`.
+
+Bad: `{ Provider: 'OpenAI', workspace_id: 'ws_…' }`.
+
+### Hard rules
+
+1. **No raw PII.** Never send email, display name, IP, or user agent as an
+   event property. Send `userId` (the opaque server id) and nothing else that
+   identifies a person.
+2. **No provider API keys, ever.** Not as a property, not hashed, not
+   truncated, not as a label. Presence/absence is expressed by a boolean like
+   `hasOpenaiKey`.
+3. **No message content.** Event properties for `message_sent` are metadata
+   only: `provider`, `model`, `chatWindowId`, `tokenCount` (when available),
+   `latencyMs`. Never `content`.
+4. **Server emits server events; client emits client events.** A signup is a
+   server event (api knows it happened). A "user clicked the composer" is a
+   client event. Do not double-count.
+5. **Error-track, don't event-track, errors.** Crashes go to Sentry. Only
+   successful state transitions are PostHog events.
+
+### Sampling
+
+- Sentry errors: 100%.
+- Sentry transactions (when later enabled): 10% in prod, 0% elsewhere.
+- PostHog: 100% — no sampling until volume justifies it.


### PR DESCRIPTION
## Summary

Non-destructive tooling foundation — four ADRs, a roadmap, `.env.example` placeholders, a Playwright scaffold, and a non-blocking CI job.

**No change to `apps/web/src/**`, `apps/api/src/**`, or `packages/**`.** No Sentry / PostHog / Supabase integration yet — those are explicit follow-up PRs per the roadmap.

## What is in this PR

- `.env.example` — commented placeholders for `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`. Empty values — Sentry/PostHog disabled by default.
- `docs/technical/adr/0001-keep-drizzle-postgres.md` — reject Supabase migration; keep Drizzle + custom auth + AES-256-GCM.
- `docs/technical/adr/0002-sentry-for-error-tracking.md` — adopt Sentry (api + web) in wave 1.
- `docs/technical/adr/0003-posthog-deferred.md` — prepare only; trigger criteria for lifting the deferral.
- `docs/technical/adr/0004-playwright-scaffold-only.md` — scaffold now, real UI specs in wave 2.
- `docs/technical/tooling-roadmap.md` — four-wave plan + instrumentation convention (snake_case events, camelCase props, no PII, no provider keys in clear).
- `apps/e2e/` — minimal Playwright workspace, one HTTP smoke test hitting `/health` via the `request` fixture (no browser install).
- `.github/workflows/ci.yml` — adds `e2e-smoke` job, `continue-on-error: true`, runs after `check`.

## Surfaces explicitly untouched

- `apps/web/src/**`
- `apps/api/src/**`
- `packages/**`

## Test plan

- [ ] `check` job passes on CI.
- [ ] `e2e-smoke` job runs (may be green or go to error, non-blocking — that is the point of wave 1).
- [ ] Locally: `pnpm --filter @webapp/api dev` then `pnpm --filter @webapp/e2e test` → smoke test green.
- [ ] `pnpm typecheck` still green at repo root.

## Next owners

- **L** — wave 1 api Sentry PR (`feat(api): sentry init`).
- **E** — wave 1 web Sentry PR (`feat(web): sentry init`).
- **X** — review both; revisit roadmap before wave 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)