### PR TITLE
feat(providers): POST /v1/provider-connections/:id/test

### DIFF
--- a/apps/api/src/controllers/provider-connections.controller.ts
+++ b/apps/api/src/controllers/provider-connections.controller.ts
@@ -6,63 +6,58 @@ import {
   respond,
   respondError,
   respondNotFound,
+  respondRateLimited,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ProviderConnectionMeta } from '../db/provider-connections.repo.js';
 import * as providerRepo from '../db/provider-connections.repo.js';
-import { verifyOpenAIKey, createOpenAIClient } from '../providers/openai.provider.js';
-import type { ChatCompletionResult } from '../providers/provider.interface.js';
+import { verifyOpenAIKey } from '../providers/openai.provider.js';
 import { RateLimiter, type RateLimitResult } from '../lib/rate-limiter.js';
-import { respondRateLimited } from '../lib/http.js';
 
-// All recognised provider values — used to validate the :provider URL param.
 const VALID_PROVIDERS = new Set<AIProvider>(['openai', 'anthropic', 'perplexity']);
-
-// Providers supported for create/replace at this stage.
 const ENABLED_PROVIDERS = new Set<AIProvider>(['openai']);
-
-// ── Deps ──────────────────────────────────────────────────────────────────────
 
 interface SessionDeps {
   findSessionByTokenHash: (hash: string) => Promise<{ userId: string; expiresAt: Date } | null>;
   findUserById: (id: string) => Promise<{ id: string; email: string } | null>;
 }
 
+export type PingResult = 'ok' | 'unauthorized' | 'provider_error';
+
 export interface ProviderConnectionsDeps {
-  resolveUser:      (req: IncomingMessage) => Promise<{ id: string } | null>;
-  verifyKey:        (provider: AIProvider, apiKey: string) => Promise<'ok' | 'unauthorized' | 'provider_error'>;
-  upsertConnection: (userId: string, provider: AIProvider, apiKey: string) => Promise<ProviderConnectionMeta>;
-  findConnection:   (userId: string, provider: AIProvider) => Promise<ProviderConnectionMeta | null>;
-  listConnections:  (userId: string) => Promise<ProviderConnectionMeta[]>;
-  deleteConnection: (userId: string, provider: AIProvider) => Promise<void>;
-  getDecryptedKey:  (userId: string, provider: AIProvider) => Promise<string | null>;
-  generate:         (apiKey: string) => Promise<ChatCompletionResult>;
-  checkRateLimit:   (key: string) => RateLimitResult;
+  resolveUser:         (req: IncomingMessage) => Promise<{ id: string } | null>;
+  verifyKey:           (provider: AIProvider, apiKey: string) => Promise<'ok' | 'unauthorized' | 'provider_error'>;
+  upsertConnection:    (userId: string, provider: AIProvider, apiKey: string) => Promise<ProviderConnectionMeta>;
+  findConnection:      (userId: string, provider: AIProvider) => Promise<ProviderConnectionMeta | null>;
+  listConnections:     (userId: string) => Promise<ProviderConnectionMeta[]>;
+  deleteConnection:    (userId: string, provider: AIProvider) => Promise<void>;
+  getDecryptedKeyById: (userId: string, id: string) => Promise<{ provider: AIProvider; apiKey: string } | null>;
+  pingConnection:      (provider: AIProvider, apiKey: string) => Promise<PingResult>;
+  checkRateLimit:      (key: string) => RateLimitResult;
 }
 
-const TEST_MODEL = 'gpt-4o-mini';
-const TEST_MESSAGES = [{ role: 'user' as const, content: 'Say "ok".' }];
+const providerTestLimiter = new RateLimiter(1, 60 * 1000);
 
-// 10 test calls per user per hour.
-const providerTestLimiter = new RateLimiter(10, 60 * 60 * 1000);
+async function pingProvider(provider: AIProvider, apiKey: string): Promise<PingResult> {
+  if (provider === 'openai') return verifyOpenAIKey(apiKey);
+  return 'provider_error';
+}
 
 export function makeProviderConnectionsDeps(db: Db, sessionDeps: SessionDeps): ProviderConnectionsDeps {
   return {
-    resolveUser:      (req)                   => resolveCurrentUser(req, sessionDeps),
-    verifyKey:        (_provider, apiKey)     => verifyOpenAIKey(apiKey),
-    upsertConnection: (userId, provider, key) => providerRepo.upsertProviderConnection(db, userId, provider, key),
-    findConnection:   (userId, provider)      => providerRepo.findProviderConnection(db, userId, provider),
-    listConnections:  (userId)                => providerRepo.listProviderConnections(db, userId),
-    deleteConnection: (userId, provider)      => providerRepo.deleteProviderConnection(db, userId, provider),
-    getDecryptedKey:  (userId, provider)      => providerRepo.getDecryptedApiKey(db, userId, provider),
-    generate:         (apiKey)                => createOpenAIClient(apiKey).createChatCompletion(TEST_MESSAGES, TEST_MODEL),
-    checkRateLimit:   (key)                   => providerTestLimiter.check(key),
+    resolveUser:         (req)                   => resolveCurrentUser(req, sessionDeps),
+    verifyKey:           (_provider, apiKey)     => verifyOpenAIKey(apiKey),
+    upsertConnection:    (userId, provider, key) => providerRepo.upsertProviderConnection(db, userId, provider, key),
+    findConnection:      (userId, provider)      => providerRepo.findProviderConnection(db, userId, provider),
+    listConnections:     (userId)                => providerRepo.listProviderConnections(db, userId),
+    deleteConnection:    (userId, provider)      => providerRepo.deleteProviderConnection(db, userId, provider),
+    getDecryptedKeyById: (userId, id)            => providerRepo.getDecryptedApiKeyById(db, userId, id),
+    pingConnection:      (provider, apiKey)      => pingProvider(provider, apiKey),
+    checkRateLimit:      (key)                   => providerTestLimiter.check(key),
   };
 }
-
-// ── Private helpers ───────────────────────────────────────────────────────────
 
 function toResponse(meta: ProviderConnectionMeta): ProviderConnection {
   return {
@@ -77,15 +72,12 @@ function parseProvider(raw: string): AIProvider | null {
   return VALID_PROVIDERS.has(raw as AIProvider) ? (raw as AIProvider) : null;
 }
 
-// ── Controllers ───────────────────────────────────────────────────────────────
-
 export async function listConnectionsController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
-
   const list = await deps.listConnections(user.id);
   return respond(list.map(toResponse));
 }
@@ -96,10 +88,8 @@ export async function getConnectionController(
 ): Promise<InternalResult> {
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
-
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
-
   const meta = await deps.findConnection(user.id, provider);
   return meta ? respond(toResponse(meta)) : respondNotFound(`No connection for provider '${provider}'`);
 }
@@ -110,25 +100,19 @@ export async function upsertConnectionController(
 ): Promise<InternalResult> {
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
-
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
-
   if (!ENABLED_PROVIDERS.has(provider)) {
     return respondError('validation_error', `Provider '${provider}' is not yet supported`, 400);
   }
-
   const bodyResult = await readJsonBody(ctx.req);
   if (!bodyResult.ok) return bodyResult.result;
   const body = bodyResult.data;
-
   if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
   if (typeof body['apiKey'] !== 'string' || !body['apiKey'].trim()) {
     return respondError('validation_error', 'apiKey is required and must be a non-empty string');
   }
-
   const apiKey = body['apiKey'].trim();
-
   const verifyResult = await deps.verifyKey(provider, apiKey);
   if (verifyResult === 'unauthorized') {
     return respondError('provider_auth_error', 'API key is invalid or unauthorized', 401);
@@ -136,7 +120,6 @@ export async function upsertConnectionController(
   if (verifyResult === 'provider_error') {
     return respondError('provider_error', 'Could not reach the provider to validate the key — try again later', 502);
   }
-
   const meta = await deps.upsertConnection(user.id, provider, apiKey);
   return respond(toResponse(meta));
 }
@@ -147,10 +130,8 @@ export async function deleteConnectionController(
 ): Promise<InternalResult> {
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
-
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
-
   await deps.deleteConnection(user.id, provider);
   return respond(null);
 }
@@ -162,28 +143,20 @@ export async function testConnectionController(
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const rl = deps.checkRateLimit(user.id);
+  const connectionId = ctx.params['id'] ?? '';
+  if (!connectionId) return respondError('validation_error', 'Missing connection id', 400);
+
+  const record = await deps.getDecryptedKeyById(user.id, connectionId);
+  if (!record) return respondNotFound(`No connection found with id '${connectionId}'`);
+
+  const rl = deps.checkRateLimit(connectionId);
   if (!rl.ok) return respondRateLimited(rl.retryAfterSecs);
 
-  const apiKey = await deps.getDecryptedKey(user.id, 'openai');
-  if (!apiKey) {
-    return respondError('not_found', 'No OpenAI connection configured for this account', 404);
-  }
+  const result = await deps.pingConnection(record.provider, record.apiKey);
+  if (result === 'ok') return respond({ ok: true });
 
-  let result: ChatCompletionResult;
-  try {
-    result = await deps.generate(apiKey);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Unknown provider error';
-    if (/401|unauthorized|invalid.*key/i.test(msg)) {
-      return respondError('provider_auth_error', 'OpenAI rejected the stored key', 401);
-    }
-    return respondError('provider_error', `OpenAI call failed: ${msg}`, 502);
+  if (result === 'unauthorized') {
+    return respond({ ok: false, code: 'provider_auth_error', message: 'Provider rejected the stored key' });
   }
-
-  return respond({
-    provider: 'openai',
-    model: result.model,
-    outputPreview: result.content.slice(0, 120),
-  });
+  return respond({ ok: false, code: 'provider_error', message: 'Could not reach the provider' });
 }

--- a/apps/api/src/db/provider-connections.repo.ts
+++ b/apps/api/src/db/provider-connections.repo.ts
@@ -108,6 +108,48 @@ export async function listProviderConnections(
 }
 
 /**
+ * Returns safe connection metadata for a user-id pair.
+ * Returns null if no connection exists or it belongs to another user.
+ */
+export async function findProviderConnectionById(
+  db: Db,
+  userId: string,
+  id: string,
+): Promise<ProviderConnectionMeta | null> {
+  const [row] = await db
+    .select()
+    .from(providerConnections)
+    .where(and(
+      eq(providerConnections.userId, userId),
+      eq(providerConnections.id, id),
+    ))
+    .limit(1);
+  return row ? toMeta(row) : null;
+}
+
+/**
+ * Returns the decrypted API key for a user-id pair.
+ * Returns null if no connection exists or it belongs to another user.
+ * This is for internal server use only — never forward this to the client.
+ */
+export async function getDecryptedApiKeyById(
+  db: Db,
+  userId: string,
+  id: string,
+): Promise<{ provider: AIProvider; apiKey: string } | null> {
+  const [row] = await db
+    .select()
+    .from(providerConnections)
+    .where(and(
+      eq(providerConnections.userId, userId),
+      eq(providerConnections.id, id),
+    ))
+    .limit(1);
+  if (!row) return null;
+  return { provider: row.provider, apiKey: decryptApiKey(row.encryptedApiKey) };
+}
+
+/**
  * Removes a provider connection for the given user.
  */
 export async function deleteProviderConnection(

--- a/apps/api/src/routes/provider-connections.test.ts
+++ b/apps/api/src/routes/provider-connections.test.ts
@@ -25,15 +25,15 @@ function mockMeta(overrides: Partial<ProviderConnectionMeta> = {}): ProviderConn
 
 function makeDeps(overrides: Partial<ProviderConnectionsDeps> = {}): ProviderConnectionsDeps {
   return {
-    resolveUser:      async () => null,
-    verifyKey:        async () => 'ok',
-    upsertConnection: async () => mockMeta(),
-    findConnection:   async () => null,
-    listConnections:  async () => [],
-    deleteConnection: async () => undefined,
-    getDecryptedKey:  async () => null,
-    generate:         async () => ({ content: 'ok', model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } }),
-    checkRateLimit:   () => ({ ok: true, retryAfterSecs: 0 }),
+    resolveUser:         async () => null,
+    verifyKey:           async () => 'ok',
+    upsertConnection:    async () => mockMeta(),
+    findConnection:      async () => null,
+    listConnections:     async () => [],
+    deleteConnection:    async () => undefined,
+    getDecryptedKeyById: async () => null,
+    pingConnection:      async () => 'ok',
+    checkRateLimit:      () => ({ ok: true, retryAfterSecs: 0 }),
     ...overrides,
   };
 }
@@ -327,10 +327,12 @@ describe('DELETE /v1/provider-connections/:provider — authenticated', () => {
 
 // ── Test connection ───────────────────────────────────────────────────────────
 
-describe('POST /v1/provider-connections/openai/test', () => {
+describe('POST /v1/provider-connections/:id/test', () => {
+  const CONN_ID = 'conn-abc-123';
+
   it('returns 401 when unauthenticated', async () => {
     const { baseUrl, close } = await startServer(makeDeps());
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
     expect(res.status).toBe(401);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
@@ -338,12 +340,12 @@ describe('POST /v1/provider-connections/openai/test', () => {
     await close();
   });
 
-  it('returns 404 when no OpenAI connection is stored', async () => {
+  it('returns 404 when the connection id does not belong to the user', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:     async () => USER_1,
-      getDecryptedKey: async () => null,
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => null,
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
     expect(res.status).toBe(404);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
@@ -351,75 +353,116 @@ describe('POST /v1/provider-connections/openai/test', () => {
     await close();
   });
 
-  it('returns ok payload with provider/model/outputPreview on success', async () => {
+  it("scopes lookup to the caller's user id and the url :id param", async () => {
+    let receivedUserId: string | null = null;
+    let receivedId: string | null = null;
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:     async () => USER_1,
-      getDecryptedKey: async () => 'sk-stored-key',
-      generate:        async () => ({ content: 'ok', model: 'gpt-4o-mini', usage: { promptTokens: 5, completionTokens: 1, totalTokens: 6 } }),
+      resolveUser:         async () => USER_2,
+      getDecryptedKeyById: async (userId, id) => {
+        receivedUserId = userId;
+        receivedId = id;
+        return null;
+      },
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
+    await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
+    expect(receivedUserId).toBe(USER_2.id);
+    expect(receivedId).toBe(CONN_ID);
+    await close();
+  });
+
+  it('returns { ok: true } on successful provider ping', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: 'sk-stored-key' }),
+      pingConnection:      async () => 'ok',
+    }));
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as ApiResponse<{ provider: string; model: string; outputPreview: string }>;
-    if (!body.ok) throw new Error('expected ok');
-    expect(body.data.provider).toBe('openai');
-    expect(body.data.model).toBe('gpt-4o-mini');
-    expect(body.data.outputPreview).toBe('ok');
-    expect('apiKey' in body.data).toBe(false);
+    const body = (await res.json()) as ApiResponse<{ ok: true }>;
+    if (!body.ok) throw new Error('expected ok envelope');
+    expect(body.data).toEqual({ ok: true });
     await close();
   });
 
-  it('returns 401 provider_auth_error when generate throws auth error', async () => {
+  it('forwards the stored provider and decrypted key to pingConnection', async () => {
+    let receivedProvider: string | null = null;
+    let receivedKey: string | null = null;
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:     async () => USER_1,
-      getDecryptedKey: async () => 'sk-bad-stored-key',
-      generate:        async () => { throw new Error('OpenAI API error: 401 Unauthorized invalid_api_key'); },
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: 'sk-fwd' }),
+      pingConnection:      async (provider, apiKey) => {
+        receivedProvider = provider;
+        receivedKey = apiKey;
+        return 'ok';
+      },
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
-    expect(res.status).toBe(401);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('provider_auth_error');
-    expect(body.error.message).not.toContain('sk-bad-stored-key');
+    await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
+    expect(receivedProvider).toBe('openai');
+    expect(receivedKey).toBe('sk-fwd');
     await close();
   });
 
-  it('returns 502 provider_error on network failure', async () => {
+  it('returns { ok: false, code: "provider_auth_error" } when provider rejects the key', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:     async () => USER_1,
-      getDecryptedKey: async () => 'sk-valid-key',
-      generate:        async () => { throw new Error('fetch failed: connection refused'); },
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: 'sk-bad' }),
+      pingConnection:      async () => 'unauthorized',
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
-    expect(res.status).toBe(502);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('provider_error');
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ ok: false; code: string; message: string }>;
+    if (!body.ok) throw new Error('expected ok envelope');
+    expect(body.data.ok).toBe(false);
+    expect(body.data.code).toBe('provider_auth_error');
+    expect(typeof body.data.message).toBe('string');
     await close();
   });
 
-  it('error responses never contain the stored plaintext key', async () => {
+  it('returns { ok: false, code: "provider_error" } when provider is unreachable', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:     async () => USER_1,
-      getDecryptedKey: async () => 'sk-ultra-secret-stored',
-      generate:        async () => { throw new Error('some error'); },
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: 'sk-ok' }),
+      pingConnection:      async () => 'provider_error',
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ ok: false; code: string; message: string }>;
+    if (!body.ok) throw new Error('expected ok envelope');
+    expect(body.data.ok).toBe(false);
+    expect(body.data.code).toBe('provider_error');
+    await close();
+  });
+
+  it('never leaks the decrypted key in the response body', async () => {
+    const secret = 'sk-ultra-secret-stored';
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: secret }),
+      pingConnection:      async () => 'unauthorized',
+    }));
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
     const text = await res.text();
-    expect(text).not.toContain('sk-ultra-secret-stored');
+    expect(text).not.toContain(secret);
     await close();
   });
 
-  it('returns 429 when rate limit is exceeded', async () => {
+  it('returns 429 when rate limit is exceeded and keys by connection id', async () => {
+    const seen: string[] = [];
     const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:    async () => USER_1,
-      checkRateLimit: () => ({ ok: false, retryAfterSecs: 3600 }),
+      resolveUser:         async () => USER_1,
+      getDecryptedKeyById: async () => ({ provider: 'openai', apiKey: 'sk-ok' }),
+      checkRateLimit:      (key) => {
+        seen.push(key);
+        return { ok: false, retryAfterSecs: 60 };
+      },
     }));
-    const res = await fetch(`${baseUrl}/v1/provider-connections/openai/test`, { method: 'POST' });
+    const res = await fetch(`${baseUrl}/v1/provider-connections/${CONN_ID}/test`, { method: 'POST' });
     expect(res.status).toBe(429);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('rate_limited');
-    expect(res.headers.get('retry-after')).toBe('3600');
+    expect(res.headers.get('retry-after')).toBe('60');
+    expect(seen).toEqual([CONN_ID]);
     await close();
   });
 });

--- a/apps/api/src/routes/provider-connections.ts
+++ b/apps/api/src/routes/provider-connections.ts
@@ -16,6 +16,6 @@ export function makeProviderConnectionRoutes(deps: ProviderConnectionsDeps): Rou
     { method: 'GET',    path: `${base}/:provider`,         handler: (ctx) => getConnectionController(ctx, deps) },
     { method: 'PUT',    path: `${base}/:provider`,         handler: (ctx) => upsertConnectionController(ctx, deps) },
     { method: 'DELETE', path: `${base}/:provider`,         handler: (ctx) => deleteConnectionController(ctx, deps) },
-    { method: 'POST',   path: `${base}/openai/test`,       handler: (ctx) => testConnectionController(ctx, deps) },
+    { method: 'POST',   path: `${base}/:id/test`,          handler: (ctx) => testConnectionController(ctx, deps) },
   ];
 }


### PR DESCRIPTION
## Summary
- Replaces `/v1/provider-connections/openai/test` with `/v1/provider-connections/:id/test` to match issue #31's AC.
- Uses the provider's cheapest ping (OpenAI `/models` via `verifyOpenAIKey`) instead of a paid chat-completion round-trip.
- Returns `{ ok: true }` on success and `{ ok: false, code, message }` on provider auth/connectivity failure — both wrapped in the standard API envelope.
- Rate-limits to **1 call / minute per connection id** (was 10/hour per user), matching the AC literally.
- Adds `findProviderConnectionById` + `getDecryptedApiKeyById` repo helpers, both scoped to `userId` so a user can only test connections they own.

## Behavior
| Case                                           | Status | Body                                                                     |
|------------------------------------------------|:------:|--------------------------------------------------------------------------|
| Unauthenticated                                |  401   | `unauthenticated`                                                        |
| Connection id not owned by caller / not found  |  404   | `not_found`                                                              |
| Ping succeeds                                  |  200   | `{ ok: true }`                                                           |
| Ping rejected (401 from provider)              |  200   | `{ ok: false, code: "provider_auth_error", message }`                    |
| Ping unreachable / other provider error        |  200   | `{ ok: false, code: "provider_error", message }`                         |
| Rate-limited (≥2 calls in 60s for that conn id)|  429   | `rate_limited` + `Retry-After` header                                    |

## Test plan
- [x] `pnpm --filter @webapp/api test` — 228/228 passing (9 cover the new endpoint: 401, 404, id/user scoping, success envelope, key forwarding, `provider_auth_error`, `provider_error`, key-leakage check, rate-limit keyed by conn id).
- [x] `pnpm typecheck` clean across the monorepo.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)