### PR TITLE
docs(contributing): document label taxonomy and memory-update rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,34 @@ Examples:
 - At least one approval required.
 - CI (`typecheck`, `lint`) must pass.
 
+## Labels
+
+Every issue and PR must carry the five-axis taxonomy below. Missing labels default to the most conservative interpretation (`ai:human-checkpoint` + `risk:review-required`).
+
+| Axis     | Values                                                                 | What it drives                                                                                     |
+| -------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `role:`  | `frontend`, `backend`, `coord`                                         | Which agent/human owns the work.                                                                   |
+| `type:`  | `feat`, `fix`, `chore`, `refactor`, `test`, `docs`                     | Mirrors the commit-message type.                                                                   |
+| *priority* | `P0-now`, `P1-week`, `P2-soon`, `P3-backlog`                         | Scheduling order.                                                                                  |
+| `ai:`    | `autonomous`, `human-checkpoint`                                       | `autonomous` = agent runs through to PR. `human-checkpoint` = agent stops after the plan.          |
+| `risk:`  | `safe`, `review-required`, `destructive`                               | Merge gate. `destructive` is never auto-created or auto-merged.                                    |
+
+Rules of thumb:
+
+- Label when the issue is created, not when it's picked up.
+- `risk:destructive` always pairs with `ai:human-checkpoint`.
+- Auto-merge requires `ai:autonomous` + `risk:safe` explicitly (and is currently opt-in per-label — see `project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md`).
+
+## Memory updates
+
+`project-memory/` is the in-repo source of truth for architecture, decisions, and state. When code changes invalidate a memory file, **fix the memory file in the same PR as the code change**. Out-of-date memory is treated as a bug.
+
+Expectations:
+
+- Update `project-memory/03-current-state.md` and `08-recent-changes.md` when a session ships something user-visible or structural.
+- Touch `project-memory/01-architecture.md` or `02-decisions.md` only when the change is architecturally meaningful.
+- Never edit `project-memory/backlog/issues.json` directly — it is generated. Backlog deltas go through `project-memory/backlog/issues.delta.json` (see `issues.delta.schema.md`).
+
 ## Local workflow
 
 ```bash


### PR DESCRIPTION
Closes #47

## Summary
Adds two missing sections to `CONTRIBUTING.md` called out by the AC:
1. **Labels** — the five-axis taxonomy (`role:`, `type:`, priority, `ai:`, `risk:`) with defaults and the auto-merge gate, mirroring `project-memory/AI-ISSUE-EXECUTION-PROTOCOL.md`.
2. **Memory updates** — rule that code changes invalidating `project-memory/` must fix the memory in the same PR, plus pointers to the files touched per kind of change and the backlog-delta pathway.

`apps/api/README.md` is already ≥ AC (Overview, Run, Env vars, Endpoints, Tests), unchanged.

## Acceptance criteria
- [x] `apps/api/README.md`: Overview, Run, Env vars, Endpoints link, Tests — already satisfied before this PR (AC pre-existed).
- [x] `CONTRIBUTING.md`: branch pattern (already existed), conventional-commits scopes (already existed), label use (added), memory-update rule (added).

## Test plan
Docs only; no code change. `pnpm typecheck` green.

## Out of scope
- Code of conduct (explicitly excluded by the issue).