### PR TITLE
chore(repo): ignore apps/e2e playwright artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ yarn-debug.log*
 
 # coverage
 coverage/
+
+# playwright e2e artefacts
+apps/e2e/test-results/
+apps/e2e/playwright-report/
+apps/e2e/blob-report/


### PR DESCRIPTION
## Summary
- Add `apps/e2e/{test-results,playwright-report,blob-report}/` to root `.gitignore`.

Closes #60

## AC check
- Ignore pattern covers every Playwright artefact surface (test-results on local, report + blob on CI).
- `git status` clean after removing any pre-existing `apps/e2e/test-results/` and re-running e2e.

## Test plan
- [x] `git status` clean after `rm -rf apps/e2e/test-results && pnpm --filter @webapp/e2e test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)