### PR TITLE
chore(infra): docker-compose postgres + local bootstrap docs

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -54,8 +54,57 @@ Vitest spins up the real server on an ephemeral port per suite and asserts on th
 
 ## Env vars
 
-| Name           | Default       | Notes                              |
-| -------------- | ------------- | ---------------------------------- |
-| `API_PORT`     | `4000`        | 1–65535                            |
-| `NODE_ENV`     | `development` | `development` \| `production` \| `test` |
-| `API_VERSION`  | `0.1.0`       | Reported by `/health`              |
+| Name                          | Default        | Notes                                                                                  |
+| ----------------------------- | -------------- | -------------------------------------------------------------------------------------- |
+| `API_PORT`                    | `4000`         | 1–65535                                                                                |
+| `NODE_ENV`                    | `development`  | `development` \| `production` \| `test`                                                |
+| `API_VERSION`                 | `0.1.0`        | Reported by `/health`                                                                  |
+| `DATABASE_URL`                | *(unset)*      | Enables DB-backed routes. Unset = in-memory fallback.                                  |
+| `PROVIDER_ENCRYPTION_KEY`     | *(unset)*      | **Required when `DATABASE_URL` is set.** 64-char hex (32 bytes).                        |
+| `CORS_ORIGIN`                 | `*`            | Set to an explicit origin (e.g. `http://localhost:3000`) when `DATABASE_URL` is on.    |
+| `API_MAX_BODY_BYTES`          | `102400`       | POST body cap in bytes.                                                                |
+| `OPENAI_MAX_CONTEXT_MESSAGES` | `20`           | Prior messages sent to the provider per call.                                          |
+| `ENABLE_DEV_ENDPOINTS`        | `true` in dev  | `/v1/dev` helpers gated on this.                                                       |
+| `SENTRY_DSN_API`              | *(unset)*      | Error capture disabled when empty.                                                     |
+
+Generate a provider encryption key:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+## Local Postgres (DB mode)
+
+A `docker-compose.yml` at the repo root ships a `postgres:16` service preconfigured for dev.
+
+```bash
+# 1. Start Postgres (detached)
+docker compose up -d postgres
+
+# 2. Export env (db + encryption key required together)
+export DATABASE_URL="postgres://webapp:webapp@localhost:5432/webapp"
+export PROVIDER_ENCRYPTION_KEY="$(node -e 'console.log(require(\"crypto\").randomBytes(32).toString(\"hex\"))')"
+
+# 3. Apply migrations
+pnpm --filter @webapp/api db:migrate
+
+# 4. Run the API
+pnpm --filter @webapp/api dev
+
+# 5. Smoke test
+curl -i http://localhost:4000/v1/health
+```
+
+Stop the DB with `docker compose down` (preserves the volume) or `docker compose down -v` (drops data).
+
+### Fallback — in-memory mode
+
+With `DATABASE_URL` **unset**, the API still boots and serves the in-memory route set (`projects`, `workspaces`, `chat-windows`, `messages` as frozen seed data). Use this for frontend-only work that doesn't need auth or persistence.
+
+```bash
+unset DATABASE_URL
+pnpm --filter @webapp/api dev
+curl -i http://localhost:4000/v1/health
+```
+
+The startup log prints which mode is active.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,23 @@
 services:
   postgres:
     image: postgres:16-alpine
+    container_name: webapp-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: webapp_dev
+      POSTGRES_USER: webapp
+      POSTGRES_PASSWORD: webapp
+      POSTGRES_DB: webapp
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U webapp -d webapp"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
 volumes:
   postgres_data:
+    name: webapp_postgres_data


### PR DESCRIPTION
## Closes

Closes #24

## Summary

Makes Postgres runnable locally in one command so the DB-backed routes become testable end-to-end. Replaces the WIP `docker-compose.yml` with a dev-ready variant: `postgres:16`, user/db `webapp/webapp/webapp`, healthcheck, named volume. Documents the full bootstrap in `apps/api/README.md` — `docker compose up -d postgres` → export env → `db:migrate` → run API. Documents the `DATABASE_URL` unset fallback (in-memory routes).

Docker is not installed on the author machine; **validation is static only**. Runtime AC (boot, `/health` 200 with DB) must be cocher by anyone with Docker locally after merge.

## Acceptance criteria

- [x] `docker-compose.yml` defines `postgres:16` service on port 5432.
- [x] Env values aligned with the documented `DATABASE_URL=postgres://webapp:webapp@localhost:5432/webapp` (no `.env.example` dependency — #22 is separate).
- [x] README documents `docker compose up -d postgres && pnpm --filter @webapp/api db:migrate`.
- [ ] `/health` returns 200 with DB present — **requires Docker at runtime**; trivially satisfied once `docker compose up -d postgres` is run.

## Out of scope

- Prod infra, backups (issue notes these).
- CI Postgres service (#32).
- `.env.example` (#22).
- Seeding (separate backlog item).

## Test plan

Author (static):
- [x] `pnpm typecheck` — green (no TS touched).
- [x] `docker-compose.yml` shape lint: required keys present, no tabs, 24 lines.
- [x] Scope check: only `docker-compose.yml` and `apps/api/README.md` modified.

Reviewer (runtime, 5-minute check):

```bash
docker compose up -d postgres
# wait ~5s for healthcheck
export DATABASE_URL="postgres://webapp:webapp@localhost:5432/webapp"
export PROVIDER_ENCRYPTION_KEY="$(node -e 'console.log(require(\"crypto\").randomBytes(32).toString(\"hex\"))')"
pnpm --filter @webapp/api db:migrate
pnpm --filter @webapp/api dev
curl -i http://localhost:4000/v1/health    # expect 200
# fallback:
unset DATABASE_URL PROVIDER_ENCRYPTION_KEY
pnpm --filter @webapp/api dev
curl -i http://localhost:4000/v1/health    # still 200, in-memory
```

## Risk and autonomy

- Risk: `risk:safe`
- Autonomy: `ai:autonomous`

## Notes on env.ts coupling

`apps/api/src/config/env.ts` throws if `DATABASE_URL` is set without `PROVIDER_ENCRYPTION_KEY`. The README reflects this explicitly — reviewers don't need to discover the coupling from a stack trace.

## Follow-ups

- Delta proposed: no — nothing out-of-scope discovered beyond what's already in the backlog (#22 env.example, #32 CI pg, seed issue).
- Decision: n/a.