### PR TITLE
chore(env): commit .env.example for api and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ Monorepo foundation for AI Workspace — users connect multiple AI providers (Op
 
 ```bash
 pnpm install
+cp apps/api/.env.example apps/api/.env
+cp apps/web/.env.example apps/web/.env.local
 pnpm dev
 ```
+
+Both `.env.example` files are safe to commit and serve as the source of truth for every env var read by the apps. Running `pnpm dev` with only these placeholders works — the backend falls back to the in-memory store when `DATABASE_URL` is unset, and the frontend falls back to mock data when `NEXT_PUBLIC_API_URL` is unset.
+
+For the full DB-backed path, see [apps/api/README.md](./apps/api/README.md#local-postgres-db-mode).
 
 ## Structure
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,39 @@
+# apps/api — environment variables
+#
+# Copy to apps/api/.env (or export in your shell) before running `pnpm --filter @webapp/api dev`.
+# Real secrets NEVER go in this file. Rotate anything that leaks here.
+
+# ─── HTTP ──────────────────────────────────────────────────────────────────────
+API_PORT=4000
+NODE_ENV=development
+API_VERSION=0.1.0
+
+# Comma-separated list, exact origin, or "*". Must NOT be "*" when DATABASE_URL is set
+# (cookie-based sessions won't survive a wildcard origin).
+CORS_ORIGIN=http://localhost:3000
+
+# POST body cap in bytes.
+API_MAX_BODY_BYTES=102400
+
+# Dev-only routes under /v1/dev. Defaults to true outside production.
+ENABLE_DEV_ENDPOINTS=true
+
+# ─── Database (optional — unset = in-memory fallback) ─────────────────────────
+# Match the docker-compose service shipped in the repo root:
+#   docker compose up -d postgres
+DATABASE_URL=postgres://webapp:webapp@localhost:5432/webapp
+
+# Required whenever DATABASE_URL is set. 64 hex chars (32 bytes).
+# Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+PROVIDER_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000
+
+# ─── Providers ────────────────────────────────────────────────────────────────
+# Upper bound on prior messages forwarded to the AI provider per call.
+OPENAI_MAX_CONTEXT_MESSAGES=20
+
+# ─── Observability (optional) ─────────────────────────────────────────────────
+# Sentry DSN for the API process. Leave empty to disable error capture.
+SENTRY_DSN_API=
+SENTRY_ENVIRONMENT=development
+SENTRY_RELEASE=

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -54,6 +54,8 @@ Vitest spins up the real server on an ephemeral port per suite and asserts on th
 
 ## Env vars
 
+Canonical template: [`apps/api/.env.example`](./.env.example). Copy it to `apps/api/.env` (or export the vars in your shell) and tweak values as needed. The table below documents each variable.
+
 | Name                          | Default        | Notes                                                                                  |
 | ----------------------------- | -------------- | -------------------------------------------------------------------------------------- |
 | `API_PORT`                    | `4000`         | 1–65535                                                                                |

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,16 @@
+# apps/web — environment variables
+#
+# Copy to apps/web/.env.local before running `pnpm --filter @webapp/web dev`.
+# Every NEXT_PUBLIC_* variable is embedded into the client bundle — never put secrets here.
+
+# Backend base URL. Trailing slash is stripped. When unset, the UI falls back to
+# local mock data (homepage + project detail) so the web app can run in isolation.
+NEXT_PUBLIC_API_URL=http://localhost:4000
+
+# Canonical frontend URL (used for absolute links / Open Graph / sharing).
+# Reserved — not yet consumed by the code but expected by downstream tasks.
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Sentry DSN for the browser SDK. Reserved — not yet consumed (see backlog issue #41).
+# Leave empty to keep Sentry disabled.
+NEXT_PUBLIC_SENTRY_DSN=


### PR DESCRIPTION
## Closes

Closes #22

## Summary

Ships canonical `.env.example` files for both apps so a fresh clone runs with one copy-command. Every backend variable actually read by `apps/api/src/config/env.ts` is documented with a safe placeholder (notably `PROVIDER_ENCRYPTION_KEY` uses a 64-hex-zero placeholder that passes validation). Web-side documents the single var the code reads today (`NEXT_PUBLIC_API_URL`) plus two reserved keys (`NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SENTRY_DSN`) that downstream issues will consume. Root README gets a 3-line bootstrap, and `apps/api/README.md` links to the template.

## Acceptance criteria

- [x] `apps/api/.env.example` lists every `process.env.*` read by `apps/api/src/config/env.ts`: `API_PORT`, `NODE_ENV`, `API_VERSION`, `CORS_ORIGIN`, `API_MAX_BODY_BYTES`, `ENABLE_DEV_ENDPOINTS`, `DATABASE_URL`, `PROVIDER_ENCRYPTION_KEY`, `OPENAI_MAX_CONTEXT_MESSAGES`, `SENTRY_DSN_API`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`.
- [x] `apps/web/.env.example` includes `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_SENTRY_DSN` (last two marked reserved).
- [x] No real secrets. `PROVIDER_ENCRYPTION_KEY` is a valid-shape zero placeholder.
- [x] Root `README.md` + `apps/api/README.md` reference the templates.
- [x] `.gitignore` already excludes `.env` / `.env.local` / `.env.*.local`; `.env.example` is tracked.

## Notes on AC deviation

The original issue body names `PROVIDER_KEY_SECRET` and `SESSION_COOKIE_NAME`. The actual code uses `PROVIDER_ENCRYPTION_KEY` and does not read `SESSION_COOKIE_NAME` anywhere. I followed the code (source of truth); the issue text was stale. Flagged in the issue comment.

## Out of scope

- Loading `.env` at runtime (Node / Next.js handle this; no dotenv loader added).
- Secret management (vault, SOPS, etc.).

## Test plan

- [x] `pnpm typecheck` — green.
- [x] Grep verification: `.env.example` covers every `process.env.*` read in `apps/api/src/**` (excluding tests).
- [x] Placeholder `PROVIDER_ENCRYPTION_KEY` passes the 64-hex-char regex in `env.ts`.
- [ ] Manual post-merge: `cp apps/api/.env.example apps/api/.env && cp apps/web/.env.example apps/web/.env.local && pnpm dev` boots both apps without crash (in-memory fallback path).

## Risk and autonomy

- Risk: `risk:safe`
- Autonomy: `ai:autonomous`

## Follow-ups

- Delta proposed: no.
- Decision: n/a. `NEXT_PUBLIC_APP_URL` and `NEXT_PUBLIC_SENTRY_DSN` are intentionally listed without consumers — the backlog already has dedicated issues for wiring them (#41 Sentry web).