### PR TITLE
chore(ci): issue + PR templates matching label taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/backend.yml
+++ b/.github/ISSUE_TEMPLATE/backend.yml
@@ -1,0 +1,85 @@
+name: Backend task
+description: API / DB / providers / auth work in apps/api
+title: "[backend] <type>(<area>): <short imperative>"
+labels: ["role:backend"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill every section. Agents pick up tasks by reading this exact shape.
+        Label namespaces used: `role:*`, `type:*`, `P0-now|P1-week|P2-soon|P3-backlog`, `ai:autonomous|ai:human-checkpoint`, `risk:safe|risk:review-required|risk:destructive`.
+        Custom Project fields: **Owner** (L/E/X), **Area** (api/web/ci/memory/packages-types), **Status**, **Priority**.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One paragraph. What outcome are we after, in business/product terms.
+      placeholder: Persist chat messages with the user's provider key…
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist. Each box is verifiable by reading code, running tests, or hitting an endpoint.
+      value: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Bullet list. Anything the agent must NOT touch in this PR.
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      description: How to verify. Commands, fixtures, manual steps.
+      placeholder: |
+        - Vitest: new test covers the provider-error branch.
+        - Manual: POST /v1/messages with missing connection → 412.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0-now
+        - P1-week
+        - P2-soon
+        - P3-backlog
+    validations:
+      required: true
+
+  - type: dropdown
+    id: autonomy
+    attributes:
+      label: AI autonomy
+      description: ai:autonomous = agent runs to PR on its own. ai:human-checkpoint = agent stops after the plan.
+      options:
+        - ai:autonomous
+        - ai:human-checkpoint
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk
+      description: risk:safe = reversible local change. risk:review-required = non-trivial. risk:destructive = data or security impact; always human-gated.
+      options:
+        - risk:safe
+        - risk:review-required
+        - risk:destructive
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Source backlog
+    url: https://github.com/Yuume2/WebAppV1/blob/main/project-memory/backlog/issues.json
+    about: The canonical backlog lives in issues.json. Prefer editing it there and re-running tools/create-github-issues.mjs.

--- a/.github/ISSUE_TEMPLATE/coord.yml
+++ b/.github/ISSUE_TEMPLATE/coord.yml
@@ -1,0 +1,80 @@
+name: Coordination task
+description: CI, tooling, docs, memory, cross-cutting
+title: "[coord] <type>(<area>): <short imperative>"
+labels: ["role:coord"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill every section. Agents pick up tasks by reading this exact shape.
+        Label namespaces used: `role:*`, `type:*`, `P0-now|P1-week|P2-soon|P3-backlog`, `ai:autonomous|ai:human-checkpoint`, `risk:safe|risk:review-required|risk:destructive`.
+        Custom Project fields: **Owner** (L/E/X), **Area** (api/web/ci/memory/packages-types), **Status**, **Priority**.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One paragraph. Why does this exist and what does "done" look like.
+      placeholder: Make CI fail on broken types instead of echoing "ok"…
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist. Each box verifiable in the resulting PR or repo state.
+      value: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Bullet list. Anything the agent must NOT touch in this PR.
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      description: How to verify the change worked. For docs/memory, describe the grep or review step.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0-now
+        - P1-week
+        - P2-soon
+        - P3-backlog
+    validations:
+      required: true
+
+  - type: dropdown
+    id: autonomy
+    attributes:
+      label: AI autonomy
+      options:
+        - ai:autonomous
+        - ai:human-checkpoint
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk
+      options:
+        - risk:safe
+        - risk:review-required
+        - risk:destructive
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/frontend.yml
+++ b/.github/ISSUE_TEMPLATE/frontend.yml
@@ -1,0 +1,85 @@
+name: Frontend task
+description: Next.js / UI work in apps/web
+title: "[frontend] <type>(<area>): <short imperative>"
+labels: ["role:frontend"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill every section. Agents pick up tasks by reading this exact shape.
+        Label namespaces used: `role:*`, `type:*`, `P0-now|P1-week|P2-soon|P3-backlog`, `ai:autonomous|ai:human-checkpoint`, `risk:safe|risk:review-required|risk:destructive`.
+        Custom Project fields: **Owner** (L/E/X), **Area** (api/web/ci/memory/packages-types), **Status**, **Priority**.
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One paragraph. What outcome are we after, in business/product terms.
+      placeholder: Let users submit their API key from a settings page…
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Checklist. Each box verifiable via UI, Playwright, or unit test.
+      value: |
+        - [ ] …
+        - [ ] …
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Bullet list. Anything the agent must NOT touch in this PR.
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test plan
+      description: How to verify. Playwright spec, manual steps, screenshots.
+      placeholder: |
+        - Playwright vs stub backend: send message → assistant renders.
+        - Manual: API unset → mock fallback still works.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0-now
+        - P1-week
+        - P2-soon
+        - P3-backlog
+    validations:
+      required: true
+
+  - type: dropdown
+    id: autonomy
+    attributes:
+      label: AI autonomy
+      description: ai:autonomous = agent runs to PR on its own. ai:human-checkpoint = agent stops after the plan.
+      options:
+        - ai:autonomous
+        - ai:human-checkpoint
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk
+      description: risk:safe = reversible local change. risk:review-required = non-trivial. risk:destructive = data or security impact; always human-gated.
+      options:
+        - risk:safe
+        - risk:review-required
+        - risk:destructive
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Title convention (keep the prefix from the issue): [backend|frontend|coord] <type>(<area>): <short imperative>
+-->
+
+## Closes
+
+Closes #
+
+## Summary
+
+One paragraph. What changed and why — not what the diff contains.
+
+## Acceptance criteria
+
+<!-- Mirror the issue's AC checklist. Every box must be literally true before requesting review. -->
+
+- [ ] …
+- [ ] …
+
+## Out of scope
+
+<!-- Anything in the issue's Out-of-scope that a reviewer might otherwise expect. -->
+
+## Test plan
+
+<!-- Commands and manual steps. Paste relevant output if non-trivial. -->
+
+- [ ] `pnpm typecheck`
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm build` (if backend or shared types changed)
+- [ ] Manual check: …
+
+## Risk and autonomy
+
+<!-- Copy from the source issue. -->
+
+- Risk: `risk:safe` | `risk:review-required` | `risk:destructive`
+- Autonomy: `ai:autonomous` | `ai:human-checkpoint`
+
+## Follow-ups
+
+<!-- If the agent opened a delta at project-memory/backlog/issues.delta.json, note it here. -->
+
+- Delta proposed: yes / no
+- Decision: `AUTO-APPLIED` / `HOLD — <reason>`
+
+## Project
+
+<!-- Reviewer sanity check -->
+
+- Owner: L / E / X
+- Area: api / web / ci / memory / packages-types
+- Priority: P0-now / P1-week / P2-soon / P3-backlog


### PR DESCRIPTION
## Closes

Closes #44

## Summary

Adds repo-level issue forms (backend / frontend / coord) and a PR template. Each issue form enforces Goal / Acceptance criteria / Out-of-scope / Test-plan, plus dropdowns bound to the existing label taxonomy so agents and humans file issues in the same shape. The PR template mirrors the AC checklist and requires a `Closes #` link. No code touched.

## Acceptance criteria

- [x] `.github/ISSUE_TEMPLATE/backend.yml` — Goal / AC / Out-of-scope / Test-plan + priority/autonomy/risk dropdowns.
- [x] `.github/ISSUE_TEMPLATE/frontend.yml` — same shape, frontend-scoped placeholders.
- [x] `.github/ISSUE_TEMPLATE/coord.yml` — same shape, coord/tooling-scoped.
- [x] `.github/pull_request_template.md` — AC checklist + `Closes #` line + risk/autonomy reminders.
- [x] Templates reference label namespaces (`role:*`, `type:*`, `P*`, `ai:*`, `risk:*`).
- [x] `config.yml` disables blank issues and points at the canonical backlog.

## Out of scope

- Automation (issue labeling workflows, label-sync actions).
- Seeding labels (covered by a separate coord issue).

## Test plan

- [x] `pnpm typecheck` — green (cached, no code changes).
- [x] YAML shape check: each form has `name:` + `body:` + three required dropdowns.
- [ ] Manual on GitHub: open the "New issue" picker on `main` post-merge, confirm three forms appear.

## Risk and autonomy

- Risk: `risk:safe`
- Autonomy: `ai:autonomous`

## Follow-ups

- Delta proposed: no — scope fully covered by this PR.
- Decision: n/a