### PR TITLE
chore(repo): ignore e2e artefacts + harden issue-status CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ yarn-debug.log*
 
 # coverage
 coverage/
+
+# playwright e2e artefacts
+apps/e2e/test-results/
+apps/e2e/playwright-report/
+apps/e2e/blob-report/

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "issues:delta:dry-run": "node tools/apply-issue-delta.mjs --dry-run",
     "issues:delta:apply": "node tools/apply-issue-delta.mjs --yes",
     "project:status": "node tools/issue-status.mjs",
+    "project:status:test": "node --test tools/issue-status.test.mjs",
     "project:status:in-progress": "node tools/issue-status.mjs --status \"In Progress\"",
     "project:status:review": "node tools/issue-status.mjs --status Review",
     "project:status:blocked": "node tools/issue-status.mjs --status Blocked",

--- a/tools/issue-status.mjs
+++ b/tools/issue-status.mjs
@@ -23,6 +23,14 @@ function die(msg, code = 1) {
   process.exit(code);
 }
 
+export class ArgsError extends Error {
+  constructor(message, { exitCode = 1, showUsage = false } = {}) {
+    super(message);
+    this.exitCode = exitCode;
+    this.showUsage = showUsage;
+  }
+}
+
 function runCapture(bin, argv) {
   const r = spawnSync(bin, argv, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
   return { code: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
@@ -35,40 +43,68 @@ function ghJson(argv) {
   catch (e) { die(`cannot parse gh output for \`gh ${argv.join(' ')}\`: ${e.message}`); }
 }
 
+export const USAGE_LINES = [
+  'usage: node tools/issue-status.mjs <issueNumber> <status>',
+  `       status: ${VALID_STATUSES.map((s) => `"${s}"`).join(' | ')}`,
+  'example: node tools/issue-status.mjs 27 "In Progress"',
+];
+
+function printUsage() {
+  for (const line of USAGE_LINES) console.error(line);
+}
+
 function usage() {
-  console.error('usage: node tools/issue-status.mjs <issueNumber> <status>');
-  console.error(`       status: ${VALID_STATUSES.map((s) => `"${s}"`).join(' | ')}`);
-  console.error('example: node tools/issue-status.mjs 27 "In Progress"');
+  printUsage();
   process.exit(2);
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
+export function parseArgsFrom(argv) {
   const positional = [];
   let flagStatus;
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
     if (a === '--status' || a === '-s') {
-      flagStatus = args[++i];
+      flagStatus = argv[++i];
       continue;
     }
-    if (a === '--help' || a === '-h') usage();
-    if (a.startsWith('--')) die(`unknown flag: ${a}`);
+    if (a === '--help' || a === '-h') {
+      throw new ArgsError('help', { exitCode: 2, showUsage: true });
+    }
+    if (a.startsWith('--')) throw new ArgsError(`unknown flag: ${a}`);
     positional.push(a);
   }
-  if (positional.length === 0) usage();
+  if (positional.length === 0) {
+    throw new ArgsError('missing arguments', { exitCode: 2, showUsage: true });
+  }
 
   const issueNumber = Number.parseInt(positional[0], 10);
   if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
-    die(`invalid issue number: "${positional[0]}"`);
+    throw new ArgsError(
+      `invalid issue number: "${positional[0]}"\n  hint: pass the issue number first. ${USAGE_LINES[0]}`,
+    );
   }
 
   const status = (flagStatus ?? positional.slice(1).join(' ')).trim();
-  if (!status) usage();
+  if (!status) throw new ArgsError('missing status', { exitCode: 2, showUsage: true });
   if (!VALID_STATUSES.includes(status)) {
-    die(`invalid status: "${status}". Expected one of: ${VALID_STATUSES.join(', ')}`);
+    throw new ArgsError(
+      `invalid status: "${status}". Expected one of: ${VALID_STATUSES.join(', ')}`,
+    );
   }
   return { issueNumber, status };
+}
+
+function parseArgs() {
+  try {
+    return parseArgsFrom(process.argv.slice(2));
+  } catch (err) {
+    if (err instanceof ArgsError) {
+      if (err.message !== 'help') console.error(c.red(`error: ${err.message}`));
+      if (err.showUsage) printUsage();
+      process.exit(err.exitCode);
+    }
+    throw err;
+  }
 }
 
 function preflight() {
@@ -163,4 +199,6 @@ function main() {
   console.log(c.green('Done'));
 }
 
-main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/issue-status.test.mjs
+++ b/tools/issue-status.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgsFrom, ArgsError } from './issue-status.mjs';
+
+test('positional: <issueNumber> <status>', () => {
+  assert.deepEqual(parseArgsFrom(['21', 'In Progress']), {
+    issueNumber: 21,
+    status: 'In Progress',
+  });
+});
+
+test('flag: --status "In Progress" <issueNumber>', () => {
+  assert.deepEqual(parseArgsFrom(['--status', 'In Progress', '21']), {
+    issueNumber: 21,
+    status: 'In Progress',
+  });
+});
+
+test('flag: <issueNumber> --status Review', () => {
+  assert.deepEqual(parseArgsFrom(['21', '--status', 'Review']), {
+    issueNumber: 21,
+    status: 'Review',
+  });
+});
+
+test('positional joins multi-word status', () => {
+  assert.deepEqual(parseArgsFrom(['42', 'In', 'Progress']), {
+    issueNumber: 42,
+    status: 'In Progress',
+  });
+});
+
+test('error: first arg is a status keyword — hint points to right ordering', () => {
+  assert.throws(
+    () => parseArgsFrom(['in-progress', '21']),
+    (err) => {
+      assert.ok(err instanceof ArgsError);
+      assert.match(err.message, /invalid issue number: "in-progress"/);
+      assert.match(err.message, /usage: node tools\/issue-status\.mjs <issueNumber> <status>/);
+      return true;
+    },
+  );
+});
+
+test('error: invalid status', () => {
+  assert.throws(
+    () => parseArgsFrom(['21', 'Bogus']),
+    (err) => err instanceof ArgsError && /invalid status: "Bogus"/.test(err.message),
+  );
+});
+
+test('error: unknown flag', () => {
+  assert.throws(
+    () => parseArgsFrom(['--wat', '21', 'Review']),
+    (err) => err instanceof ArgsError && /unknown flag: --wat/.test(err.message),
+  );
+});
+
+test('error: missing args shows usage', () => {
+  assert.throws(
+    () => parseArgsFrom([]),
+    (err) => err instanceof ArgsError && err.showUsage === true && err.exitCode === 2,
+  );
+});


### PR DESCRIPTION
## Summary
- Ignore `apps/e2e/{test-results,playwright-report,blob-report}/` so `git status` stays clean after Playwright runs.
- `tools/issue-status.mjs`: hint at correct arg order when the first positional is not a valid issue number. Extract `parseArgsFrom` + `ArgsError` for testability.
- Add `tools/issue-status.test.mjs` (node:test, 8 cases) covering both arg orders, the new ordering-hint error, invalid status, unknown flag, missing args.
- Wire `pnpm project:status:test`.

Closes #60
Closes #61

## AC check
- **#60**: `git status` clean after `pnpm --filter @webapp/e2e test` on a cold repo (verified by removing prior `apps/e2e/test-results/`; ignore pattern covers it).
- **#61**:
  - `node tools/issue-status.mjs in-progress 21` → exits with `invalid issue number: "in-progress"` **plus** usage hint.
  - `node tools/issue-status.mjs --status "In Progress" 21` works (as npm script `project:status:in-progress` already invoked).
  - `node tools/issue-status.mjs 21 "In Progress"` still works.
  - `pnpm project:status:test` → 8/8 green.

## Test plan
- [x] `pnpm project:status:test` passes
- [x] `pnpm typecheck` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)