### PR TITLE
chore(tooling): project status automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
     "project:fields:dry-run": "node tools/update-project-fields.mjs --dry-run",
     "project:fields:apply": "node tools/update-project-fields.mjs --yes",
     "issues:delta:dry-run": "node tools/apply-issue-delta.mjs --dry-run",
-    "issues:delta:apply": "node tools/apply-issue-delta.mjs --yes"
+    "issues:delta:apply": "node tools/apply-issue-delta.mjs --yes",
+    "project:status": "node tools/issue-status.mjs",
+    "project:status:in-progress": "node tools/issue-status.mjs --status \"In Progress\"",
+    "project:status:review": "node tools/issue-status.mjs --status Review",
+    "project:status:blocked": "node tools/issue-status.mjs --status Blocked",
+    "project:status:done": "node tools/issue-status.mjs --status Done"
   },
   "devDependencies": {
     "turbo": "^2.3.3",

--- a/project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md
+++ b/project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md
@@ -27,10 +27,28 @@ Labels drive every decision below.
 
 If labels are missing, treat as `ai:human-checkpoint` + `risk:review-required`.
 
+## 2.5. AC vs code reality check
+
+Before touching Status, before branching, before coding: **read the code the AC describes** and decide whether the AC is already satisfied on `main`. This has bitten us three times already (#22, #23, #27 — AC stale vs code).
+
+- Grep / read the files the AC names.
+- If every AC bullet is already true in the code:
+  1. Do **not** code.
+  2. Post a comment on the issue listing each AC bullet with the file/line that already satisfies it.
+  3. Propose one of:
+     - close the issue as already-done, OR
+     - open a small doc-only PR that makes the existing behaviour discoverable (README, comment, constant).
+  4. Stop and wait for Yume's pick.
+- If some AC bullets are already true and others are not: proceed with only the gaps. Flag in the final report which AC bullets pre-existed.
+
+Skipping this check is how we end up writing code that was already shipped.
+
 ## 3. Move issue to "In Progress"
 
-- Set Project #1 `Status` = `In Progress` via `gh project item-edit` (or have Yume click if tooling not available at run time).
+- Run: `pnpm project:status:in-progress <N>`
 - Comment on the issue: `"Starting execution — branch: feat/<scope>-<slug>-#N"`.
+
+Never edit the Status field with ad-hoc `gh project item-edit` calls. The script is the only supported transition path.
 
 ## 4. Create branch
 
@@ -80,8 +98,18 @@ If `ai:human-checkpoint`: **post the plan as a comment on the issue and stop**. 
 
 ## 10. Move issue to "Review"
 
-- Set Project #1 `Status` = `Review` on the issue (not the PR).
+- Run: `pnpm project:status:review <N>`
 - Post a comment: `"PR: <url>"`.
+
+## 10.5. Blocked path
+
+If execution cannot continue — missing dependency, broken environment, irreversible ambiguity, an AC that requires something the sandbox can't do — do **not** leave the issue in `In Progress`.
+
+1. Run: `pnpm project:status:blocked <N>`
+2. Comment on the issue with: the blocker, what was tried, what Yume needs to unblock.
+3. Stop. Do not branch further, do not push speculative code.
+
+Rule: an issue must never stay in `In Progress` once the agent has stopped working on it. Either push it to `Review` (PR opened), or to `Blocked` (stopped mid-run), or back to `Ready` (handing it off).
 
 ## 11. Propose follow-ups via a delta file
 

--- a/project-memory/prompts/execute-issue.md
+++ b/project-memory/prompts/execute-issue.md
@@ -23,7 +23,11 @@ Follow `project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md` **strictly**. Do not skip
 
 ## Execution
 
-Run the numbered cycle in the protocol: read → move to In Progress → branch → plan → code → test → commit → push → PR with `Closes #<N>` → move to Review.
+Run the numbered cycle in the protocol: read → **AC vs code reality check (§2.5)** → `pnpm project:status:in-progress <N>` → branch → plan → code → test → commit → push → PR with `Closes #<N>` → `pnpm project:status:review <N>`.
+
+If at any point the work becomes impossible (missing dep, blocked env, irreversible ambiguity): `pnpm project:status:blocked <N>`, comment the blocker, stop.
+
+Never leave the issue in `In Progress` without work in flight.
 
 ## Follow-ups (delta)
 

--- a/tools/issue-status.mjs
+++ b/tools/issue-status.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const BACKLOG_PATH = resolve(REPO_ROOT, 'project-memory/backlog/issues.json');
+
+const VALID_STATUSES = ['Backlog', 'Ready', 'In Progress', 'Blocked', 'Review', 'Done'];
+
+const c = {
+  red:    (s) => `\x1b[31m${s}\x1b[0m`,
+  green:  (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  cyan:   (s) => `\x1b[36m${s}\x1b[0m`,
+  dim:    (s) => `\x1b[2m${s}\x1b[0m`,
+};
+
+function die(msg, code = 1) {
+  console.error(c.red(`error: ${msg}`));
+  process.exit(code);
+}
+
+function runCapture(bin, argv) {
+  const r = spawnSync(bin, argv, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  return { code: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function ghJson(argv) {
+  const r = runCapture('gh', argv);
+  if (r.code !== 0) die(`gh ${argv.join(' ')}\n${r.stderr || r.stdout}`);
+  try { return JSON.parse(r.stdout); }
+  catch (e) { die(`cannot parse gh output for \`gh ${argv.join(' ')}\`: ${e.message}`); }
+}
+
+function usage() {
+  console.error('usage: node tools/issue-status.mjs <issueNumber> <status>');
+  console.error(`       status: ${VALID_STATUSES.map((s) => `"${s}"`).join(' | ')}`);
+  console.error('example: node tools/issue-status.mjs 27 "In Progress"');
+  process.exit(2);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const positional = [];
+  let flagStatus;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--status' || a === '-s') {
+      flagStatus = args[++i];
+      continue;
+    }
+    if (a === '--help' || a === '-h') usage();
+    if (a.startsWith('--')) die(`unknown flag: ${a}`);
+    positional.push(a);
+  }
+  if (positional.length === 0) usage();
+
+  const issueNumber = Number.parseInt(positional[0], 10);
+  if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+    die(`invalid issue number: "${positional[0]}"`);
+  }
+
+  const status = (flagStatus ?? positional.slice(1).join(' ')).trim();
+  if (!status) usage();
+  if (!VALID_STATUSES.includes(status)) {
+    die(`invalid status: "${status}". Expected one of: ${VALID_STATUSES.join(', ')}`);
+  }
+  return { issueNumber, status };
+}
+
+function preflight() {
+  if (runCapture('which', ['gh']).code !== 0) die('gh CLI not found');
+  const auth = runCapture('gh', ['auth', 'status']);
+  if (auth.code !== 0) die('not authenticated (run: gh auth login)');
+  const scopes = `${auth.stdout}\n${auth.stderr}`;
+  if (!/\bproject\b/.test(scopes)) die('missing `project` scope — run: gh auth refresh -s project');
+}
+
+function loadProjectCoords() {
+  let raw;
+  try { raw = readFileSync(BACKLOG_PATH, 'utf8'); }
+  catch { die(`cannot read ${BACKLOG_PATH}`); }
+  let data;
+  try { data = JSON.parse(raw); }
+  catch (e) { die(`invalid JSON in issues.json: ${e.message}`); }
+  const owner = data?.project?.projectOwnerLogin;
+  const number = data?.project?.projectNumber;
+  if (!owner || !Number.isFinite(number)) {
+    die('issues.json must expose project.projectOwnerLogin and project.projectNumber');
+  }
+  return { owner, number };
+}
+
+function getProjectId(number, owner) {
+  const j = ghJson(['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+  if (!j.id) die('could not resolve project id');
+  return j.id;
+}
+
+function getStatusField(number, owner) {
+  const j = ghJson(['project', 'field-list', String(number), '--owner', owner, '--format', 'json']);
+  const field = (j.fields ?? []).find(
+    (x) => x.name === 'Status' && x.type === 'ProjectV2SingleSelectField',
+  );
+  if (!field) die('project has no single-select "Status" field');
+  return field;
+}
+
+function findItemIdForIssue(number, owner, issueNumber) {
+  const j = ghJson([
+    'project', 'item-list', String(number),
+    '--owner', owner, '--format', 'json', '--limit', '500',
+  ]);
+  const match = (j.items ?? []).find((it) => {
+    const content = it.content;
+    if (!content) return false;
+    if (content.type && content.type !== 'Issue') return false;
+    if (typeof content.number === 'number') return content.number === issueNumber;
+    if (typeof content.url === 'string') return content.url.endsWith(`/issues/${issueNumber}`);
+    return false;
+  });
+  return match?.id ?? null;
+}
+
+function setStatus(projectId, itemId, fieldId, optionId) {
+  const r = runCapture('gh', [
+    'project', 'item-edit',
+    '--project-id', projectId,
+    '--id', itemId,
+    '--field-id', fieldId,
+    '--single-select-option-id', optionId,
+  ]);
+  if (r.code !== 0) die(`gh project item-edit failed:\n${r.stderr || r.stdout}`);
+}
+
+function main() {
+  const { issueNumber, status } = parseArgs();
+  preflight();
+
+  const { owner, number } = loadProjectCoords();
+  console.log(c.cyan(`Setting issue #${issueNumber} → ${status}`));
+  console.log(c.dim(`  project: ${owner} #${number}`));
+
+  const projectId = getProjectId(number, owner);
+  const field = getStatusField(number, owner);
+
+  const option = (field.options ?? []).find((o) => o.name === status);
+  if (!option) {
+    die(
+      `project Status field has no option "${status}". Available: ${(field.options ?? []).map((o) => o.name).join(', ')}`,
+    );
+  }
+
+  const itemId = findItemIdForIssue(number, owner, issueNumber);
+  if (!itemId) {
+    die(`issue #${issueNumber} is not in project ${owner}#${number} — add it before updating its Status`);
+  }
+
+  setStatus(projectId, itemId, field.id, option.id);
+  console.log(c.green('Done'));
+}
+
+main();


### PR DESCRIPTION
## Summary

Eliminates manual `gh project item-edit` calls for Status transitions. One script handles Backlog / Ready / In Progress / Blocked / Review / Done on Project #1. Protocol updated to (a) mandate the script instead of ad-hoc CLI, (b) enforce a new **AC vs code reality check** before branching, (c) formalize the `Blocked` path so issues never rot in `In Progress`.

No code produit changed. Scope is strictly `tools/**`, `project-memory/**`, `package.json`.

## What changed

- **New** `tools/issue-status.mjs` (135 lines, prod-ready, `chmod +x`)
  - CLI: `node tools/issue-status.mjs <issueNumber> <status>` (positional) or `--status "<value>" <issueNumber>` (flag form, used by pnpm scripts)
  - Reads `project.projectOwnerLogin` + `project.projectNumber` from `project-memory/backlog/issues.json`
  - Resolves project id via `gh project view`
  - Finds item by matching `content.number` or `content.url.endsWith('/issues/<N>')`
  - Looks up the Status field + option by name
  - Calls `gh project item-edit --single-select-option-id`
  - Preflight: `gh` installed, auth OK, `project` scope present
  - Exit codes: 0 ok, 1 on any error, 2 on usage error
- **package.json** — 5 new npm scripts:
  - `project:status` — generic passthrough: `pnpm project:status 27 Ready`
  - `project:status:in-progress` — `pnpm project:status:in-progress 27`
  - `project:status:review` — `pnpm project:status:review 27`
  - `project:status:blocked` — `pnpm project:status:blocked 27`
  - `project:status:done` — `pnpm project:status:done 27`
- **`AI-ISSUE-EXECUTION-PROTOCOL.md`**:
  - §2.5 NEW — AC vs code reality check (grep first, don't re-ship shipped code). Answers #22, #23, #27 pain.
  - §3 — must use `pnpm project:status:in-progress <N>`. No ad-hoc `gh project item-edit` for Status.
  - §10 — must use `pnpm project:status:review <N>`.
  - §10.5 NEW — Blocked path: run `pnpm project:status:blocked <N>` + comment blocker + stop. Rule: issues never linger in `In Progress`.
- **`prompts/execute-issue.md`** — Execution section names the exact pnpm commands and the Blocked escape hatch.

## How it fixes the manual-work gap

| Before | After |
|---|---|
| 2–3 `gh project item-edit` calls per issue, hand-typed field and option IDs | 1 pnpm command, name-based resolution |
| Item sometimes left in `In Progress` when execution stalls | Explicit `Blocked` transition + protocol rule |
| AC stale vs code discovered mid-implementation (3 recent cases) | §2.5 grep-first rule with stop-and-propose branch |

## Usage examples

```bash
pnpm project:status:in-progress 27      # start
pnpm project:status:review 27           # PR opened
pnpm project:status:blocked 27          # cannot continue
pnpm project:status:done 27             # rarely needed; workflow closes on merge
pnpm project:status 27 Ready            # generic form

# error paths
pnpm project:status 99999 Ready         # issue not in project → exit 1
pnpm project:status 27 Wrong            # invalid status → exit 1, list valid values
```

## Verified behaviours

- [x] `pnpm typecheck` — unchanged (no TS source touched).
- [x] `node --check tools/issue-status.mjs` — syntax OK.
- [x] Usage (no args) prints help + exit 2.
- [x] Invalid status → exit 1 with list of accepted values.
- [x] Invalid issue number → exit 1.
- [x] Non-existent issue → exit 1 with actionable message.
- [x] Real Project call: issue #27 → Review round-tripped successfully under both positional and flag invocation forms.
- [x] `pnpm project:status:review 27` — verified against Project #1.
- [x] Scope strict: only `tools/issue-status.mjs`, `package.json`, `project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md`, `project-memory/prompts/execute-issue.md` touched.

## Risk and autonomy

- Risk: `risk:safe` (tooling only; single-select Status writes, no destructive ops, all reversible by re-running the script).
- Autonomy: `ai:autonomous`.

## Follow-ups

- Delta proposed: no.