### PR TITLE
refactor(web): migrate web to canonical chat-windows endpoint (#38)

### DIFF
--- a/apps/web/src/app/project/[id]/page.tsx
+++ b/apps/web/src/app/project/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { getApiBaseUrl } from '@/lib/api/env';
 import { fetchProject } from '@/lib/api/projects';
 import { fetchProjectWorkspaces } from '@/lib/api/workspaces';
-import { fetchWorkspaceWindows } from '@/lib/api/windows';
+import { fetchWorkspaceWindows } from '@/lib/api/chat-windows';
 import { fetchWindowMessages } from '@/lib/api/messages';
 import type { ApiCallError } from '@/lib/api/client';
 import type { ChatWindow } from '@webapp/types';

--- a/apps/web/src/lib/api/chat-windows.ts
+++ b/apps/web/src/lib/api/chat-windows.ts
@@ -1,4 +1,5 @@
 import type { ChatWindow } from '@webapp/types';
+import { API_CHAT_WINDOWS_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
 
 export function fetchWorkspaceWindows(
@@ -7,7 +8,7 @@ export function fetchWorkspaceWindows(
 ): Promise<ChatWindow[]> {
   const encoded = encodeURIComponent(workspaceId);
   return apiFetch<ChatWindow[]>(
-    `/v1/workspaces/${encoded}/windows`,
+    `${API_CHAT_WINDOWS_PATH}?workspaceId=${encoded}`,
     signal ? { signal } : undefined,
   );
 }


### PR DESCRIPTION
Closes #38

## Summary
Backend standardized on `/v1/chat-windows/*`. Web was still calling the legacy alias `/v1/workspaces/:id/windows`. Renames the API wrapper file and switches the list path to `/v1/chat-windows?workspaceId=:id` via `API_CHAT_WINDOWS_PATH` from `@webapp/types`.

## Acceptance criteria
- [x] `lib/api/windows.ts` renamed `chat-windows.ts`; call site updated
- [x] Local `windowId` → `chatWindowId` rename already complete (zero hits in `apps/web/src/`)
- [x] `pnpm --filter @webapp/web typecheck && build` — green

## Out of scope
Removing backend aliases (backend task).

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green