### PR TITLE
feat(web): login + register pages consuming /v1/auth/* (#16)

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AuthForm } from '@/features/auth/AuthForm';
+
+export const metadata: Metadata = {
+  title: 'Log in · AI Workspace V1',
+};
+
+export default function LoginPage() {
+  return <AuthForm mode="login" />;
+}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { AuthForm } from '@/features/auth/AuthForm';
+
+export const metadata: Metadata = {
+  title: 'Create account · AI Workspace V1',
+};
+
+export default function RegisterPage() {
+  return <AuthForm mode="register" />;
+}

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, type FormEvent } from 'react';
+import { Button } from '@/components/Button';
+import { Panel } from '@/components/Panel';
+import { login, register } from '@/lib/api/auth';
+import type { ApiCallError } from '@/lib/api/client';
+
+type Mode = 'login' | 'register';
+
+interface AuthFormProps {
+  mode: Mode;
+}
+
+const copy: Record<Mode, { title: string; cta: string; switchTo: string; switchHref: string; switchLabel: string }> = {
+  login: {
+    title: 'Log in',
+    cta: 'Log in',
+    switchTo: 'No account yet?',
+    switchHref: '/register',
+    switchLabel: 'Create one',
+  },
+  register: {
+    title: 'Create your account',
+    cta: 'Sign up',
+    switchTo: 'Already have an account?',
+    switchHref: '/login',
+    switchLabel: 'Log in',
+  },
+};
+
+function messageFor(err: ApiCallError, mode: Mode): string {
+  switch (err.code) {
+    case 'unauthenticated':
+      return 'Wrong email or password.';
+    case 'conflict':
+      return 'An account with that email already exists.';
+    case 'validation_error':
+      return err.message || 'Invalid input.';
+    case 'rate_limited':
+      return 'Too many attempts. Try again in a few minutes.';
+    case 'no_api_url':
+      return 'API URL not configured. Set NEXT_PUBLIC_API_URL.';
+    case 'network_error':
+    case 'timeout':
+      return 'Could not reach the API.';
+    default:
+      return mode === 'login' ? 'Login failed.' : 'Sign-up failed.';
+  }
+}
+
+export function AuthForm({ mode }: AuthFormProps) {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setPending(true);
+    try {
+      if (mode === 'login') {
+        await login({ email, password });
+      } else {
+        await register({
+          email,
+          password,
+          ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
+        });
+      }
+      router.push('/');
+      router.refresh();
+    } catch (err) {
+      setError(messageFor(err as ApiCallError, mode));
+      setPending(false);
+    }
+  }
+
+  const c = copy[mode];
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
+      <Panel style={{ padding: '2rem', width: '100%', maxWidth: 380 }}>
+        <h1 style={{ fontSize: '1.25rem', margin: '0 0 1.25rem 0', color: '#f5f5f5' }}>{c.title}</h1>
+        <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}>
+          {mode === 'register' ? (
+            <Field label="Display name (optional)">
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                autoComplete="name"
+                style={inputStyle}
+              />
+            </Field>
+          ) : null}
+          <Field label="Email">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              style={inputStyle}
+            />
+          </Field>
+          <Field label="Password">
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={mode === 'register' ? 8 : undefined}
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              style={inputStyle}
+            />
+          </Field>
+
+          {error ? (
+            <div
+              role="alert"
+              style={{
+                color: '#ffb4b4',
+                fontSize: '0.82rem',
+                padding: '0.5rem 0.7rem',
+                background: '#6b2a2a1a',
+                border: '1px solid #6b2a2a55',
+                borderRadius: 6,
+              }}
+            >
+              {error}
+            </div>
+          ) : null}
+
+          <Button type="submit" disabled={pending}>
+            {pending ? 'Please wait…' : c.cta}
+          </Button>
+        </form>
+        <div style={{ marginTop: '1.1rem', fontSize: '0.82rem', color: '#8a8a95' }}>
+          {c.switchTo}{' '}
+          <Link href={c.switchHref} style={{ color: '#e8e8ef' }}>
+            {c.switchLabel}
+          </Link>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <span style={{ fontSize: '0.78rem', color: '#8a8a95' }}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.55rem 0.7rem',
+  borderRadius: 6,
+  border: '1px solid #2a2a30',
+  background: '#0f0f13',
+  color: '#f5f5f5',
+  fontSize: '0.9rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -1,0 +1,42 @@
+import type {
+  AuthLoginInput,
+  AuthRegisterInput,
+  SafeUser,
+} from '@webapp/types';
+import {
+  API_AUTH_LOGIN_PATH,
+  API_AUTH_LOGOUT_PATH,
+  API_AUTH_ME_PATH,
+  API_AUTH_SIGNUP_PATH,
+} from '@webapp/types';
+import { apiFetch } from '@/lib/api/client';
+
+export function login(input: AuthLoginInput): Promise<SafeUser> {
+  return apiFetch<SafeUser>(API_AUTH_LOGIN_PATH, {
+    method: 'POST',
+    body: input,
+    credentials: 'include',
+  });
+}
+
+export function register(input: AuthRegisterInput): Promise<SafeUser> {
+  return apiFetch<SafeUser>(API_AUTH_SIGNUP_PATH, {
+    method: 'POST',
+    body: input,
+    credentials: 'include',
+  });
+}
+
+export function logout(): Promise<null> {
+  return apiFetch<null>(API_AUTH_LOGOUT_PATH, {
+    method: 'POST',
+    credentials: 'include',
+  });
+}
+
+export function me(signal?: AbortSignal): Promise<SafeUser> {
+  return apiFetch<SafeUser>(API_AUTH_ME_PATH, {
+    credentials: 'include',
+    ...(signal ? { signal } : {}),
+  });
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -35,6 +35,9 @@ export interface ApiFetchOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   cache?: RequestCache;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  body?: unknown;
+  credentials?: RequestCredentials;
 }
 
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
@@ -51,11 +54,22 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
     else options.signal.addEventListener('abort', () => controller.abort(), { once: true });
   }
 
+  const method = options.method ?? 'GET';
+  const headers: Record<string, string> = { accept: 'application/json' };
+  let bodyInit: BodyInit | undefined;
+  if (options.body !== undefined) {
+    headers['content-type'] = 'application/json';
+    bodyInit = JSON.stringify(options.body);
+  }
+
   let res: Response;
   try {
     res = await fetch(url, {
-      headers: { accept: 'application/json' },
+      method,
+      headers,
+      body: bodyInit,
       cache: options.cache ?? 'no-store',
+      credentials: options.credentials ?? 'include',
       signal: controller.signal,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- New `/login` and `/register` pages with shared `AuthForm` client component
- `lib/api/auth.ts`: `login`, `register`, `logout`, `me` using existing `@webapp/types` DTOs (`AuthLoginInput`, `AuthRegisterInput`, `SafeUser`) and path constants
- `apiFetch` extended: `method`, `body`, `credentials` (default `'include'`) — cookie session flow

## Error mapping
- `unauthenticated` → "Wrong email or password."
- `conflict` → "An account with that email already exists."
- `validation_error` → backend message
- `rate_limited` → "Too many attempts. Try again in a few minutes."
- `no_api_url` / `network_error` / `timeout` → clear fallback messages

## Out of scope (separate issues)
- Session guard + logout in app shell (#17)
- Password reset, OAuth

## Deploy note
API must set `CORS_ORIGIN` to the exact web origin (not `*`) — CORS middleware only emits `Access-Control-Allow-Credentials: true` for a specific origin. Without this, the browser drops the session cookie.

## Test plan
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web build`
- [x] `pnpm typecheck` (monorepo)
- [ ] Manual: signup new email → redirect `/`, cookie set
- [ ] Manual: login correct → redirect `/`
- [ ] Manual: login wrong password → error banner
- [ ] Manual: signup duplicate email → "already exists" banner
- [ ] Manual: short password → validation banner

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)