### PR TITLE
chore(memory): refresh project-memory to reflect post-PR#6 state

### DIFF
--- a/project-memory/03-current-state.md
+++ b/project-memory/03-current-state.md
@@ -1,57 +1,57 @@
 # 03 — Current State
 
-Last verified: 2026-04-22.
+Last verified: 2026-04-24 (post PR #6 merge; reflects `main` at `9b45cf3`).
 
 ## Branches
 
-- `main` — stable.
-- `feat/integration-homepage-projects` — **current, pushed**. Tip `5708b9a`. Carries the full Track A surface read path: projects list + detail + workspaces + windows + messages, all wired end-to-end with mock fallback. Tests 19/19 green. Typecheck green. Web build green.
-- Feature branches merged into integration (kept for history, now redundant):
-  - `feat/api-project-detail`
-  - `feat/web-project-detail-api`
-  - `feat/api-project-workspaces`
-  - `feat/web-project-workspaces-api`
-  - `feat/api-workspace-windows` (merged `97418e0`)
-  - `feat/api-window-messages` (merged `5708b9a`)
-- `origin/feat/api-foundation` — parallel Track B (DB+auth+OpenAI V1), 53+ commits ahead, **unmerged, not evaluated this session**. Architecturally incompatible with Track A. Decision deferred.
+- `main` — truth. Tip `9b45cf3`. Track A + Track B now merged. DB-gated write path, auth, provider-connections, Sentry, drizzle migrations.
+- `origin/feat/api-foundation` — archival, superseded by the Track B merge (PR #6, commit `f46f599`).
+- Historical integration branches (merged or abandoned) should not be read as active.
 
-## Done (Track A, read-only V1 read path)
+Active work is tracked in the GitHub Project (project #1, `Yuume2/WebAppV1`), not here. See `04-active-tasks.md`.
 
-- Monorepo scaffold (pnpm, turbo, tsconfig base).
-- Shared types `@webapp/types`: `Project`, `Workspace`, `ChatWindow`, `Message`, `MessageRole`, `AIProvider`, `ApiError`, `ApiResponse<T>`, `HealthStatus`.
-- Backend foundation: env, logger, request-id, param router (`:id`), `handleRequest` middleware, `HttpError`, `createApiServer`.
-- Endpoints (all GET):
-  - `/health`, `/v1/health`
-  - `/v1/projects`
-  - `/v1/projects/:id`
-  - `/v1/projects/:id/workspaces`
-  - `/v1/workspaces/:id/windows`
-  - `/v1/windows/:id/messages`
-- Seed stores aligned across backend + web mocks (proj-1/2, ws-1/1b/2, win-1..7, m-1..10).
-- Vitest: 19 integration tests green.
-- Frontend UI: AppShell/Panel/Button, Workspace feature (canvas/sidebar/composer), Chat feature (ChatWindow, useChatSessions), presets, inline rename.
-- Frontend API clients: `lib/api/{client,env,projects,workspaces,windows,messages}`.
-- Homepage `/` wired to `GET /v1/projects` (mock fallback + source badge).
-- Project detail `/project/[id]`:
-  - Project: `fetchProject` + mock fallback + 404 error panel + source badge.
-  - Workspaces: `fetchProjectWorkspaces` + mock fallback + workspaces source badge + error panel.
-  - Windows: `fetchWorkspaceWindows` + mock fallback when workspaces came from mock or on error.
-  - Messages: `fetchWindowMessages` per active window, parallel `Promise.all`, mock fallback per window on error.
+## Done (shipped to main)
+
+**Monorepo / tooling**
+- pnpm workspaces + Turborepo, TS strict, Node 20+.
+- Shared types `@webapp/types`: read models + write-path DTOs (auth, projects, workspaces, chat-windows, messages, provider-connections) + `ApiError` / `ApiResponse<T>` / `ApiErrorCode` + path constants (`API_*_PATH`).
+- `.env.example` for `apps/api` and `apps/web` committed (#54).
+- docker-compose Postgres + local bootstrap docs (#51).
+- Drizzle migrations + workflow (#50).
+- Issue + PR templates matching label taxonomy (#49).
+- Project-status automation CLI + `pnpm project:status:*` (#56).
+- GitHub→Notion Tasks sync (#48).
+
+**Backend (`apps/api`)**
+- Plain `node:http` server, custom router with `:param` segments, `handleRequest` middleware, `HttpError`, uniform `ApiResponse<T>` envelope.
+- Endpoints (canonical): `/v1/health`, `/v1/projects`, `/v1/workspaces`, `/v1/chat-windows`, `/v1/messages` (GET + POST + `:id` GET), `/v1/provider-connections` (GET/PUT/DELETE + `/openai/test`), `/v1/auth/{signup,login,logout,me}`, `/v1/state`, legacy alias reads (`/v1/workspaces/:id/windows`, `/v1/windows/:id/messages`), dev `/v1/dev/{reset,seed}`.
+- DB-gated mode: when `DATABASE_URL` is set, all business routes are user-scoped DB-backed. Without it, in-memory fallback (seeded) powers the same surface minus auth + provider-connections.
+- Auth: signup/login/logout + session cookie + `/v1/auth/me`, bcrypt password hashing, signed session tokens. Repos: `users.repo`, `sessions.repo`.
+- Provider-connections: AES-256-GCM at-rest encryption of API keys (`api-key-cipher`), per-user CRUD, OpenAI test endpoint.
+- OpenAI provider: POST `/v1/messages` runs the chat-completion loop, 30s timeout, 412 when no provider configured, typed error codes (`provider_error`, `provider_auth_error`, etc.).
+- Sentry wired (`lib/sentry.ts`, no-op when DSN absent).
+- Vitest: 226 tests green (24 files). Run `pnpm --filter @webapp/api test`.
+
+**Frontend (`apps/web`)**
+- Next.js 15 App Router. Routes: `/` (projects list), `/project/[id]` (workspaces + windows + messages read).
+- API clients read-only against legacy paths (`lib/api/{projects,workspaces,windows,messages}`). No POST/PUT/DELETE clients yet.
+- No auth UI, no provider-settings UI, no write actions — still local state + mock fallback for the render layer.
 
 ## In progress
 
-- PR `feat/integration-homepage-projects` → `main` not yet opened (no `gh` CLI, must be manual).
+Tracked in GitHub Project #1. As of 2026-04-24 22:30:
+- #21 (this memory refresh).
+- #55 open PR — provider message loop hardening (merged content already in main; PR itself pending close).
 
-## Blocked / missing (to call V1 "ready to show")
+## Blocked / missing (to ship a usable MVP)
 
-- Surface `windows` and `messages` source badges inside rendered `Workspace` view (needs a `headerRight` slot on `Workspace` component). Cosmetic.
-- No write endpoints (create/update project/workspace/window, POST message). All reads only.
-- No real provider call (OpenAI/Anthropic/Perplexity) — chat input stays local state.
-- No DB, no auth, no persistence, no rate limiting.
-- `apps/api/README.md` and `CONTRIBUTING.md` are 1-line stubs.
-- CI typecheck/lint/test still have `|| echo …` fallbacks.
-- Track B decision still pending.
+- Web has no write clients — create/rename/delete flows for projects/workspaces/windows/messages all still local. Issues #19/#20/#28/#36/#38.
+- No login/register pages (#16) or session guard (#17). Auth backend is ready.
+- No provider-settings UI (#18/#36/#37). Backend CRUD + test endpoint ready.
+- CI still has `|| echo …` fallbacks (#43). Lint/typecheck/test not real gates.
+- `apps/api/README.md` / `CONTRIBUTING.md` still thin (#47).
+- Provider adapters beyond OpenAI (Anthropic #14, Perplexity #33) not started.
 
 ## Next obvious step
 
-Open PR `feat/integration-homepage-projects` → `main` (manual). Tree is in a coherent read-only V1 state.
+Pick the highest-priority Ready issue from GitHub Project #1. Backend foundation is complete enough that the next unlock is either (a) write-path web clients, or (b) the auth UI pages.

--- a/project-memory/04-active-tasks.md
+++ b/project-memory/04-active-tasks.md
@@ -1,35 +1,30 @@
 # 04 — Active Tasks
 
-Not a sprint board. Concrete next actions.
+**Authoritative source: [GitHub Project #1 — Yuume2/WebAppV1](https://github.com/users/Yuume2/projects/1).**
 
-## Done
+This file is intentionally short. Do not hand-maintain a task list here — the Project board is the truth, and tooling automates the lifecycle.
 
-- [x] Param router `:id` + `HttpError`.
-- [x] `GET /v1/projects/:id`.
-- [x] `GET /v1/projects/:id/workspaces`.
-- [x] `GET /v1/workspaces/:id/windows`.
-- [x] `GET /v1/windows/:id/messages`.
-- [x] `Message` + `MessageRole` added to `@webapp/types`.
-- [x] Frontend clients: `lib/api/{projects,workspaces,windows,messages}`.
-- [x] `/project/[id]` wired end-to-end: project, workspaces, windows, messages — all with mock fallback.
-- [x] All 6 feature branches integrated into `feat/integration-homepage-projects`. Tests 19/19, typecheck green, web build green.
+## Agent workflow
 
-## Remaining before PR `feat/integration-homepage-projects` → `main`
+1. Pick the highest-priority Ready issue (`P0-now` first, no blockers, not already assigned).
+2. Mark it In Progress: `node tools/issue-status.mjs <n> "In Progress"` (also exposed as `pnpm project:status:in-progress <n>`).
+3. Branch: `feat/<scope>-<slug>-#<n>` (or `chore/…-#<n>` / `fix/…-#<n>`).
+4. Implement + tests. AC vs code reality check before declaring done.
+5. PR with `Closes #<n>`. Move to Review: `pnpm project:status:review <n>`.
+6. Follow-ups → `project-memory/backlog/issues.delta.json`, then `pnpm issues:delta:dry-run` (auto-apply only when every follow-up is `risk:safe` + `ai:autonomous`).
 
-- [ ] Open PR manually on GitHub (no `gh` CLI).
-- [ ] (Optional, cosmetic) add `headerRight` slot to `Workspace` and surface windows/messages source badges inside the rendered workspace view.
+Full protocol: `project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md`. Command sheet: `project-memory/prompts/execute-issue.md`.
 
-## After PR merges (V1 "ready to show" polish)
+## Labels
 
-- [ ] Flesh out `apps/api/README.md`.
-- [ ] Flesh out `CONTRIBUTING.md`.
-- [ ] Remove `|| echo …` fallbacks in CI scripts; make typecheck/lint/test real gates.
+- Role: `role:frontend`, `role:backend`, `role:coord`.
+- Type: `type:feat`, `type:fix`, `type:chore`, `type:docs`, `type:refactor`, `type:test`.
+- Priority: `P0-now`, `P1-week`, `P2-soon`, `P3-backlog`.
+- Risk: `risk:safe`, `risk:review-required`.
+- AI: `ai:autonomous`, `ai:human-checkpoint`.
 
-## Bigger next-bloc decisions (outside V1 read path)
+Merge authority: the agent may auto-merge only when `risk:safe` AND `ai:autonomous` AND CI passes AND no secret / sensitive code is touched. Otherwise Review only.
 
-- [ ] Decide V1 track with Yume (Track A integration vs Track B `feat/api-foundation`). Blocks any write/auth/provider work.
-- [ ] Write path: POST message, create window, create workspace — requires persistence story.
-- [ ] DB pick (likely Postgres) + persistence interface behind `services/`.
-- [ ] Real provider adapters (OpenAI/Anthropic/Perplexity).
-- [ ] Auth (session cookie or token).
-- [ ] `.env.example` with real provider key hints.
+## Backlog cheat-sheet
+
+`project-memory/backlog/issues.json` holds the seed backlog. Deltas (new issues, updates) go through `tools/create-github-issues.mjs` with `pnpm issues:delta:{dry-run,apply}`.

--- a/project-memory/05-api-map.md
+++ b/project-memory/05-api-map.md
@@ -2,72 +2,142 @@
 
 Base: `http://localhost:<API_PORT|4000>`. Envelope: `ApiResponse<T>` from `@webapp/types`.
 
+All business routes except health exist in two modes:
+- **DB mode** (when `DATABASE_URL` is set): user-scoped, auth-required (session cookie), backed by drizzle repos.
+- **In-memory fallback** (no DB): same paths, seeded stores, no auth, no provider-connections, no auth endpoints.
+
+Path constants live in `@webapp/types` (`API_*_PATH`).
+
 ## Endpoints
 
-| Method | Path               | Controller                  | Service                 | Response         |
-|--------|--------------------|-----------------------------|-------------------------|------------------|
-| GET    | /health            | healthController            | —                       | `HealthStatus`   |
-| GET    | /v1/health         | healthController            | —                       | `HealthStatus`   |
-| GET    | /v1/projects       | listProjectsController      | `listProjects()`        | `Project[]`      |
-| GET    | /v1/projects/:id   | getProjectController        | `getProjectById(id)`    | `Project`        |
-| GET    | /v1/projects/:id/workspaces | listProjectWorkspacesController | `listWorkspacesByProjectId(projectId)` | `Workspace[]` |
-| GET    | /v1/workspaces/:id/windows  | listWorkspaceWindowsController  | `listWindowsByWorkspaceId(workspaceId)` | `ChatWindow[]` |
-| GET    | /v1/windows/:id/messages    | listWindowMessagesController    | `listMessagesByWindowId(windowId)` | `Message[]` |
+### Health
 
-All responses:
+| Method | Path         | Response       |
+|--------|--------------|----------------|
+| GET    | /health      | `HealthStatus` |
+| GET    | /v1/health   | `HealthStatus` |
+
+### Projects (`API_PROJECTS_PATH = /v1/projects`)
+
+| Method | Path                 | Auth (DB mode) | Body / returns                  |
+|--------|----------------------|----------------|---------------------------------|
+| GET    | /v1/projects         | session        | `Project[]`                     |
+| POST   | /v1/projects         | session        | `CreateProjectDto` → `Project`  |
+| GET    | /v1/projects/:id     | session        | `Project` (404 `not_found`)     |
+
+### Workspaces (`API_WORKSPACES_PATH = /v1/workspaces`)
+
+| Method | Path                    | Returns                                |
+|--------|-------------------------|----------------------------------------|
+| GET    | /v1/workspaces          | `Workspace[]` (`?projectId` filter)    |
+| POST   | /v1/workspaces          | `Workspace`                            |
+| GET    | /v1/workspaces/:id      | `Workspace`                            |
+
+### Chat windows (`API_CHAT_WINDOWS_PATH = /v1/chat-windows`)
+
+| Method | Path                       | Returns                                   |
+|--------|----------------------------|-------------------------------------------|
+| GET    | /v1/chat-windows           | `ChatWindow[]` (`?workspaceId` filter)    |
+| POST   | /v1/chat-windows           | `ChatWindow`                              |
+| GET    | /v1/chat-windows/:id       | `ChatWindow`                              |
+
+### Messages (`API_MESSAGES_PATH = /v1/messages`)
+
+| Method | Path                   | Returns                                  |
+|--------|------------------------|------------------------------------------|
+| GET    | /v1/messages           | `Message[]` (`?chatWindowId` filter)     |
+| POST   | /v1/messages           | `Message` — user msg persisted + OpenAI call + assistant msg persisted. `412` when no provider. Timeout 30s. |
+| GET    | /v1/messages/:id       | `Message`                                |
+
+### Legacy read aliases (kept until web migrates to canonical paths — #38)
+
+| Method | Path                                | Rewrites to                                  |
+|--------|-------------------------------------|----------------------------------------------|
+| GET    | /v1/workspaces/:id/windows          | `GET /v1/chat-windows?workspaceId=:id`       |
+| GET    | /v1/windows/:id/messages            | `GET /v1/messages?chatWindowId=:id`          |
+
+### Auth (DB mode only)
+
+| Method | Path                 | Body                        | Returns / effect                        |
+|--------|----------------------|-----------------------------|-----------------------------------------|
+| POST   | /v1/auth/signup      | `AuthSignupDto`             | sets session cookie, `AuthMe`           |
+| POST   | /v1/auth/login       | `AuthLoginDto`              | sets session cookie, `AuthMe`           |
+| POST   | /v1/auth/logout      | —                           | clears session cookie                   |
+| GET    | /v1/auth/me          | —                           | `AuthMe` or 401                         |
+
+### Provider connections (DB mode only, auth-required, `API_PROVIDER_CONNECTIONS_PATH = /v1/provider-connections`)
+
+| Method | Path                                        | Body                             | Effect                                         |
+|--------|---------------------------------------------|----------------------------------|------------------------------------------------|
+| GET    | /v1/provider-connections                    | —                                | `ProviderConnectionMetadata[]` (no secrets)    |
+| GET    | /v1/provider-connections/:provider          | —                                | `ProviderConnectionMetadata`                   |
+| PUT    | /v1/provider-connections/:provider          | `UpsertProviderConnectionDto`    | encrypts + stores API key                      |
+| DELETE | /v1/provider-connections/:provider          | —                                | removes connection                             |
+| POST   | /v1/provider-connections/openai/test        | —                                | live ping OpenAI with stored key               |
+
+### State
+
+| Method | Path         | Returns                                           |
+|--------|--------------|---------------------------------------------------|
+| GET    | /v1/state    | `{ projects, workspaces, chatWindows, messages }` bootstrap snapshot (user-scoped in DB mode) |
+
+### Dev (only when `ENABLE_DEV_ENDPOINTS=true`)
+
+| Method | Path               | Effect                                            |
+|--------|--------------------|---------------------------------------------------|
+| POST   | /v1/dev/reset      | resets in-memory stores / dev DB fixtures         |
+| POST   | /v1/dev/seed       | reseeds dev fixtures                              |
+
+## Envelope
 
 ```ts
 { ok: true, data: T }
-| { ok: false, error: { code, message, details? } }
+| { ok: false, error: { code: ApiErrorCode, message: string, details?: unknown } }
 ```
 
-Status mapping (set by `handle-request`):
+`ApiErrorCode` includes: `bad_request`, `unauthorized`, `forbidden`, `not_found`, `conflict`, `validation_error`, `method_not_allowed`, `internal_error`, `provider_error`, `provider_auth_error`, `provider_not_configured` (backlog — #57).
+
+Status mapping (via `middleware/handle-request`):
 - `ok:true` → 200
-- `ok:false` returned by controller → 400
+- Controller `HttpError` → its status + `fail(code, message)`
 - Unknown path → 404 `not_found`
 - Known path, wrong method → 405 `method_not_allowed`
-- Controller throws `HttpError` → custom status + `fail(code, message)` envelope (e.g. 404 `not_found` for unknown resource id).
-- Unhandled throw → 500 `internal_error`
+- Unhandled throw → 500 `internal_error` (also fed to Sentry if configured)
 
 Headers:
 - `Content-Type: application/json; charset=utf-8`
 - `Cache-Control: no-store`
-- `X-Request-Id: <uuid>` (set by `request-id` util per request).
+- `X-Request-Id: <uuid>`
+- CORS headers per `CORS_ORIGIN`; cookies when session middleware authenticates.
 
 ## File map
 
-- Routes registry: `apps/api/src/routes/index.ts`
-- Controllers: `apps/api/src/controllers/*.controller.ts`
-- Services: `apps/api/src/services/*.service.ts`
-- Envelope helpers (`ok`, `fail`, `writeJson`): `apps/api/src/lib/http.ts`
-- Router: `apps/api/src/lib/router.ts` (literal + `:param` segments, returns `RouteMatch { handler, params }`)
-- Middleware: `apps/api/src/middleware/handle-request.ts`
-- Env parser: `apps/api/src/config/env.ts`
-- Server factory: `apps/api/src/lib/server.ts`
-- Test harness: `apps/api/src/test/server-harness.ts`
-- Route tests: `apps/api/src/routes/*.test.ts`, `apps/api/src/middleware/handle-request.test.ts`
+- Routes registry: `apps/api/src/routes/index.ts` (toggles DB vs in-memory at module load).
+- Route modules: `apps/api/src/routes/{auth,projects-db,workspaces-db,chat-windows-db,messages-db,provider-connections,dev}.ts`.
+- Controllers: `apps/api/src/controllers/*.controller.ts` (paired `*-db.controller.ts` for DB mode).
+- Services (in-memory fallback): `apps/api/src/services/*.service.ts`.
+- Repos (DB mode): `apps/api/src/db/*.repo.ts` + `db/schema.ts`.
+- Envelope helpers: `apps/api/src/lib/http.ts` (`ok`, `fail`, `writeJson`, `HttpError`).
+- Router: `apps/api/src/lib/router.ts`.
+- DB factory: `apps/api/src/lib/db.ts`.
+- Auth primitives: `apps/api/src/lib/{cookie,password,session-token,resolve-user}.ts`.
+- Cipher: `apps/api/src/lib/api-key-cipher.ts`.
+- Sentry wrapper: `apps/api/src/lib/sentry.ts`.
+- Test harness: `apps/api/src/test/server-harness.ts`.
 
 ## How to add a route
 
-1. Add controller in `apps/api/src/controllers/`.
-2. Add service if it touches data.
-3. Register in `apps/api/src/routes/index.ts`.
-4. Add a vitest using `server-harness`.
+1. Controller in `controllers/` (pair a `*-db.controller.ts` when user-scoping).
+2. For DB mode add a repo in `db/` or reuse one.
+3. Register in a dedicated `routes/<thing>.ts` (or inline in `routes/index.ts` for trivial ones) and wire from `routes/index.ts`.
+4. Add vitest via `server-harness` (DB-mode tests use an in-process fake DB).
 5. Update this file.
 
-## Domain types used by the API
+## Backend env (see `apps/api/.env.example` for full list)
 
-From `@webapp/types`:
-
-- `Project` = `{ id, name, description?, createdAt, updatedAt }`
-- `Workspace` = `{ id, projectId, name, windowIds, createdAt, updatedAt }`
-- `ChatWindow` = `{ id, workspaceId, title, provider, model, createdAt, updatedAt }`
-- `Message` = `{ id, windowId, role, content, createdAt }`
-- `MessageRole` = `'user' | 'assistant'`
-- `AIProvider` = `'openai' | 'anthropic' | 'perplexity'`
-
-## Backend env
-
-- `API_PORT` (default 4000)
-- `NODE_ENV` (`development` | `production` | `test`)
-- `API_VERSION` (default `0.1.0`)
+- `API_PORT`, `NODE_ENV`, `API_VERSION`
+- `CORS_ORIGIN`, `API_MAX_BODY_BYTES`, `ENABLE_DEV_ENDPOINTS`
+- `DATABASE_URL` (switches on DB mode)
+- `PROVIDER_ENCRYPTION_KEY` (required when DB is set — 32-byte hex)
+- `OPENAI_MAX_CONTEXT_MESSAGES`
+- `SENTRY_DSN_API`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`

--- a/project-memory/06-frontend-map.md
+++ b/project-memory/06-frontend-map.md
@@ -2,6 +2,8 @@
 
 App: `apps/web`. Next.js 15 App Router. TS strict. Path alias `@/* → src/*`.
 
+**Current status: read-only + local state.** No write clients, no auth UI, no provider-settings UI. The backend already supports all of those — the web app has simply not been wired to them yet. Tracking: issues #16, #17, #18, #19, #20, #28, #36, #37, #38, #41.
+
 ## Routes
 
 | Route               | File                                    | Data source                                     |
@@ -9,19 +11,19 @@ App: `apps/web`. Next.js 15 App Router. TS strict. Path alias `@/* → src/*`.
 | `/`                 | `src/app/page.tsx`                      | `lib/api/projects` if `NEXT_PUBLIC_API_URL`, else `lib/mocks` |
 | `/project/[id]`     | `src/app/project/[id]/page.tsx`         | `fetchProject(id)` + `fetchProjectWorkspaces(id)` + `fetchWorkspaceWindows(activeWsId)` + per-window `fetchWindowMessages(winId)` (parallel). Mock fallback at every layer. |
 
-Layout: `src/app/layout.tsx`.
+Layout: `src/app/layout.tsx`. No auth-gated routes exist yet (#17).
 
 ## Features
 
 - `features/workspace/`
-  - `Workspace.tsx` (client) — shell for canvas + sidebar.
+  - `Workspace.tsx` — shell for canvas + sidebar.
   - `WorkspaceCanvas.tsx` — renders chat windows.
   - `WorkspaceSidebar.tsx` — workspace list (shared window manager).
-  - `NewWindowComposer.tsx` — create window with preset.
-  - `useWorkspaceState.ts` — local state, window lifecycle (create/rename/focus).
+  - `NewWindowComposer.tsx` — create window with preset (local-only, does not POST).
+  - `useWorkspaceState.ts` — local React state, window lifecycle (create/rename/focus).
 - `features/chat/`
   - `ChatWindow.tsx` — single chat window UI.
-  - `useChatSessions.ts` — per-window independent session state (local only).
+  - `useChatSessions.ts` — per-window session state (local only; no POST message yet).
 
 ## Components
 
@@ -29,30 +31,35 @@ Layout: `src/app/layout.tsx`.
 
 ## lib
 
-- `lib/api/env.ts` — `getApiBaseUrl()`, trims trailing slashes, returns `null` when unset.
-- `lib/api/client.ts` — `apiFetch<T>(path, { timeoutMs?, signal?, cache? })`; default 5s timeout, `cache: 'no-store'`; validates envelope, throws `ApiCallError` with `code`/`status` on failure.
-- `lib/api/projects.ts` — `fetchProjects(signal?)`, `fetchProject(id, signal?)`.
-- `lib/api/workspaces.ts` — `fetchProjectWorkspaces(projectId, signal?)`.
-- `lib/api/windows.ts` — `fetchWorkspaceWindows(workspaceId, signal?)`.
-- `lib/api/messages.ts` — `fetchWindowMessages(windowId, signal?)`.
-- `lib/data/index.ts` — mock-backed read API for projects, workspaces, windows; used by routes other than homepage.
+- `lib/api/env.ts` — `getApiBaseUrl()`, returns `null` when `NEXT_PUBLIC_API_URL` is unset.
+- `lib/api/client.ts` — `apiFetch<T>` with 5s default timeout, `cache: 'no-store'`, envelope validation, throws `ApiCallError` on failure.
+- `lib/api/projects.ts` — `fetchProjects`, `fetchProject`.
+- `lib/api/workspaces.ts` — `fetchProjectWorkspaces`.
+- `lib/api/windows.ts` — `fetchWorkspaceWindows` (hits legacy alias `GET /v1/workspaces/:id/windows`).
+- `lib/api/messages.ts` — `fetchWindowMessages` (hits legacy alias `GET /v1/windows/:id/messages`).
+- `lib/data/index.ts` — mock-backed read API for routes other than `/`.
 - `lib/data/presets.ts` — window preset definitions.
 - `lib/mocks/fixtures.ts` — static mock data.
 
+All current clients are **read-only**. A canonical-path migration (`/v1/chat-windows`, `/v1/messages`) is tracked in #38. Write clients for projects/workspaces/chat-windows and POST-message are in #19 / #28.
+
 ## Styles
 
-`src/styles/globals.css`. No Tailwind installed (yet); plain CSS.
+`src/styles/globals.css`. No Tailwind installed yet; plain CSS.
 
 ## State model
 
 - Workspace + windows = local React state (`useWorkspaceState`, `useChatSessions`). Not persisted.
 - Workspace selected via URL query `?workspace=…`.
-- No global store (Redux/Zustand). Stays local to features.
+- No global store (Redux/Zustand). No session / auth state.
+- No optimistic writes (will land with #28).
 
 ## Env
 
-- `NEXT_PUBLIC_APP_URL` (frontend URL)
-- `NEXT_PUBLIC_API_URL` (backend base; toggles real-API vs mock)
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_API_URL` (toggles real-API vs mock). See `apps/web/.env.example`.
+
+Sentry browser SDK init is tracked in #41 — not yet present on web (backend-only today).
 
 ## Dev
 
@@ -63,7 +70,7 @@ pnpm --filter @webapp/web dev
 ## Where to add what
 
 - New page → `src/app/<route>/page.tsx`.
-- Shared primitive (button, panel…) → `src/components/`.
-- Feature module (self-contained UI + hooks) → `src/features/<name>/`.
+- Shared primitive → `src/components/`.
+- Feature module → `src/features/<name>/`.
 - API call → `src/lib/api/<resource>.ts` then consume in a component/hook.
 - Mock data helper → `src/lib/data/` or `src/lib/mocks/`.

--- a/project-memory/07-backend-map.md
+++ b/project-memory/07-backend-map.md
@@ -5,67 +5,111 @@ App: `apps/api`. Node 20+, TS strict, plain `node:http`, no framework.
 ## Responsibilities
 
 - Serve JSON endpoints for the web app.
-- Own all sensitive state (future: user keys, DB).
-- Enforce a uniform `ApiResponse<T>` envelope.
+- Own sensitive state: user accounts, sessions, encrypted provider API keys, message history.
+- Call external AI providers on behalf of the user (currently OpenAI).
+- Enforce a uniform `ApiResponse<T>` envelope everywhere.
 
 ## Structure
 
 ```
 apps/api/src
-├── index.ts                 entrypoint, listen, shutdown
+├── index.ts                       entrypoint, listen, shutdown, Sentry init
 ├── config/
-│   └── env.ts               parses/validates env
+│   └── env.ts                     parses/validates env (incl. PROVIDER_ENCRYPTION_KEY)
 ├── lib/
-│   ├── http.ts              types + ok/fail/writeJson/isHttpMethod
-│   ├── logger.ts            structured logger
-│   ├── request-id.ts        uuid per request
-│   ├── router.ts            custom method+path matcher
-│   └── server.ts            buildRouter + createApiServer
+│   ├── http.ts                    envelope types + ok/fail/writeJson, HttpError
+│   ├── logger.ts                  structured logger
+│   ├── request-id.ts              uuid per request
+│   ├── router.ts                  method+path matcher with :param
+│   ├── server.ts                  buildRouter + createApiServer
+│   ├── db.ts                      drizzle client factory (only constructed when DATABASE_URL set)
+│   ├── cookie.ts                  cookie parse/serialize
+│   ├── password.ts                bcrypt hash + verify
+│   ├── session-token.ts           signed session token mint/verify
+│   ├── resolve-user.ts            session-cookie → user lookup
+│   ├── api-key-cipher.ts          AES-256-GCM encrypt/decrypt provider keys
+│   ├── rate-limiter.ts            simple in-memory rate limiter (not wired yet)
+│   └── sentry.ts                  init / captureException / flush (no-op without DSN)
 ├── middleware/
-│   ├── handle-request.ts    request pipeline
-│   └── handle-request.test.ts
+│   ├── handle-request.ts          request pipeline + error → envelope + Sentry capture
+│   └── cors.test.ts
 ├── routes/
-│   ├── index.ts             RouteDefinition[]
-│   ├── health.test.ts
-│   ├── projects.test.ts
-│   ├── workspaces.test.ts
-│   ├── windows.test.ts
-│   └── messages.test.ts
+│   ├── index.ts                   registers business + auth + dev routes; switches DB vs in-memory
+│   ├── auth.ts                    makeAuthRoutes(deps)
+│   ├── projects-db.ts             makeProjectDbRoutes(deps)
+│   ├── workspaces-db.ts           makeWorkspaceDbRoutes(deps)
+│   ├── chat-windows-db.ts         makeChatWindowDbRoutes(deps)
+│   ├── messages-db.ts             makeMessageDbRoutes(deps)
+│   ├── provider-connections.ts    makeProviderConnectionRoutes(deps)
+│   ├── dev.ts                     /v1/dev/{reset,seed} — dev only
+│   └── *.test.ts                  per-route vitest suites
 ├── controllers/
 │   ├── health.controller.ts
-│   ├── projects.controller.ts
-│   ├── workspaces.controller.ts
-│   └── messages.controller.ts
-├── services/
-│   ├── projects.service.ts   in-memory frozen seed
-│   ├── workspaces.service.ts in-memory frozen seed (+ workspaceExists)
-│   ├── windows.service.ts    in-memory frozen seed (+ windowExists)
-│   └── messages.service.ts   in-memory frozen seed
+│   ├── projects.controller.ts + projects-db.controller.ts
+│   ├── workspaces.controller.ts + workspaces-db.controller.ts
+│   ├── chat-windows.controller.ts + chat-windows-db.controller.ts
+│   ├── messages.controller.ts + messages-db.controller.ts   (POST → OpenAI loop)
+│   ├── auth.controller.ts
+│   ├── provider-connections.controller.ts
+│   ├── state.controller.ts + state-db.controller.ts
+│   └── dev.controller.ts
+├── services/                      in-memory fallback stores (no DB)
+│   ├── projects.service.ts
+│   ├── workspaces.service.ts
+│   ├── chat-windows.service.ts
+│   ├── messages.service.ts
+│   └── provider-key.service.ts    in-memory key store used by legacy tests
+├── db/                            drizzle repos (DB mode)
+│   ├── schema.ts
+│   ├── users.repo.ts
+│   ├── sessions.repo.ts
+│   ├── projects.repo.ts
+│   ├── workspaces.repo.ts
+│   ├── chat-windows.repo.ts
+│   ├── messages.repo.ts
+│   └── provider-connections.repo.ts
+├── providers/
+│   ├── provider.interface.ts      shared Provider contract
+│   └── openai.provider.ts         OpenAI chat-completion adapter (30s timeout, typed errors)
 ├── test/
-│   └── server-harness.ts    boots http.Server for tests
-└── types/                   (placeholder)
+│   └── server-harness.ts          boots http.Server on ephemeral port
+└── types/                         (placeholder)
 ```
+
+Drizzle migrations live in `apps/api/drizzle/` (three applied: `0000_*`, `0001_*`, `0002_message_provider_metadata`).
 
 ## Request flow
 
 1. `createApiServer()` → `http.createServer(handler)`.
-2. `handleRequest(router, req, res)` reads method+URL, creates `RequestContext`, calls `router.match`.
-3. Controller runs, returns `ApiResponse<T>`.
-4. `writeJson(res, 200, body, requestId)` sends it.
-5. No handler → 405 `method_not_allowed` if path is registered for another method, else 404 `not_found`. Unknown HTTP method → 405 immediately. Thrown handler errors → 500 `internal_error`. All via `fail()` envelope.
+2. `handleRequest(router, req, res)` reads method+URL, attaches request-id, runs CORS, calls `router.match`.
+3. DB-mode controllers call `resolveUser(ctx)` to hydrate the session user, then delegate to a repo.
+4. Controller returns `ApiResponse<T>`; middleware calls `writeJson`.
+5. Unknown path → 404. Known path, wrong method → 405. `HttpError` → its status. Unhandled throw → 500 + `captureException`.
+
+## DB vs in-memory toggle
+
+`routes/index.ts` constructs the single DB handle exactly once, at module load, only when `env.databaseUrl` is set. Every business route family picks DB vs in-memory based on that handle:
+
+- DB mode: auth + provider-connections routes present, write paths user-scoped.
+- No DB: auth + provider-connections absent, write paths land in shared seeded stores (dev / MVP convenience, kept for tests).
+
+This seam keeps the existing in-memory integration tests green while letting DB-backed tests run against the same harness with a DB handle.
 
 ## Sensitive zones
 
-- `lib/router.ts` — path matching; change carefully. Supports `:param` segments (decoded per-segment). `match` returns `RouteMatch { handler, params }`.
-- `lib/http.ts` — envelope contract; do not break shape (web depends on it). Exports `HttpError` for status-bearing throws from controllers.
-- `services/projects.service.ts` — in-memory store; will be swapped for DB. Keep interface narrow.
-- `middleware/handle-request.ts` — global error path; any throw must become a proper `ApiResponse` + status.
+- `lib/router.ts` — path matching; change carefully. Supports `:param` segments (decoded per-segment).
+- `lib/http.ts` — envelope contract; do not break shape.
+- `lib/api-key-cipher.ts` — AES-GCM roundtrip. Never log plaintext keys; require `PROVIDER_ENCRYPTION_KEY` when DB is set.
+- `lib/session-token.ts` + `db/sessions.repo.ts` — auth seam; invalid state here is a critical bug.
+- `providers/openai.provider.ts` — external I/O, must stay behind the `Provider` interface; respect the 30s timeout.
+- `middleware/handle-request.ts` — global error path; every throw must become a proper `ApiResponse` + status.
 
 ## Tests
 
-- Vitest, integration-style via `server-harness` spinning a real `http.Server` on ephemeral port.
-- 19 tests pass as of 2026-04-22. Run: `pnpm --filter @webapp/api test`.
+- Vitest, integration-style via `server-harness`.
+- 226 tests across 24 files as of 2026-04-24. Run: `pnpm --filter @webapp/api test`.
+- DB-backed suites use an in-process fake DB harness (no Postgres required).
 
 ## Env
 
-`API_PORT` (4000), `NODE_ENV` (`development|production|test`), `API_VERSION` (`0.1.0`).
+See `05-api-map.md` and `apps/api/.env.example`.

--- a/project-memory/08-recent-changes.md
+++ b/project-memory/08-recent-changes.md
@@ -2,10 +2,30 @@
 
 Newest first. One line per commit. Update at end of a session or via `tools/update-memory.sh`.
 
+## 2026-04-24
+
+- 9b45cf3 chore(types): add write-path DTOs for auth and provider-connections (#58).
+- e49048d chore(tooling): project status automation — CLI + `pnpm project:status:*` (#56).
+- 6fb6698 feat(providers): harden POST message loop — 412 no-provider, 30s timeout, `provider_error` code (#55).
+- 3a04ee7 chore(env): commit `.env.example` for api and web (#54).
+- 29f78aa feat(api): register `/v1/health` alias (#53).
+- 0adce92 chore(infra): docker-compose postgres + local bootstrap docs (#51).
+- 364f390 chore(db): document drizzle workflow (#50).
+- 220dc68 chore(ci): issue + PR templates matching label taxonomy (#49).
+- 397a83d chore(tooling): backlog automation + AI issue execution protocol.
+- 82b6904 chore(ops): free GitHub → Notion Tasks sync (Actions + Notion API) (#48).
+
+## 2026-04-23
+
+- f46f599 merge: PR #6 — integrate messages provider metadata branch into main. **Track B merged.** Main now has DB-gated routes, auth, provider-connections (AES-GCM encrypted), Sentry, drizzle migrations.
+- c8e3c26 feat(api): integrate messages provider metadata branch into main.
+- 87beb1c feat(api): sentry init — minimal error capture (#4).
+- dbd40ef chore(tooling): ADRs, roadmap, env placeholders, e2e scaffold (#3).
+
 ## 2026-04-22 (session pm)
 
-- 5708b9a merge(integration): feat/api-window-messages into feat/integration-homepage-projects (no conflict).
-- 97418e0 merge(integration): feat/api-workspace-windows into feat/integration-homepage-projects (no conflict).
+- 5708b9a merge(integration): feat/api-window-messages into the Track A integration branch (no conflict).
+- 97418e0 merge(integration): feat/api-workspace-windows into the Track A integration branch (no conflict).
 - f1903e7 feat(api): add `GET /v1/windows/:id/messages` + seed store + `Message`/`MessageRole` types + frontend `lib/api/messages.ts` + per-window parallel fetch in `/project/[id]` with mock fallback. 3 new API tests (19 total).
 - 152b5a1 feat(web): wire workspace view to real `GET /v1/workspaces/:id/windows` with `lib/api/windows.ts` and mock fallback.
 - 128ae4d feat(api): add `GET /v1/workspaces/:id/windows` + seeded store + `workspaceExists` helper + 3 new tests (16 total at that point).
@@ -13,7 +33,7 @@ Newest first. One line per commit. Update at end of a session or via `tools/upda
 
 ## 2026-04-22
 
-- Fast-forward merged `feat/web-project-workspaces-api` (and transitively all 4 feat branches) into `feat/integration-homepage-projects`. Tests 13/13 green, web build green. Integration branch now carries the full Track A surface.
+- Fast-forward merged `feat/web-project-workspaces-api` (and transitively all 4 feat branches) into the Track A integration branch. Tests 13/13 green, web build green. Integration branch now carried the full Track A surface.
 - **Discovered `origin/feat/api-foundation` is 53 commits ahead** of the integration branch with a parallel DB+auth+OpenAI V1. Not merged this session. Flagged as a track decision needed in `03-current-state.md`.
 - 7824866 feat(web): wire `/project/[id]` workspaces to real `GET /v1/projects/:id/workspaces` (mock fallback, dual badges, workspaces error panel).
 


### PR DESCRIPTION
## Summary
- Sync `project-memory/` with main at `9b45cf3`.
- Documents Track A + Track B merged state: DB-gated routes, auth, provider-connections (AES-GCM), Sentry, drizzle migrations, write endpoints.
- `04-active-tasks.md` now points at GitHub Project #1 instead of duplicating state.

## AC check
- `grep -r "read-only V1\\|integration-homepage-projects\\|19 tests" project-memory/ --include="*.md"` → empty.
- `pnpm typecheck` → 6/6 green.

Closes #21

## Test plan
- [x] stale-phrase grep empty
- [x] typecheck green
- [ ] human review of wording (label: ai:human-checkpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)