### PR TITLE
feat(web): POST message client + optimistic render (#28)

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -11,10 +11,13 @@ interface ChatWindowProps {
   model: string;
   messages: MockMessage[];
   active?: boolean;
+  pending?: boolean;
   onClose?: (id: string) => void;
   onFocus?: (id: string) => void;
   onSend?: (id: string, content: string) => void;
   onRename?: (id: string, title: string) => void;
+  onRetry?: (id: string, clientTempId: string) => void;
+  onCancel?: (id: string) => void;
 }
 
 const providerColor: Record<AIProvider, string> = {
@@ -36,10 +39,13 @@ export function ChatWindow({
   model,
   messages,
   active = false,
+  pending = false,
   onClose,
   onFocus,
   onSend,
   onRename,
+  onRetry,
+  onCancel,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
   const [editing, setEditing] = useState(false);
@@ -53,11 +59,14 @@ export function ChatWindow({
   };
 
   const submit = () => {
+    if (pending) return;
     const trimmed = draft.trim();
     if (!trimmed) return;
     onSend?.(id, trimmed);
     setDraft('');
   };
+
+  const canSend = !pending && draft.trim().length > 0;
 
   return (
     <div
@@ -186,7 +195,15 @@ export function ChatWindow({
             <span style={{ fontSize: '0.75rem' }}>Type below to start the conversation.</span>
           </div>
         ) : (
-          messages.map((m) => <MessageBubble key={m.id} message={m} />)
+          messages.map((m) => (
+            <MessageBubble
+              key={m.id}
+              message={m}
+              onRetry={
+                onRetry && m.clientTempId ? () => onRetry(id, m.clientTempId!) : undefined
+              }
+            />
+          ))
         )}
       </div>
 
@@ -208,37 +225,62 @@ export function ChatWindow({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onFocus={() => onFocus?.(id)}
-          placeholder="Send a message…"
+          placeholder={pending ? 'Waiting for reply…' : 'Send a message…'}
           aria-label={`Message ${title}`}
+          disabled={pending}
           style={{
             flex: 1,
             background: '#1b1b23',
             border: '1px solid #2a2a30',
             borderRadius: 8,
             padding: '0.55rem 0.75rem',
-            color: '#f5f5f5',
+            color: pending ? '#8a8a95' : '#f5f5f5',
             fontSize: '0.875rem',
             fontFamily: 'inherit',
             outline: 'none',
           }}
         />
-        <button
-          type="submit"
-          disabled={!draft.trim()}
-          style={{
-            background: draft.trim() ? '#f5f5f5' : '#2a2a30',
-            color: draft.trim() ? '#0b0b0d' : '#6a6a75',
-            border: 'none',
-            borderRadius: 8,
-            padding: '0 0.9rem',
-            fontSize: '0.85rem',
-            fontWeight: 500,
-            cursor: draft.trim() ? 'pointer' : 'not-allowed',
-            fontFamily: 'inherit',
-          }}
-        >
-          Send
-        </button>
+        {pending && onCancel ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel(id);
+            }}
+            aria-label="Cancel in-flight message"
+            style={{
+              background: '#2a2a30',
+              color: '#f5f5f5',
+              border: '1px solid #3a3a45',
+              borderRadius: 8,
+              padding: '0 0.9rem',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Cancel
+          </button>
+        ) : (
+          <button
+            type="submit"
+            disabled={!canSend}
+            style={{
+              background: canSend ? '#f5f5f5' : '#2a2a30',
+              color: canSend ? '#0b0b0d' : '#6a6a75',
+              border: 'none',
+              borderRadius: 8,
+              padding: '0 0.9rem',
+              fontSize: '0.85rem',
+              fontWeight: 500,
+              cursor: canSend ? 'pointer' : 'not-allowed',
+              fontFamily: 'inherit',
+            }}
+          >
+            Send
+          </button>
+        )}
       </form>
     </div>
   );
@@ -283,7 +325,32 @@ function formatMessageTimestamp(iso: string): string | null {
   return d.toISOString().replace('T', ' ').slice(0, 16);
 }
 
-function MessageBubble({ message }: { message: MockMessage }) {
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        border: '2px solid rgba(245,245,245,0.18)',
+        borderTopColor: '#f5f5f5',
+        animation: 'chat-spin 0.7s linear infinite',
+        marginLeft: 6,
+        verticalAlign: '-1px',
+      }}
+    />
+  );
+}
+
+function MessageBubble({
+  message,
+  onRetry,
+}: {
+  message: MockMessage;
+  onRetry?: () => void;
+}) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
   const timestamp = formatMessageTimestamp(message.createdAt);
@@ -292,23 +359,32 @@ function MessageBubble({ message }: { message: MockMessage }) {
   if (message.model) metaParts.push(message.model);
   if (timestamp) metaParts.push(timestamp);
   const showMeta = isAssistant && metaParts.length > 0;
+  const status = message.status ?? 'ok';
+  const isPending = status === 'pending';
+  const isFailed = status === 'failed';
+  const borderColor = isFailed ? '#6b2a2a' : '#24242c';
+  const opacity = isPending ? 0.7 : 1;
+
   return (
     <div
       style={{
         alignSelf: isUser ? 'flex-end' : 'flex-start',
         maxWidth: '85%',
         background: isUser ? '#2b2b36' : '#1b1b23',
-        border: '1px solid #24242c',
+        border: `1px solid ${borderColor}`,
         borderRadius: 10,
         padding: '0.55rem 0.75rem',
         fontSize: '0.85rem',
         lineHeight: 1.4,
         color: '#e8e8ef',
         whiteSpace: 'pre-wrap',
+        opacity,
       }}
     >
       <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
           fontSize: '0.65rem',
           color: '#8a8a95',
           marginBottom: 4,
@@ -316,9 +392,61 @@ function MessageBubble({ message }: { message: MockMessage }) {
           letterSpacing: '0.03em',
         }}
       >
-        {message.role}
+        <span>{message.role}</span>
+        {isPending && <Spinner />}
+        {isFailed && (
+          <span
+            style={{
+              color: '#ff8b8b',
+              marginLeft: 6,
+              textTransform: 'none',
+              letterSpacing: 0,
+            }}
+          >
+            failed
+          </span>
+        )}
       </div>
       {message.content}
+      {isFailed && (
+        <div
+          style={{
+            marginTop: 6,
+            display: 'flex',
+            alignItems: 'center',
+            flexWrap: 'wrap',
+            gap: 8,
+            fontSize: '0.7rem',
+          }}
+        >
+          {message.errorMessage && (
+            <span style={{ color: '#ffd3d3' }}>
+              {message.errorCode ?? 'error'} — {message.errorMessage}
+            </span>
+          )}
+          {onRetry && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRetry();
+              }}
+              style={{
+                background: 'transparent',
+                color: '#ffd3d3',
+                border: '1px solid #6b2a2a',
+                borderRadius: 6,
+                padding: '2px 8px',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                fontSize: '0.7rem',
+              }}
+            >
+              Retry
+            </button>
+          )}
+        </div>
+      )}
       {showMeta && (
         <div
           data-testid="message-meta"

--- a/apps/web/src/features/chat/useChatSessions.ts
+++ b/apps/web/src/features/chat/useChatSessions.ts
@@ -1,36 +1,240 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MockMessage } from '@/lib/data';
+import { getApiBaseUrl } from '@/lib/api/env';
+import { isGeneratedPair, postMessage, type PostMessageResult } from '@/lib/api/messages';
+import type { ApiCallError } from '@/lib/api/client';
 
 export interface ChatSessionsApi {
   getMessages: (chatWindowId: string) => MockMessage[];
+  isPending: (chatWindowId: string) => boolean;
   sendUserMessage: (chatWindowId: string, content: string) => void;
+  retry: (chatWindowId: string, clientTempId: string) => void;
+  cancel: (chatWindowId: string) => void;
+}
+
+interface SessionState {
+  messages: MockMessage[];
+  pendingTempId: string | null;
+}
+
+type Sessions = Record<string, SessionState>;
+
+let tempCounter = 0;
+function nextTempId(chatWindowId: string): string {
+  tempCounter += 1;
+  return `tmp-${chatWindowId}-${Date.now()}-${tempCounter}`;
+}
+
+function toSessions(initial: Record<string, MockMessage[]>): Sessions {
+  const out: Sessions = {};
+  for (const [id, list] of Object.entries(initial)) {
+    out[id] = {
+      messages: list.map((m) => ({ ...m, status: m.status ?? 'ok' })),
+      pendingTempId: null,
+    };
+  }
+  return out;
+}
+
+function asApiCallError(err: unknown): ApiCallError {
+  if (err && typeof err === 'object' && 'message' in err) return err as ApiCallError;
+  return new Error(typeof err === 'string' ? err : 'Unknown error') as ApiCallError;
 }
 
 export function useChatSessions(initial: Record<string, MockMessage[]>): ChatSessionsApi {
-  const [sessions, setSessions] = useState<Record<string, MockMessage[]>>(initial);
+  const [sessions, setSessions] = useState<Sessions>(() => toSessions(initial));
+  const controllers = useRef<Map<string, AbortController>>(new Map());
+  const sessionsRef = useRef<Sessions>(sessions);
+  sessionsRef.current = sessions;
+
+  useEffect(() => {
+    const map = controllers.current;
+    return () => {
+      map.forEach((c) => c.abort());
+      map.clear();
+    };
+  }, []);
 
   const getMessages = useCallback(
-    (chatWindowId: string) => sessions[chatWindowId] ?? [],
+    (chatWindowId: string): MockMessage[] => sessions[chatWindowId]?.messages ?? [],
     [sessions],
   );
 
-  const sendUserMessage = useCallback((chatWindowId: string, content: string) => {
-    const trimmed = content.trim();
-    if (!trimmed) return;
-    setSessions((prev) => {
-      const current = prev[chatWindowId] ?? [];
-      const next: MockMessage = {
-        id: `local-${chatWindowId}-${Date.now()}`,
+  const isPending = useCallback(
+    (chatWindowId: string): boolean => sessions[chatWindowId]?.pendingTempId != null,
+    [sessions],
+  );
+
+  const fulfillSuccess = useCallback(
+    (chatWindowId: string, tempId: string, result: PostMessageResult) => {
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        const userRow = isGeneratedPair(result) ? result.userMessage : result;
+        const assistantRow = isGeneratedPair(result) ? result.assistantMessage : null;
+        const replaced: MockMessage[] = current.messages.map((m) => {
+          if (m.clientTempId !== tempId) return m;
+          return {
+            id: userRow.id,
+            chatWindowId: userRow.chatWindowId,
+            role: userRow.role,
+            content: userRow.content,
+            createdAt: userRow.createdAt,
+            status: 'ok',
+          };
+        });
+        const withAssistant: MockMessage[] = assistantRow
+          ? [
+              ...replaced,
+              {
+                id: assistantRow.id,
+                chatWindowId: assistantRow.chatWindowId,
+                role: assistantRow.role,
+                content: assistantRow.content,
+                createdAt: assistantRow.createdAt,
+                provider: assistantRow.provider ?? undefined,
+                model: assistantRow.model ?? undefined,
+                status: 'ok',
+              },
+            ]
+          : replaced;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            messages: withAssistant,
+            pendingTempId: current.pendingTempId === tempId ? null : current.pendingTempId,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const fulfillError = useCallback(
+    (chatWindowId: string, tempId: string, err: unknown) => {
+      const e = asApiCallError(err);
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            messages: current.messages.map((m) =>
+              m.clientTempId === tempId
+                ? {
+                    ...m,
+                    status: 'failed',
+                    errorCode: e.code ?? 'error',
+                    errorMessage: e.message,
+                  }
+                : m,
+            ),
+            pendingTempId: current.pendingTempId === tempId ? null : current.pendingTempId,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const dispatchPost = useCallback(
+    (chatWindowId: string, tempId: string, content: string) => {
+      const ctrl = new AbortController();
+      controllers.current.get(chatWindowId)?.abort();
+      controllers.current.set(chatWindowId, ctrl);
+
+      postMessage({ chatWindowId, role: 'user', content }, ctrl.signal)
+        .then((result) => {
+          if (controllers.current.get(chatWindowId) === ctrl) {
+            controllers.current.delete(chatWindowId);
+          }
+          if (ctrl.signal.aborted) return;
+          fulfillSuccess(chatWindowId, tempId, result);
+        })
+        .catch((err: unknown) => {
+          if (controllers.current.get(chatWindowId) === ctrl) {
+            controllers.current.delete(chatWindowId);
+          }
+          if (ctrl.signal.aborted) {
+            const code = (err as ApiCallError | null)?.code;
+            if (code === 'timeout') {
+              fulfillError(chatWindowId, tempId, err);
+            } else {
+              fulfillError(chatWindowId, tempId, {
+                code: 'canceled',
+                message: 'Request canceled',
+              });
+            }
+            return;
+          }
+          fulfillError(chatWindowId, tempId, err);
+        });
+    },
+    [fulfillSuccess, fulfillError],
+  );
+
+  const sendUserMessage = useCallback(
+    (chatWindowId: string, content: string) => {
+      const trimmed = content.trim();
+      if (!trimmed) return;
+      const useApi = !!getApiBaseUrl() && !chatWindowId.startsWith('local-');
+      const tempId = nextTempId(chatWindowId);
+      const now = new Date().toISOString();
+      const optimistic: MockMessage = {
+        id: tempId,
         chatWindowId,
         role: 'user',
         content: trimmed,
-        createdAt: new Date().toISOString(),
+        createdAt: now,
+        status: useApi ? 'pending' : 'ok',
+        clientTempId: tempId,
       };
-      return { ...prev, [chatWindowId]: [...current, next] };
-    });
+      setSessions((prev) => {
+        const current = prev[chatWindowId] ?? { messages: [], pendingTempId: null };
+        return {
+          ...prev,
+          [chatWindowId]: {
+            messages: [...current.messages, optimistic],
+            pendingTempId: useApi ? tempId : current.pendingTempId,
+          },
+        };
+      });
+      if (useApi) dispatchPost(chatWindowId, tempId, trimmed);
+    },
+    [dispatchPost],
+  );
+
+  const retry = useCallback(
+    (chatWindowId: string, clientTempId: string) => {
+      const target = sessionsRef.current[chatWindowId]?.messages.find(
+        (m) => m.clientTempId === clientTempId,
+      );
+      if (!target || target.status !== 'failed') return;
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            messages: current.messages.map((m) =>
+              m.clientTempId === clientTempId
+                ? { ...m, status: 'pending', errorCode: undefined, errorMessage: undefined }
+                : m,
+            ),
+            pendingTempId: clientTempId,
+          },
+        };
+      });
+      dispatchPost(chatWindowId, clientTempId, target.content);
+    },
+    [dispatchPost],
+  );
+
+  const cancel = useCallback((chatWindowId: string) => {
+    controllers.current.get(chatWindowId)?.abort();
   }, []);
 
-  return { getMessages, sendUserMessage };
+  return { getMessages, isPending, sendUserMessage, retry, cancel };
 }

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -46,7 +46,10 @@ export function Workspace({
       <WorkspaceCanvas
         visibleWindows={state.visibleWindows}
         getMessages={chat.getMessages}
+        isPending={chat.isPending}
         onSend={chat.sendUserMessage}
+        onRetry={chat.retry}
+        onCancel={chat.cancel}
         activeId={state.activeId}
         hasClosed={state.closedWindows.length > 0}
         onClose={state.close}

--- a/apps/web/src/features/workspace/WorkspaceCanvas.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCanvas.tsx
@@ -8,7 +8,10 @@ import { WINDOW_PRESETS } from '@/lib/data';
 interface WorkspaceCanvasProps {
   visibleWindows: ChatWindowType[];
   getMessages: (chatWindowId: string) => MockMessage[];
+  isPending: (chatWindowId: string) => boolean;
   onSend: (chatWindowId: string, content: string) => void;
+  onRetry: (chatWindowId: string, clientTempId: string) => void;
+  onCancel: (chatWindowId: string) => void;
   activeId: string | null;
   hasClosed: boolean;
   onClose: (id: string) => void;
@@ -21,7 +24,10 @@ interface WorkspaceCanvasProps {
 export function WorkspaceCanvas({
   visibleWindows,
   getMessages,
+  isPending,
   onSend,
+  onRetry,
+  onCancel,
   activeId,
   hasClosed,
   onClose,
@@ -55,10 +61,13 @@ export function WorkspaceCanvas({
             model={w.model}
             messages={getMessages(w.id)}
             active={activeId === w.id}
+            pending={isPending(w.id)}
             onClose={onClose}
             onFocus={onFocus}
             onSend={onSend}
             onRename={onRename}
+            onRetry={onRetry}
+            onCancel={onCancel}
           />
         ))
       )}

--- a/apps/web/src/lib/api/messages.ts
+++ b/apps/web/src/lib/api/messages.ts
@@ -1,5 +1,6 @@
-import type { Message } from '@webapp/types';
+import type { GeneratedMessagePair, Message, MessageRole } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
+import { postJson } from '@/lib/api/http';
 
 export function fetchWindowMessages(
   chatWindowId: string,
@@ -10,4 +11,28 @@ export function fetchWindowMessages(
     `/v1/windows/${encoded}/messages`,
     signal ? { signal } : undefined,
   );
+}
+
+export interface PostMessageInput {
+  chatWindowId: string;
+  role: MessageRole;
+  content: string;
+}
+
+export type PostMessageResult = Message | GeneratedMessagePair;
+
+export function isGeneratedPair(r: PostMessageResult): r is GeneratedMessagePair {
+  return (
+    typeof r === 'object' &&
+    r !== null &&
+    'userMessage' in r &&
+    'assistantMessage' in r
+  );
+}
+
+export function postMessage(
+  input: PostMessageInput,
+  signal?: AbortSignal,
+): Promise<PostMessageResult> {
+  return postJson<PostMessageResult>('/v1/messages', input, signal);
 }

--- a/apps/web/src/lib/data/index.ts
+++ b/apps/web/src/lib/data/index.ts
@@ -5,9 +5,10 @@ import {
   windows,
   messages,
   type MockMessage,
+  type MockMessageStatus,
 } from '@/lib/mocks/fixtures';
 
-export type { MockMessage };
+export type { MockMessage, MockMessageStatus };
 export { WINDOW_PRESETS, getPreset, type WindowPreset } from '@/lib/data/presets';
 
 export type WorkspaceResolution =

--- a/apps/web/src/lib/mocks/fixtures.ts
+++ b/apps/web/src/lib/mocks/fixtures.ts
@@ -1,5 +1,7 @@
 import type { AIProvider, ChatWindow, MessageRole, Project, Workspace } from '@webapp/types';
 
+export type MockMessageStatus = 'pending' | 'ok' | 'failed';
+
 export interface MockMessage {
   id: string;
   chatWindowId: string;
@@ -8,6 +10,10 @@ export interface MockMessage {
   createdAt: string;
   provider?: AIProvider | null;
   model?: string | null;
+  status?: MockMessageStatus;
+  clientTempId?: string;
+  errorCode?: string;
+  errorMessage?: string;
 }
 
 const now = '2026-04-18T00:00:00.000Z';

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -11,3 +11,9 @@ body {
   background: #0b0b0d;
   color: #f5f5f5;
 }
+
+@keyframes chat-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
Closes #28

Plan approved upstream; this PR is the full implementation.

## Summary
Replaces the in-memory-only `sendUserMessage` with a real optimistic-POST flow. Temp user bubble appears instantly; POST dispatches against `/v1/messages` with an `AbortController`; success swaps the temp id for the persisted row and appends the assistant message when the openai path returns a `GeneratedMessagePair`; failure marks the bubble `failed` with `code — message` and a `Retry` button.

## Acceptance criteria
- [x] `lib/api/messages.ts` adds `postMessage(input, signal?)` returning `Message | GeneratedMessagePair`
- [x] Composer submit: optimistic user msg with temp id, POST, replace id + append assistant on success; mark failed with retry on error
- [x] In-flight spinner; `AbortController` Cancel button
- [x] `NEXT_PUBLIC_API_URL` unset → local-echo preserved (also preserved for `local-*` temp windows)

## UX decisions
- **Composer while in-flight**: input disabled with "Waiting for reply…" placeholder; Send button replaced by Cancel. Prevents double-posts and makes the state unambiguous without a full-screen blocker.
- **Per-window pending state**: one in-flight message per window. Keyed AbortController map. Opening a new message while one is pending replaces the previous signal — but the UI blocks that path via the disabled input, so the replacement only fires via Retry, which is the correct behavior.
- **Failed bubble**: red border on the user bubble only, inline `code — message` line and Retry button. Opacity stays at 1 (failed needs attention, not fade).
- **Pending bubble**: opacity 0.7 + spinner next to the "user" header label. Subtle but legible.
- **Cancel semantics**: aborts the request; surfaces `canceled — Request canceled` on the bubble (not hidden). This documents that the server may still have committed the row; Retry re-sends and handles duplicates on the server side if/when dedup lands (tracked implicitly for post-MVP).
- **Mock mode**: `NEXT_PUBLIC_API_URL` unset OR window id starts with `local-` (newly-created window whose POST hasn't yet swapped the id) → no POST, status stays `ok`. Preserves the current preview experience for Yume.

## Edge cases handled
| Case | Behavior |
|---|---|
| Empty content | Early return, no optimistic bubble |
| User spams Send while pending | Input disabled, Submit is a no-op |
| Cancel mid-flight | Bubble → `failed` with `canceled` code; Retry available |
| Timeout (5 s in `postJson`) | Bubble → `failed` with `timeout` code |
| Network drop | Bubble → `failed` with `network_error` |
| Backend 412 provider_not_configured | Bubble → `failed` with the backend code + message shown inline |
| openai window → backend returns `{ userMessage, assistantMessage }` | Both rendered; assistant row gets provider/model metadata (ties into #39) |
| non-openai window → backend returns single `Message` | Renders user row only, no fake assistant |
| Unmount mid-flight | `useEffect` cleanup aborts all controllers |
| Window closed mid-flight | Pending state persists in hook state; if window re-opens, bubbles are still there |
| Retry on non-failed bubble | No-op (guarded by status check) |
| Empty messages array | Existing empty-state preserved unchanged |

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green
- `pnpm --filter @webapp/web lint` — `✔ No ESLint warnings or errors`
- Manual with stub backend:
  - send → assistant renders (openai window), metadata row populates
  - force 4xx from backend → failed bubble + Retry → success on retry
  - cancel mid-flight → failed(canceled) → Retry → success
  - `NEXT_PUBLIC_API_URL` unset → no network, local echo preserved

## Out of scope
- SSE streaming (post-MVP)
- Edit / delete / resend
- File uploads
- Server-side retry dedup (noted in plan)

## Follow-up
Real integration test (Playwright) lands in #42 once auth and create-window flows exist on main.