### PR TITLE
feat(web): global ErrorBoundary + Toast host (#40)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import '@/styles/globals.css';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { ToastHost } from '@/components/ToastHost';
 
 export const metadata: Metadata = {
   title: 'AI Workspace V1',
@@ -9,7 +11,11 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ErrorBoundary>
+          <ToastHost>{children}</ToastHost>
+        </ErrorBoundary>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (typeof console !== 'undefined') {
+      console.error('[ErrorBoundary]', error, info.componentStack);
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  override render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    if (this.props.fallback) return this.props.fallback(error, this.reset);
+    return (
+      <div role="alert" style={fallbackStyle}>
+        <h2 style={{ margin: 0, fontSize: '1.1rem' }}>Something went wrong</h2>
+        <p style={{ margin: 0, color: '#c9c9d2' }}>{error.message || 'Unknown error'}</p>
+        <button
+          type="button"
+          onClick={this.reset}
+          style={{
+            marginTop: '0.5rem',
+            background: '#f5f5f5',
+            color: '#0b0b0d',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0.5rem 0.9rem',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            fontSize: '0.875rem',
+            fontWeight: 500,
+            alignSelf: 'flex-start',
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+}
+
+const fallbackStyle: React.CSSProperties = {
+  margin: '2rem auto',
+  maxWidth: 640,
+  padding: '1.25rem 1.5rem',
+  background: '#1b1b23',
+  border: '1px solid #3a1d1d',
+  borderRadius: 12,
+  color: '#f5f5f5',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  fontFamily: 'inherit',
+};

--- a/apps/web/src/components/ToastHost.tsx
+++ b/apps/web/src/components/ToastHost.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { ApiCallError } from '@/lib/api/client';
+
+type ToastTone = 'success' | 'error' | 'info';
+
+export interface Toast {
+  id: string;
+  tone: ToastTone;
+  message: string;
+}
+
+interface ToastContextValue {
+  push: (tone: ToastTone, message: string) => void;
+  pushError: (error: unknown, prefix?: string) => void;
+  dismiss: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const AUTO_DISMISS_MS = 5000;
+
+let counter = 0;
+function nextId(): string {
+  counter += 1;
+  return `t-${Date.now()}-${counter}`;
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within ToastHost');
+  }
+  return ctx;
+}
+
+export function ToastHost({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const push = useCallback((tone: ToastTone, message: string) => {
+    const id = nextId();
+    setToasts((prev) => [...prev, { id, tone, message }]);
+  }, []);
+
+  const pushError = useCallback(
+    (error: unknown, prefix?: string) => {
+      const e = error as ApiCallError | undefined;
+      const code = e?.code ?? 'error';
+      const msg = e?.message ?? 'Unknown error';
+      const full = prefix ? `${prefix}: ${code} — ${msg}` : `${code} — ${msg}`;
+      push('error', full);
+    },
+    [push],
+  );
+
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const timers = toasts.map((t) =>
+      setTimeout(() => dismiss(t.id), AUTO_DISMISS_MS),
+    );
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, [toasts, dismiss]);
+
+  const value = useMemo<ToastContextValue>(
+    () => ({ push, pushError, dismiss }),
+    [push, pushError, dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div aria-live="polite" style={viewportStyle}>
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            role="status"
+            style={{ ...toastStyle, ...toneStyles[t.tone] }}
+            onClick={() => dismiss(t.id)}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+const viewportStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: '1rem',
+  right: '1rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  maxWidth: 420,
+  zIndex: 70,
+};
+
+const toastStyle: React.CSSProperties = {
+  padding: '0.75rem 1rem',
+  borderRadius: 8,
+  fontSize: '0.875rem',
+  boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+  cursor: 'pointer',
+  color: '#f5f5f5',
+};
+
+const toneStyles: Record<ToastTone, React.CSSProperties> = {
+  success: {
+    background: '#13321d',
+    border: '1px solid #2a6a43',
+    color: '#c9f4d6',
+  },
+  error: {
+    background: '#3a1d1d',
+    border: '1px solid #6b2a2a',
+    color: '#ffd3d3',
+  },
+  info: {
+    background: '#1b1b23',
+    border: '1px solid #2a2a30',
+    color: '#e8e8ef',
+  },
+};


### PR DESCRIPTION
Closes #40

## Summary
Adds a React `ErrorBoundary` and a minimal toast layer wired into the root layout. No new dependency.

## Acceptance criteria
- [x] `components/ErrorBoundary.tsx` wraps root (via `app/layout.tsx`)
- [x] Minimal toast component (no new dep)
- [x] `apiFetch` errors reach toast layer — via `useToast().pushError(err, prefix)` from client components

## Out of scope
Retry UI per toast.

## Notes
Adoption is incremental. The existing local toast on `/settings/providers` is intentionally left untouched to avoid churn; a follow-up can migrate it to the global host.

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green