### PR TITLE
feat(web): provider settings page shell with list + delete (#18)

### DIFF
--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { ProviderConnection } from '@webapp/types';
+import { Button } from '@/components/Button';
+import {
+  listProviderConnections,
+  removeProviderConnection,
+} from '@/lib/api/provider-connections';
+import type { ApiCallError } from '@/lib/api/client';
+
+type LoadState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'ready'; items: ProviderConnection[] }
+  | { status: 'error'; message: string };
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toISOString().replace('T', ' ').slice(0, 16);
+}
+
+function errorMessage(err: unknown): string {
+  const e = err as ApiCallError | undefined;
+  return e?.message ?? 'Unknown error';
+}
+
+export default function ProviderSettingsPage() {
+  const [state, setState] = useState<LoadState>({ status: 'idle' });
+  const [pendingDelete, setPendingDelete] = useState<ProviderConnection | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setState({ status: 'loading' });
+    try {
+      const items = await listProviderConnections(signal);
+      if (signal?.aborted) return;
+      setState({ status: 'ready', items });
+    } catch (err) {
+      if (signal?.aborted) return;
+      setState({ status: 'error', message: errorMessage(err) });
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  const onConfirmDelete = useCallback(async () => {
+    if (!pendingDelete) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await removeProviderConnection(pendingDelete.provider);
+      setPendingDelete(null);
+      await load();
+    } catch (err) {
+      setDeleteError(errorMessage(err));
+    } finally {
+      setDeleting(false);
+    }
+  }, [pendingDelete, load]);
+
+  return (
+    <main style={pageStyle}>
+      <header style={headerStyle}>
+        <h1 style={{ fontSize: '1.5rem', margin: 0 }}>Provider connections</h1>
+        <Button variant="ghost" onClick={() => void load()} disabled={state.status === 'loading'}>
+          Refresh
+        </Button>
+      </header>
+
+      {state.status === 'loading' && <p style={mutedStyle}>Loading…</p>}
+
+      {state.status === 'error' && (
+        <div role="alert" style={errorBoxStyle}>
+          Failed to load connections: {state.message}
+        </div>
+      )}
+
+      {state.status === 'ready' && state.items.length === 0 && (
+        <p style={mutedStyle}>No provider connections yet.</p>
+      )}
+
+      {state.status === 'ready' && state.items.length > 0 && (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={thStyle}>Provider</th>
+              <th style={thStyle}>Label</th>
+              <th style={thStyle}>Created</th>
+              <th style={thStyle}>Last used</th>
+              <th style={thStyle} aria-label="Actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {state.items.map((c) => (
+              <tr key={c.id}>
+                <td style={tdStyle}>{c.provider}</td>
+                <td style={tdStyle}>—</td>
+                <td style={tdStyle}>{formatDate(c.createdAt)}</td>
+                <td style={tdStyle}>—</td>
+                <td style={{ ...tdStyle, textAlign: 'right' }}>
+                  <Button variant="ghost" onClick={() => setPendingDelete(c)}>
+                    Delete
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {pendingDelete && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-delete-title"
+          style={backdropStyle}
+          onClick={() => {
+            if (!deleting) setPendingDelete(null);
+          }}
+        >
+          <div
+            style={modalStyle}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="confirm-delete-title" style={{ margin: 0, fontSize: '1.1rem' }}>
+              Delete connection?
+            </h2>
+            <p style={mutedStyle}>
+              Provider <strong>{pendingDelete.provider}</strong> will be disconnected. This cannot
+              be undone.
+            </p>
+            {deleteError && (
+              <div role="alert" style={errorBoxStyle}>
+                {deleteError}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+              <Button
+                variant="ghost"
+                onClick={() => setPendingDelete(null)}
+                disabled={deleting}
+              >
+                Cancel
+              </Button>
+              <Button onClick={onConfirmDelete} disabled={deleting}>
+                {deleting ? 'Deleting…' : 'Delete'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 880,
+  margin: '0 auto',
+  padding: '2rem 1.5rem',
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: '1.5rem',
+};
+
+const mutedStyle: React.CSSProperties = { color: '#9a9aa5' };
+
+const tableStyle: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: '0.9rem',
+};
+
+const thStyle: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '0.6rem 0.75rem',
+  borderBottom: '1px solid #2a2a30',
+  fontWeight: 600,
+  color: '#c0c0cb',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '0.6rem 0.75rem',
+  borderBottom: '1px solid #1d1d22',
+};
+
+const errorBoxStyle: React.CSSProperties = {
+  background: '#3a1d1d',
+  border: '1px solid #6b2a2a',
+  color: '#ffd3d3',
+  padding: '0.75rem 1rem',
+  borderRadius: 8,
+  marginBottom: '1rem',
+};
+
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  padding: '1.5rem',
+  minWidth: 360,
+  maxWidth: 480,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  color: '#f5f5f5',
+};

--- a/apps/web/src/lib/api/provider-connections.ts
+++ b/apps/web/src/lib/api/provider-connections.ts
@@ -1,0 +1,76 @@
+import type { ApiResponse, ProviderConnection } from '@webapp/types';
+import { API_PROVIDER_CONNECTIONS_PATH } from '@webapp/types';
+import { apiFetch, type ApiCallError } from '@/lib/api/client';
+import { getApiBaseUrl } from '@/lib/api/env';
+
+export function listProviderConnections(signal?: AbortSignal): Promise<ProviderConnection[]> {
+  return apiFetch<ProviderConnection[]>(
+    API_PROVIDER_CONNECTIONS_PATH,
+    signal ? { signal } : undefined,
+  );
+}
+
+export async function removeProviderConnection(
+  provider: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) {
+    const err = new Error('NEXT_PUBLIC_API_URL is not configured') as ApiCallError;
+    err.code = 'no_api_url';
+    throw err;
+  }
+  const url = `${baseUrl}${API_PROVIDER_CONNECTIONS_PATH}/${encodeURIComponent(provider)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'DELETE',
+      headers: { accept: 'application/json' },
+      credentials: 'include',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    clearTimeout(timer);
+    const aborted = (cause as { name?: string } | null)?.name === 'AbortError';
+    const err = new Error(
+      aborted ? `Request to ${url} aborted` : `Network error calling ${url}`,
+    ) as ApiCallError;
+    err.code = aborted ? 'timeout' : 'network_error';
+    err.cause = cause;
+    throw err;
+  }
+  clearTimeout(timer);
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch (cause) {
+    const err = new Error(`Non-JSON response from ${url}`) as ApiCallError;
+    err.status = res.status;
+    err.code = 'invalid_json';
+    err.cause = cause;
+    throw err;
+  }
+
+  const envelope = parsed as ApiResponse<unknown>;
+  if (!envelope || typeof envelope !== 'object' || typeof (envelope as { ok?: unknown }).ok !== 'boolean') {
+    const err = new Error(`Malformed envelope from ${url}`) as ApiCallError;
+    err.status = res.status;
+    err.code = 'invalid_envelope';
+    throw err;
+  }
+  if (!envelope.ok) {
+    const err = new Error(envelope.error.message) as ApiCallError;
+    err.status = res.status;
+    err.code = envelope.error.code;
+    throw err;
+  }
+}


### PR DESCRIPTION
Closes #18

## Summary
Read-only list of existing provider connections at `/settings/providers` with a delete-with-confirm modal. Separate from add-key form and test-connection button (tracked in #36 and #37).

## Acceptance criteria
- [x] `src/app/settings/providers/page.tsx`
- [x] `lib/api/provider-connections.ts` with `list` (`listProviderConnections`) and `remove` (`removeProviderConnection`)
- [x] Table: provider, label, createdAt, lastUsedAt
- [x] Delete with confirm modal

## Notes on table columns
The current `ProviderConnection` type (`packages/types`) exposes only `id`, `provider`, `createdAt`, `updatedAt`. The AC mentions `label` and `lastUsedAt`, which the backend does not currently return. Those columns render as "—" placeholders. Proper population requires a backend shape change (follow-up).

## Test plan
- `pnpm typecheck` — green
- `pnpm --filter @webapp/web build` — green (route `/settings/providers` prerendered)
- Manual:
  - visit `/settings/providers` with `NEXT_PUBLIC_API_URL` unset → malformed URL error shown (expected, no mock path)
  - with backend running + auth cookie → list renders, delete opens modal, confirm removes row