### PR TITLE
chore(types): add provider_not_configured to ApiErrorCode

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -172,7 +172,7 @@ export async function createMessageDbController(
       const apiKey = await deps.getApiKey(user.id, 'openai');
       if (!apiKey) {
         return respondError(
-          'provider_auth_error',
+          'provider_not_configured',
           'No OpenAI connection configured. Add your API key in provider settings.',
           412,
         );

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -343,7 +343,7 @@ describe('POST /v1/messages — openai generation path', () => {
     await close();
   });
 
-  it('missing OpenAI connection returns 412 provider_auth_error', async () => {
+  it('missing OpenAI connection returns 412 provider_not_configured', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
       resolveUser:    async () => USER_1,
       findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
@@ -356,7 +356,7 @@ describe('POST /v1/messages — openai generation path', () => {
     expect(res.status).toBe(412);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('provider_auth_error');
+    expect(body.error.code).toBe('provider_not_configured');
     expect(body.error.message).toContain('OpenAI');
     await close();
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -56,6 +56,7 @@ export type ApiErrorCode =
   | 'method_not_allowed'
   | 'internal_error'
   | 'provider_auth_error'
+  | 'provider_not_configured'
   | 'provider_error'
   | 'rate_limited';
 


### PR DESCRIPTION
Closes #57

## Summary
Adds dedicated `provider_not_configured` variant to `ApiErrorCode` so controllers can return 412 with a semantically precise code instead of reusing `provider_auth_error`.

## Acceptance criteria
- [x] `ApiErrorCode` in `packages/types/src/index.ts` includes `'provider_not_configured'`
- [x] `apps/api/src/controllers/messages-db.controller.ts` returns the new code at the `!apiKey` branch
- [x] Test in `apps/api/src/routes/messages-db.test.ts` asserts the new code
- [x] `pnpm typecheck` green across monorepo
- [x] `pnpm --filter @webapp/api test` green (228/228)

## Test plan
- `pnpm typecheck` — ok
- `pnpm --filter @webapp/api test` — 228 passed
- `pnpm build` — ok
- `pnpm lint` — pre-existing failure (eslint binary missing in packages/types), unrelated to this change

## Out of scope
- Other `provider_auth_error` callers (actual auth failures in provider-connections controller remain as-is, semantically correct).
- Frontend changes — no web client inspects this code yet.