### PR TITLE
chore(types): write-path DTOs for auth + provider-connections

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -168,3 +168,33 @@ export interface ProviderConnection {
 
 export const API_PROVIDER_CONNECTIONS_PATH = '/v1/provider-connections' as const;
 export const getProviderConnectionPath = (provider: string): string => `${API_PROVIDER_CONNECTIONS_PATH}/${provider}`;
+
+// ── Auth write-path DTOs ─────────────────────────────────────────────────────
+
+export interface AuthRegisterInput {
+  email: string;
+  password: string;
+  displayName?: string;
+}
+
+export interface AuthLoginInput {
+  email: string;
+  password: string;
+}
+
+export interface MeResponse {
+  user: SafeUser;
+}
+
+// ── Provider-connection write-path DTOs ──────────────────────────────────────
+
+export interface ProviderConnectionInput {
+  apiKey: string;
+}
+
+export interface ProviderConnectionPublic {
+  id: string;
+  provider: AIProvider;
+  createdAt: ISODateString;
+  updatedAt: ISODateString;
+}


### PR DESCRIPTION
Closes #25

## Summary
Adds the missing write-path DTOs to `@webapp/types`. The four `Create*Input` types already existed on main; this PR closes the gap by adding the auth + provider-connection DTOs.

## Acceptance criteria
- [x] `@webapp/types` exports: `CreateProjectInput`, `CreateWorkspaceInput`, `CreateChatWindowInput`, `CreateMessageInput` (pre-existed on main)
- [x] `@webapp/types` exports: `AuthRegisterInput`, `AuthLoginInput`, `ProviderConnectionInput`, `ProviderConnectionPublic`, `MeResponse` (added here)
- [x] Re-exported from `packages/types/src/index.ts` (single-file module — direct exports)
- [x] No new runtime deps; types only
- [x] `pnpm typecheck` green across monorepo

## Shape decisions
- `AuthRegisterInput` / `AuthLoginInput` mirror `signupController` / `loginController` body parsing (`email`, `password`, optional `displayName` for register).
- `ProviderConnectionInput` = `{ apiKey: string }` — matches `upsertConnectionController` (provider comes from URL param, not body).
- `ProviderConnectionPublic` matches the existing `toResponse()` output. Named `*Public` to make "safe to send to client" explicit vs. the internal `ProviderConnection` shape.
- `MeResponse` = `{ user: SafeUser }` — conventional wrapper for `/v1/auth/me`.

## Test plan
- [x] `pnpm typecheck` — 6/6 packages green
- [x] `pnpm --filter @webapp/api test` — 225/225 green
- [x] `pnpm build` — 5/5 green
- Pre-existing failures NOT touched by this PR: `@webapp/types#lint` (eslint not installed in packages/types — env issue on main) and `@webapp/e2e#test` (needs running API on :4000).

## Out of scope
- Zod schemas (separate issue).
- Backend controller refactor to consume these DTOs (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)