### PR TITLE
fix(tooling): issue-status.mjs hints at arg order on invalid input

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "issues:delta:dry-run": "node tools/apply-issue-delta.mjs --dry-run",
     "issues:delta:apply": "node tools/apply-issue-delta.mjs --yes",
     "project:status": "node tools/issue-status.mjs",
+    "project:status:test": "node --test tools/issue-status.test.mjs",
     "project:status:in-progress": "node tools/issue-status.mjs --status \"In Progress\"",
     "project:status:review": "node tools/issue-status.mjs --status Review",
     "project:status:blocked": "node tools/issue-status.mjs --status Blocked",

--- a/tools/issue-status.mjs
+++ b/tools/issue-status.mjs
@@ -23,6 +23,14 @@ function die(msg, code = 1) {
   process.exit(code);
 }
 
+export class ArgsError extends Error {
+  constructor(message, { exitCode = 1, showUsage = false } = {}) {
+    super(message);
+    this.exitCode = exitCode;
+    this.showUsage = showUsage;
+  }
+}
+
 function runCapture(bin, argv) {
   const r = spawnSync(bin, argv, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
   return { code: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
@@ -35,40 +43,68 @@ function ghJson(argv) {
   catch (e) { die(`cannot parse gh output for \`gh ${argv.join(' ')}\`: ${e.message}`); }
 }
 
+export const USAGE_LINES = [
+  'usage: node tools/issue-status.mjs <issueNumber> <status>',
+  `       status: ${VALID_STATUSES.map((s) => `"${s}"`).join(' | ')}`,
+  'example: node tools/issue-status.mjs 27 "In Progress"',
+];
+
+function printUsage() {
+  for (const line of USAGE_LINES) console.error(line);
+}
+
 function usage() {
-  console.error('usage: node tools/issue-status.mjs <issueNumber> <status>');
-  console.error(`       status: ${VALID_STATUSES.map((s) => `"${s}"`).join(' | ')}`);
-  console.error('example: node tools/issue-status.mjs 27 "In Progress"');
+  printUsage();
   process.exit(2);
 }
 
-function parseArgs() {
-  const args = process.argv.slice(2);
+export function parseArgsFrom(argv) {
   const positional = [];
   let flagStatus;
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
     if (a === '--status' || a === '-s') {
-      flagStatus = args[++i];
+      flagStatus = argv[++i];
       continue;
     }
-    if (a === '--help' || a === '-h') usage();
-    if (a.startsWith('--')) die(`unknown flag: ${a}`);
+    if (a === '--help' || a === '-h') {
+      throw new ArgsError('help', { exitCode: 2, showUsage: true });
+    }
+    if (a.startsWith('--')) throw new ArgsError(`unknown flag: ${a}`);
     positional.push(a);
   }
-  if (positional.length === 0) usage();
+  if (positional.length === 0) {
+    throw new ArgsError('missing arguments', { exitCode: 2, showUsage: true });
+  }
 
   const issueNumber = Number.parseInt(positional[0], 10);
   if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
-    die(`invalid issue number: "${positional[0]}"`);
+    throw new ArgsError(
+      `invalid issue number: "${positional[0]}"\n  hint: pass the issue number first. ${USAGE_LINES[0]}`,
+    );
   }
 
   const status = (flagStatus ?? positional.slice(1).join(' ')).trim();
-  if (!status) usage();
+  if (!status) throw new ArgsError('missing status', { exitCode: 2, showUsage: true });
   if (!VALID_STATUSES.includes(status)) {
-    die(`invalid status: "${status}". Expected one of: ${VALID_STATUSES.join(', ')}`);
+    throw new ArgsError(
+      `invalid status: "${status}". Expected one of: ${VALID_STATUSES.join(', ')}`,
+    );
   }
   return { issueNumber, status };
+}
+
+function parseArgs() {
+  try {
+    return parseArgsFrom(process.argv.slice(2));
+  } catch (err) {
+    if (err instanceof ArgsError) {
+      if (err.message !== 'help') console.error(c.red(`error: ${err.message}`));
+      if (err.showUsage) printUsage();
+      process.exit(err.exitCode);
+    }
+    throw err;
+  }
 }
 
 function preflight() {
@@ -163,4 +199,6 @@ function main() {
   console.log(c.green('Done'));
 }
 
-main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tools/issue-status.test.mjs
+++ b/tools/issue-status.test.mjs
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgsFrom, ArgsError } from './issue-status.mjs';
+
+test('positional: <issueNumber> <status>', () => {
+  assert.deepEqual(parseArgsFrom(['21', 'In Progress']), {
+    issueNumber: 21,
+    status: 'In Progress',
+  });
+});
+
+test('flag: --status "In Progress" <issueNumber>', () => {
+  assert.deepEqual(parseArgsFrom(['--status', 'In Progress', '21']), {
+    issueNumber: 21,
+    status: 'In Progress',
+  });
+});
+
+test('flag: <issueNumber> --status Review', () => {
+  assert.deepEqual(parseArgsFrom(['21', '--status', 'Review']), {
+    issueNumber: 21,
+    status: 'Review',
+  });
+});
+
+test('positional joins multi-word status', () => {
+  assert.deepEqual(parseArgsFrom(['42', 'In', 'Progress']), {
+    issueNumber: 42,
+    status: 'In Progress',
+  });
+});
+
+test('error: first arg is a status keyword — hint points to right ordering', () => {
+  assert.throws(
+    () => parseArgsFrom(['in-progress', '21']),
+    (err) => {
+      assert.ok(err instanceof ArgsError);
+      assert.match(err.message, /invalid issue number: "in-progress"/);
+      assert.match(err.message, /usage: node tools\/issue-status\.mjs <issueNumber> <status>/);
+      return true;
+    },
+  );
+});
+
+test('error: invalid status', () => {
+  assert.throws(
+    () => parseArgsFrom(['21', 'Bogus']),
+    (err) => err instanceof ArgsError && /invalid status: "Bogus"/.test(err.message),
+  );
+});
+
+test('error: unknown flag', () => {
+  assert.throws(
+    () => parseArgsFrom(['--wat', '21', 'Review']),
+    (err) => err instanceof ArgsError && /unknown flag: --wat/.test(err.message),
+  );
+});
+
+test('error: missing args shows usage', () => {
+  assert.throws(
+    () => parseArgsFrom([]),
+    (err) => err instanceof ArgsError && err.showUsage === true && err.exitCode === 2,
+  );
+});


### PR DESCRIPTION
Closes #61

## Summary
`node tools/issue-status.mjs in-progress 21` used to fail with only `invalid issue number: "in-progress"` — no hint that the first positional has to be the issue number. The error now appends the correct usage line so the fix is obvious.

## AC
- [x] Invalid-issue-number error prints `usage: node tools/issue-status.mjs <issueNumber> <status>` alongside the error.
- [x] `node tools/issue-status.mjs --status "In Progress" 21` works (matches the existing `project:status:in-progress` wrapper).
- [x] Existing positional `node tools/issue-status.mjs 21 "In Progress"` still works.
- [x] Unit test covers both arg orders, the ordering-hint error, and the other error paths.

## Changes
- Export `parseArgsFrom` + `ArgsError` from `tools/issue-status.mjs` so CLI and tests share the same parser.
- New `tools/issue-status.test.mjs` using node's built-in `node:test` runner — 8 cases, zero deps.
- `pnpm project:status:test` added.
- `main()` guarded with `import.meta.url` so the module is safe to import.

## Test plan
- [x] `pnpm project:status:test` — 8/8 pass
- [x] Manual: `node tools/issue-status.mjs in-progress 61` now prints the ordering hint.
- [x] Manual: `node tools/issue-status.mjs --status "In Progress" 61` still works (used during this PR).
- [x] Manual: `node tools/issue-status.mjs 61 "In Progress"` still works.

## Out of scope
- Broader CLI rewrite.
- Project #1 schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)