### PR TITLE
feat(providers): harden POST message → OpenAI loop

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -20,6 +20,21 @@ import { getDecryptedApiKey } from '../db/provider-connections.repo.js';
 import { createOpenAIClient } from '../providers/openai.provider.js';
 import type { ChatCompletionResult, ChatMessage } from '../providers/provider.interface.js';
 
+// ── Provider timeout guard ────────────────────────────────────────────────────
+
+const PROVIDER_TIMEOUT_MS = 30_000;
+const PROVIDER_TIMEOUT_MESSAGE = 'provider_timeout';
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(PROVIDER_TIMEOUT_MESSAGE)), ms);
+    p.then(
+      (v) => { clearTimeout(t); resolve(v); },
+      (e) => { clearTimeout(t); reject(e); },
+    );
+  });
+}
+
 // ── Internal DB row shapes ────────────────────────────────────────────────────
 
 interface DbMessage {
@@ -63,6 +78,7 @@ export interface MessagesDeps {
   getApiKey:         (userId: string, provider: AIProvider) => Promise<string | null>;
   generate:          (apiKey: string, messages: ChatMessage[], model: string) => Promise<ChatCompletionResult>;
   maxContextMessages: number;
+  providerTimeoutMs?: number;
 }
 
 export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps {
@@ -156,9 +172,9 @@ export async function createMessageDbController(
       const apiKey = await deps.getApiKey(user.id, 'openai');
       if (!apiKey) {
         return respondError(
-          'validation_error',
+          'provider_auth_error',
           'No OpenAI connection configured. Add your API key in provider settings.',
-          400,
+          412,
         );
       }
 
@@ -176,10 +192,16 @@ export async function createMessageDbController(
       let completion: ChatCompletionResult;
       const startedAt = Date.now();
       try {
-        completion = await deps.generate(apiKey, contextMessages, cw.model);
+        completion = await withTimeout(
+          deps.generate(apiKey, contextMessages, cw.model),
+          deps.providerTimeoutMs ?? PROVIDER_TIMEOUT_MS,
+        );
       } catch (err) {
+        if (err instanceof Error && err.message === PROVIDER_TIMEOUT_MESSAGE) {
+          return respondError('provider_error', 'Provider call timed out after 30s', 502);
+        }
         const detail = err instanceof Error ? err.message : 'Unknown provider error';
-        return respondError('internal_error', `Provider call failed: ${detail}`, 502);
+        return respondError('provider_error', `Provider call failed: ${detail}`, 502);
       }
       const latencyMs = Date.now() - startedAt;
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -343,7 +343,7 @@ describe('POST /v1/messages — openai generation path', () => {
     await close();
   });
 
-  it('missing OpenAI connection returns 400 with explicit error', async () => {
+  it('missing OpenAI connection returns 412 provider_auth_error', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
       resolveUser:    async () => USER_1,
       findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
@@ -353,10 +353,10 @@ describe('POST /v1/messages — openai generation path', () => {
     const res = await post(baseUrl, '/v1/messages', {
       chatWindowId: 'cw-1', role: 'user', content: 'Hi',
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(412);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('provider_auth_error');
     expect(body.error.message).toContain('OpenAI');
     await close();
   });
@@ -380,9 +380,33 @@ describe('POST /v1/messages — openai generation path', () => {
     expect(persistCalled).toBe(false);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('internal_error');
+    expect(body.error.code).toBe('provider_error');
     // API key must not appear in error
     expect(body.error.message).not.toContain('sk-key');
+    await close();
+  });
+
+  it('provider timeout returns 502 provider_error and does not persist', async () => {
+    let persistCalled = false;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:        async () => USER_1,
+      findChatWindow:     async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:          async () => 'sk-key',
+      listMessages:       async () => [],
+      generate:           () => new Promise(() => {/* never resolves */}),
+      persistMessagePair: async () => { persistCalled = true; return mockPair('cw-1', 'Hi', 'ok'); },
+      providerTimeoutMs:  20,
+    }));
+
+    const res = await post(baseUrl, '/v1/messages', {
+      chatWindowId: 'cw-1', role: 'user', content: 'Hi',
+    });
+    expect(res.status).toBe(502);
+    expect(persistCalled).toBe(false);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('provider_error');
+    expect(body.error.message).toMatch(/timed out/i);
     await close();
   });
 


### PR DESCRIPTION
## Closes

Closes #27

## Summary

Audit found the full user→provider→assistant loop already implemented in `messages-db.controller.ts`: it persists user msg only after a successful provider call, loads context bounded by `OPENAI_MAX_CONTEXT_MESSAGES`, decrypts the provider key from `provider_connections`, calls OpenAI, and writes both rows atomically through `persistMessagePair`. This PR closes the three AC gaps that remained:

1. **412 on missing provider** (was 400 `validation_error`) → now `412 provider_auth_error`.
2. **Provider-error code** (was `internal_error`) → now `provider_error`, status still 502.
3. **30-second timeout** — none existed. Added `withTimeout` helper wrapping `deps.generate`. Timeouts surface as `502 provider_error` with `timed out` message, **no messages persisted**.

## Acceptance criteria

- [x] `POST /v1/messages` with `role='user'` to an `openai` chat window: persists user msg, loads context, loads provider connection (decrypt), calls `openaiProvider`, persists assistant msg, returns both — **pre-existing**.
- [x] Missing provider connection → **412 `provider_auth_error`** (see note below).
- [x] Provider error → **502 `provider_error`**, assistant msg NOT persisted.
- [x] Timeout 30s → **502 `provider_error`**, assistant msg NOT persisted.
- [x] Non-`user` role returns 201 via the standard path (doesn't hit the OpenAI branch) — existing behavior preserved; AC is about the loop-trigger condition, which only fires for `role='user'`.
- [x] Vitest covers happy path, missing conn, provider error, **and timeout** (new test). 226/226 green.

## AC deviation — error code naming

Issue body says `provider_not_configured`. `@webapp/types` `ApiErrorCode` union does not include it today, and the session scope forbids touching `packages/types`. I used the closest existing code: `provider_auth_error` with HTTP 412. Semantically correct (no auth configured for the provider) and unblocks everyone now. A follow-up to add a dedicated `provider_not_configured` code is listed below — not auto-applied because it mutates shared types.

## Out of scope

- Streaming (SSE) — separate backlog item.
- Anthropic/Perplexity providers — separate backlog items.
- Token/cost accounting — existing metadata capture unchanged.
- Retries — explicit non-goal.

## Implementation notes

- `withTimeout<T>(p, ms)` uses `setTimeout` + `Promise.race` semantics; timer cleared on either settlement. Thrown error message is a sentinel (`provider_timeout`) used only to branch the response mapping — never leaked to callers.
- Timeout value injected via optional `providerTimeoutMs` on `MessagesDeps`. Default stays 30s; tests override to 20ms to keep CI fast.

## Test plan

- [x] `pnpm --filter @webapp/api test` — **226/226** green, including:
  - `missing OpenAI connection returns 412 provider_auth_error`
  - `provider call failure returns 502 and does not persist any messages` (code updated to `provider_error`)
  - `provider timeout returns 502 provider_error and does not persist` (new)
  - `persists provider metadata on the assistant row`
  - `both messages are written atomically`
- [x] `pnpm typecheck` — green.
- [ ] Manual post-merge with real OpenAI key: `curl POST /v1/messages` round-trips user+assistant; 412 returned when no provider connection.

## Risk and autonomy

- Risk: `risk:review-required` (behaviour changes on error paths, though covered by tests).
- Autonomy: executed under Yume's explicit override of the original `ai:human-checkpoint` label.

## Follow-ups

See delta: one safe+autonomous follow-up to add a dedicated `provider_not_configured` code in `@webapp/types`. **Not auto-applied** because it's a cross-package change and because this delta is co-submitted with a `review-required` parent — per protocol, mixed is held for human.