### PR TITLE
feat(web): create* API wrappers + wire chat-window create to POST (#19)

### DIFF
--- a/apps/web/src/features/workspace/useWorkspaceState.ts
+++ b/apps/web/src/features/workspace/useWorkspaceState.ts
@@ -3,6 +3,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ChatWindow } from '@webapp/types';
 import type { WindowPreset } from '@/lib/data';
+import { createChatWindow } from '@/lib/api/chat-windows';
+import { getApiBaseUrl } from '@/lib/api/env';
 
 interface WorkspaceStateInit {
   windows: ChatWindow[];
@@ -59,8 +61,9 @@ export function useWorkspaceState({ windows }: WorkspaceStateInit): WorkspaceSta
       const workspaceId = windows[0]?.workspaceId ?? 'local-ws';
       const now = new Date().toISOString();
       const title = customTitle?.trim() || preset.defaultTitle;
-      const w: ChatWindow = {
-        id: `local-${Date.now()}-${creationCounter}`,
+      const tempId = `local-${Date.now()}-${creationCounter}`;
+      const optimistic: ChatWindow = {
+        id: tempId,
         workspaceId,
         title,
         provider: preset.provider,
@@ -68,10 +71,30 @@ export function useWorkspaceState({ windows }: WorkspaceStateInit): WorkspaceSta
         createdAt: now,
         updatedAt: now,
       };
-      setPool((prev) => [...prev, w]);
-      setOpenIds((prev) => [...prev, w.id]);
-      setActiveId(w.id);
-      return w.id;
+      setPool((prev) => [...prev, optimistic]);
+      setOpenIds((prev) => [...prev, tempId]);
+      setActiveId(tempId);
+
+      if (getApiBaseUrl() && workspaceId !== 'local-ws') {
+        void createChatWindow({
+          workspaceId,
+          title,
+          provider: preset.provider,
+          model: preset.model,
+        })
+          .then((persisted) => {
+            setPool((prev) => prev.map((w) => (w.id === tempId ? persisted : w)));
+            setOpenIds((prev) => prev.map((id) => (id === tempId ? persisted.id : id)));
+            setActiveId((current) => (current === tempId ? persisted.id : current));
+          })
+          .catch(() => {
+            setPool((prev) => prev.filter((w) => w.id !== tempId));
+            setOpenIds((prev) => prev.filter((id) => id !== tempId));
+            setActiveId((current) => (current === tempId ? null : current));
+          });
+      }
+
+      return tempId;
     },
     [windows],
   );

--- a/apps/web/src/lib/api/chat-windows.ts
+++ b/apps/web/src/lib/api/chat-windows.ts
@@ -1,6 +1,7 @@
-import type { ChatWindow } from '@webapp/types';
+import type { AIProvider, ChatWindow } from '@webapp/types';
 import { API_CHAT_WINDOWS_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
+import { postJson } from '@/lib/api/http';
 
 export function fetchWorkspaceWindows(
   workspaceId: string,
@@ -11,4 +12,18 @@ export function fetchWorkspaceWindows(
     `${API_CHAT_WINDOWS_PATH}?workspaceId=${encoded}`,
     signal ? { signal } : undefined,
   );
+}
+
+export interface CreateChatWindowInput {
+  workspaceId: string;
+  title: string;
+  provider: AIProvider;
+  model: string;
+}
+
+export function createChatWindow(
+  input: CreateChatWindowInput,
+  signal?: AbortSignal,
+): Promise<ChatWindow> {
+  return postJson<ChatWindow>(API_CHAT_WINDOWS_PATH, input, signal);
 }

--- a/apps/web/src/lib/api/http.ts
+++ b/apps/web/src/lib/api/http.ts
@@ -1,0 +1,71 @@
+import type { ApiResponse } from '@webapp/types';
+import type { ApiCallError } from '@/lib/api/client';
+import { getApiBaseUrl } from '@/lib/api/env';
+
+function makeError(
+  message: string,
+  init: Partial<ApiCallError> = {},
+): ApiCallError {
+  const err = new Error(message) as ApiCallError;
+  if (init.cause !== undefined) err.cause = init.cause;
+  if (init.status !== undefined) err.status = init.status;
+  if (init.code !== undefined) err.code = init.code;
+  return err;
+}
+
+export async function postJson<T>(
+  path: string,
+  body: unknown,
+  signal?: AbortSignal,
+): Promise<T> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) throw makeError('NEXT_PUBLIC_API_URL is not configured', { code: 'no_api_url' });
+
+  const url = `${baseUrl}${path.startsWith('/') ? path : `/${path}`}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', () => controller.abort(), { once: true });
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { accept: 'application/json', 'content-type': 'application/json' },
+      credentials: 'include',
+      cache: 'no-store',
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    clearTimeout(timer);
+    const aborted = (cause as { name?: string } | null)?.name === 'AbortError';
+    throw makeError(aborted ? `Request to ${url} aborted` : `Network error calling ${url}`, {
+      code: aborted ? 'timeout' : 'network_error',
+      cause,
+    });
+  }
+  clearTimeout(timer);
+
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch (cause) {
+    throw makeError(`Non-JSON response from ${url}`, {
+      status: res.status,
+      code: 'invalid_json',
+      cause,
+    });
+  }
+
+  const envelope = parsed as ApiResponse<T>;
+  if (!envelope || typeof envelope !== 'object' || typeof (envelope as { ok?: unknown }).ok !== 'boolean') {
+    throw makeError(`Malformed envelope from ${url}`, { status: res.status, code: 'invalid_envelope' });
+  }
+  if (!envelope.ok) {
+    throw makeError(envelope.error.message, { status: res.status, code: envelope.error.code });
+  }
+  return envelope.data;
+}

--- a/apps/web/src/lib/api/projects.ts
+++ b/apps/web/src/lib/api/projects.ts
@@ -1,5 +1,6 @@
 import type { Project } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
+import { postJson } from '@/lib/api/http';
 
 export function fetchProjects(signal?: AbortSignal): Promise<Project[]> {
   return apiFetch<Project[]>('/v1/projects', signal ? { signal } : undefined);
@@ -8,4 +9,13 @@ export function fetchProjects(signal?: AbortSignal): Promise<Project[]> {
 export function fetchProject(id: string, signal?: AbortSignal): Promise<Project> {
   const encoded = encodeURIComponent(id);
   return apiFetch<Project>(`/v1/projects/${encoded}`, signal ? { signal } : undefined);
+}
+
+export interface CreateProjectInput {
+  name: string;
+  description?: string;
+}
+
+export function createProject(input: CreateProjectInput, signal?: AbortSignal): Promise<Project> {
+  return postJson<Project>('/v1/projects', input, signal);
 }

--- a/apps/web/src/lib/api/workspaces.ts
+++ b/apps/web/src/lib/api/workspaces.ts
@@ -1,5 +1,6 @@
 import type { Workspace } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
+import { postJson } from '@/lib/api/http';
 
 export function fetchProjectWorkspaces(
   projectId: string,
@@ -10,4 +11,16 @@ export function fetchProjectWorkspaces(
     `/v1/projects/${encoded}/workspaces`,
     signal ? { signal } : undefined,
   );
+}
+
+export interface CreateWorkspaceInput {
+  projectId: string;
+  name: string;
+}
+
+export function createWorkspace(
+  input: CreateWorkspaceInput,
+  signal?: AbortSignal,
+): Promise<Workspace> {
+  return postJson<Workspace>('/v1/workspaces', input, signal);
 }


### PR DESCRIPTION
Closes #19

## Summary
Adds POST wrappers for projects / workspaces / chat-windows and wires the existing chat-window create flow through the real endpoint when `NEXT_PUBLIC_API_URL` is set. Mock mode is preserved.

## Acceptance criteria
- [x] `lib/api/{projects,workspaces,chat-windows}.ts` gain `create*` functions
  - `createProject({ name, description? })`
  - `createWorkspace({ projectId, name })`
  - `createChatWindow({ workspaceId, title, provider, model })`
- [x] Create flows dispatch POST, refresh from server on success — `useWorkspaceState.createWindow` performs an optimistic insert, POSTs, swaps the temp id for the persisted row on success, rolls back on failure
- [x] Mock mode preserved when API unset — the POST is skipped when `NEXT_PUBLIC_API_URL` is absent or when the workspace is the mock `local-ws`

## Out of scope
Rename/delete (separate issue #20). Project/workspace creation UI (no UI exists yet; wrappers are ready).

## Notes
- `lib/api/http.ts` introduced as a minimal shared helper for POST-with-envelope, mirroring `apiFetch`. Avoids touching `client.ts` (which open PR #63 modifies), preventing a merge conflict.
- `createWindow` signature remains synchronous (returns temp id immediately) so every existing caller in `WorkspaceSidebar` / `NewWindowComposer` / `WorkspaceCanvas` keeps working.

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green
- Manual:
  - mock mode (no `NEXT_PUBLIC_API_URL`): window appears locally, no network call
  - real mode with backend + auth: window appears optimistically, id swaps to persisted id once POST returns
  - backend 4xx/5xx: window rolls back out of the sidebar