### PR TITLE
feat(web): test-connection button on provider settings (#37)

### DIFF
--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -6,8 +6,15 @@ import { Button } from '@/components/Button';
 import {
   listProviderConnections,
   removeProviderConnection,
+  testProviderConnection,
+  type TestConnectionResult,
 } from '@/lib/api/provider-connections';
 import type { ApiCallError } from '@/lib/api/client';
+
+interface Toast {
+  tone: 'success' | 'error';
+  message: string;
+}
 
 type LoadState =
   | { status: 'idle' }
@@ -31,6 +38,8 @@ export default function ProviderSettingsPage() {
   const [pendingDelete, setPendingDelete] = useState<ProviderConnection | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     setState({ status: 'loading' });
@@ -49,6 +58,35 @@ export default function ProviderSettingsPage() {
     void load(controller.signal);
     return () => controller.abort();
   }, [load]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const id = setTimeout(() => setToast(null), 5000);
+    return () => clearTimeout(id);
+  }, [toast]);
+
+  const onTest = useCallback(async (connection: ProviderConnection) => {
+    setTestingId(connection.id);
+    setToast(null);
+    try {
+      const result: TestConnectionResult = await testProviderConnection(connection.id);
+      if (result.ok) {
+        setToast({ tone: 'success', message: `${connection.provider}: connection OK` });
+      } else {
+        const code = result.code ?? 'unknown';
+        const message = result.message ?? 'Test failed';
+        setToast({ tone: 'error', message: `${connection.provider}: ${code} — ${message}` });
+      }
+    } catch (err) {
+      const e = err as ApiCallError | undefined;
+      setToast({
+        tone: 'error',
+        message: `${connection.provider}: ${e?.code ?? 'error'} — ${e?.message ?? 'Unknown error'}`,
+      });
+    } finally {
+      setTestingId(null);
+    }
+  }, []);
 
   const onConfirmDelete = useCallback(async () => {
     if (!pendingDelete) return;
@@ -105,14 +143,33 @@ export default function ProviderSettingsPage() {
                 <td style={tdStyle}>{formatDate(c.createdAt)}</td>
                 <td style={tdStyle}>—</td>
                 <td style={{ ...tdStyle, textAlign: 'right' }}>
-                  <Button variant="ghost" onClick={() => setPendingDelete(c)}>
-                    Delete
-                  </Button>
+                  <div style={{ display: 'inline-flex', gap: '0.5rem' }}>
+                    <Button
+                      variant="ghost"
+                      onClick={() => void onTest(c)}
+                      disabled={testingId === c.id}
+                    >
+                      {testingId === c.id ? 'Testing…' : 'Test'}
+                    </Button>
+                    <Button variant="ghost" onClick={() => setPendingDelete(c)}>
+                      Delete
+                    </Button>
+                  </div>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
+      )}
+
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{ ...toastStyle, ...(toast.tone === 'error' ? toastErrorStyle : toastSuccessStyle) }}
+        >
+          {toast.message}
+        </div>
       )}
 
       {pendingDelete && (
@@ -213,6 +270,30 @@ const backdropStyle: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'center',
   zIndex: 50,
+};
+
+const toastStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: '1rem',
+  right: '1rem',
+  maxWidth: 420,
+  padding: '0.75rem 1rem',
+  borderRadius: 8,
+  fontSize: '0.875rem',
+  boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+  zIndex: 60,
+};
+
+const toastSuccessStyle: React.CSSProperties = {
+  background: '#13321d',
+  border: '1px solid #2a6a43',
+  color: '#c9f4d6',
+};
+
+const toastErrorStyle: React.CSSProperties = {
+  background: '#3a1d1d',
+  border: '1px solid #6b2a2a',
+  color: '#ffd3d3',
 };
 
 const modalStyle: React.CSSProperties = {

--- a/apps/web/src/lib/api/provider-connections.ts
+++ b/apps/web/src/lib/api/provider-connections.ts
@@ -10,6 +10,78 @@ export function listProviderConnections(signal?: AbortSignal): Promise<ProviderC
   );
 }
 
+export interface TestConnectionResult {
+  ok: boolean;
+  code?: string;
+  message?: string;
+}
+
+export async function testProviderConnection(
+  connectionId: string,
+  signal?: AbortSignal,
+): Promise<TestConnectionResult> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) {
+    const err = new Error('NEXT_PUBLIC_API_URL is not configured') as ApiCallError;
+    err.code = 'no_api_url';
+    throw err;
+  }
+  const url = `${baseUrl}${API_PROVIDER_CONNECTIONS_PATH}/${encodeURIComponent(connectionId)}/test`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { accept: 'application/json' },
+      credentials: 'include',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    clearTimeout(timer);
+    const aborted = (cause as { name?: string } | null)?.name === 'AbortError';
+    const err = new Error(
+      aborted ? `Request to ${url} aborted` : `Network error calling ${url}`,
+    ) as ApiCallError;
+    err.code = aborted ? 'timeout' : 'network_error';
+    err.cause = cause;
+    throw err;
+  }
+  clearTimeout(timer);
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch (cause) {
+    const err = new Error(`Non-JSON response from ${url}`) as ApiCallError;
+    err.status = res.status;
+    err.code = 'invalid_json';
+    err.cause = cause;
+    throw err;
+  }
+
+  const envelope = parsed as ApiResponse<TestConnectionResult>;
+  if (!envelope || typeof envelope !== 'object' || typeof (envelope as { ok?: unknown }).ok !== 'boolean') {
+    const err = new Error(`Malformed envelope from ${url}`) as ApiCallError;
+    err.status = res.status;
+    err.code = 'invalid_envelope';
+    throw err;
+  }
+  if (!envelope.ok) {
+    const err = new Error(envelope.error.message) as ApiCallError;
+    err.status = res.status;
+    err.code = envelope.error.code;
+    throw err;
+  }
+  return envelope.data;
+}
+
 export async function removeProviderConnection(
   provider: string,
   signal?: AbortSignal,


### PR DESCRIPTION
Closes #37

## Summary
Adds a per-row **Test** button on `/settings/providers` that calls `POST /v1/provider-connections/:id/test`. The backend returns either `{ ok: true }` or `{ ok: false, code, message }` and the UI surfaces both via an auto-dismissing toast (5 s) with success/error tone.

## Acceptance criteria
- [x] Button per row calls `POST /v1/provider-connections/:id/test`
- [x] Success/error toast with code + message
- [x] Disabled while in flight (tracked per row via `testingId`)

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green (`/settings/providers` 2.73 kB → 3.12 kB)
- Manual with backend + auth cookie:
  - valid connection → green toast `openai: connection OK`
  - invalid key → red toast `openai: provider_auth_error — Provider rejected the stored key`
  - network drop → red toast `openai: network_error — …`

## Out of scope
Auto-test on save (per issue).

## Notes
Builds on #18 page shell merged in PR #67. Uses existing `API_PROVIDER_CONNECTIONS_PATH` constant. No shared-client changes (avoids conflict with open PR #63).