### PR TITLE
feat(api): register /v1/health alias

### DIFF
--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -32,12 +32,13 @@ describe('GET /health', () => {
     expect(() => new Date(body.data.timestamp).toISOString()).not.toThrow();
   });
 
-  it('returns 404 for /v1/health — not a registered route', async () => {
+  it('also serves /v1/health with the same envelope', async () => {
     const res = await fetch(`${harness.baseUrl}/v1/health`);
-    expect(res.status).toBe(404);
-    const body = (await res.json()) as ApiResponse<unknown>;
-    expect(body.ok).toBe(false);
-    if (body.ok) throw new Error('expected error envelope');
-    expect(body.error.code).toBe('not_found');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<HealthStatus>;
+    expect(body.ok).toBe(true);
+    if (!body.ok) throw new Error('expected ok envelope');
+    expect(body.data.service).toBe('webapp-api');
+    expect(body.data.status).toBe('ok');
   });
 });

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -125,6 +125,7 @@ const stateHandler = (db && authDeps)
 
 export const businessRoutes: RouteDefinition[] = [
   { method: 'GET', path: API_HEALTH_PATH, handler: healthController },
+  { method: 'GET', path: '/v1/health',    handler: healthController },
 
   ...projectRoutes,
 


### PR DESCRIPTION
## Closes

Closes #52

## Summary

Registers `/v1/health` as a second entry pointing at the existing `healthController`. Root cause of the 404 reported during PR #51 runtime validation: `API_HEALTH_PATH` in `@webapp/types` resolves to `/health`, so no versioned alias was ever wired. The existing versioned routes (`/v1/projects`, `/v1/workspaces/...`, `/v1/messages/...`) all sit under `/v1/`; health was the odd one out. Fixed with a one-line addition in `routes/index.ts` — no new controller, no new type, no refactor.

The prior test explicitly asserted 404 on `/v1/health`. That assertion was the contract from a previous design decision and is now replaced with a 200 + envelope check.

## Acceptance criteria

- [x] `GET /v1/health` returns HTTP 200.
- [x] Response envelope: `{ ok: true, data: HealthStatus }` (same controller as `/health`).
- [x] Works with `DATABASE_URL` set and unset (controller has no DB dependency).
- [x] No auth required (route registered under `businessRoutes`, not behind auth middleware).
- [x] Minimal implementation: one line added in `routes/index.ts`; reuses `healthController`.
- [x] Integration test covering `/v1/health` (updated existing test file).

## Out of scope

- Extending `HealthStatus` with DB/provider status.
- Introducing `API_HEALTH_V1_PATH` in `@webapp/types` (would touch `packages/types`; declined to keep scope strictly backend per the task rules).
- Frontend changes.

## Test plan

- [x] `pnpm --filter @webapp/api test` — 225/225 green, including the updated `/v1/health` case.
- [x] `pnpm typecheck` — green (cached).
- [ ] Manual post-merge: `curl -i http://localhost:4000/v1/health` returns 200 with `{ ok: true, ... }`, with and without `DATABASE_URL`.

## Risk and autonomy

- Risk: `risk:safe`
- Autonomy: `ai:autonomous`

## Follow-ups

- Delta proposed: no.
- Decision: n/a. The only adjacent gap (promote `/v1/health` to a typed constant in `@webapp/types`) is a cross-package refactor; not worth opening unless a frontend client ends up needing it.