### PR TITLE
feat(web): add-provider-key form on /settings/providers (#36)

### DIFF
--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import type { ProviderConnection } from '@webapp/types';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import type { AIProvider, ProviderConnection } from '@webapp/types';
 import { Button } from '@/components/Button';
 import { useToast } from '@/components/ToastHost';
 import {
   listProviderConnections,
   removeProviderConnection,
   testProviderConnection,
+  upsertProviderConnection,
   type TestConnectionResult,
 } from '@/lib/api/provider-connections';
 import type { ApiCallError } from '@/lib/api/client';
+
+const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string }> = [
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'perplexity', label: 'Perplexity' },
+];
 
 type LoadState =
   | { status: 'idle' }
@@ -35,6 +42,10 @@ export default function ProviderSettingsPage() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [testingId, setTestingId] = useState<string | null>(null);
+  const [formProvider, setFormProvider] = useState<AIProvider>('openai');
+  const [formApiKey, setFormApiKey] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
   const toast = useToast();
 
   const load = useCallback(async (signal?: AbortSignal) => {
@@ -54,6 +65,32 @@ export default function ProviderSettingsPage() {
     void load(controller.signal);
     return () => controller.abort();
   }, [load]);
+
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const key = formApiKey.trim();
+      if (!key) {
+        setFormError('API key is required.');
+        return;
+      }
+      setSaving(true);
+      setFormError(null);
+      try {
+        await upsertProviderConnection(formProvider, key);
+        setFormApiKey('');
+        toast.push('success', `${formProvider} connection saved`);
+        await load();
+      } catch (err) {
+        const e = err as ApiCallError | undefined;
+        setFormError(e?.message ?? 'Unable to save connection');
+        toast.pushError(err, formProvider);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [formApiKey, formProvider, toast, load],
+  );
 
   const onTest = useCallback(
     async (connection: ProviderConnection) => {
@@ -99,6 +136,56 @@ export default function ProviderSettingsPage() {
           Refresh
         </Button>
       </header>
+
+      <section aria-labelledby="add-connection-title" style={formSectionStyle}>
+        <h2 id="add-connection-title" style={{ margin: 0, fontSize: '1rem' }}>Add connection</h2>
+        <p style={mutedStyle}>Your key is sent to the API, then cleared from this page.</p>
+        <form onSubmit={onSubmit} autoComplete="off" style={formStyle}>
+          <label style={labelStyle}>
+            <span>Provider</span>
+            <select
+              value={formProvider}
+              onChange={(e) => setFormProvider(e.target.value as AIProvider)}
+              disabled={saving}
+              style={selectStyle}
+            >
+              {PROVIDER_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={labelStyle}>
+            <span>API key</span>
+            <input
+              type="password"
+              name="apiKey"
+              autoComplete="off"
+              spellCheck={false}
+              value={formApiKey}
+              onChange={(e) => {
+                setFormApiKey(e.target.value);
+                if (formError) setFormError(null);
+              }}
+              disabled={saving}
+              placeholder="sk-…"
+              aria-invalid={formError ? 'true' : undefined}
+              style={inputStyle}
+            />
+          </label>
+          {formError && (
+            <div role="alert" style={errorBoxStyle}>
+              {formError}
+            </div>
+          )}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Button type="submit" disabled={saving || !formApiKey.trim()}>
+              {saving ? 'Saving…' : 'Save connection'}
+            </Button>
+          </div>
+        </form>
+      </section>
 
       {state.status === 'loading' && <p style={mutedStyle}>Loading…</p>}
 
@@ -261,4 +348,52 @@ const modalStyle: React.CSSProperties = {
   flexDirection: 'column',
   gap: '1rem',
   color: '#f5f5f5',
+};
+
+const formSectionStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #24242c',
+  borderRadius: 12,
+  padding: '1.25rem 1.5rem',
+  marginBottom: '1.5rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+};
+
+const formStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  marginTop: '0.5rem',
+};
+
+const labelStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  fontSize: '0.8rem',
+  color: '#c0c0cb',
+};
+
+const selectStyle: React.CSSProperties = {
+  background: '#0f0f13',
+  border: '1px solid #2a2a30',
+  borderRadius: 8,
+  padding: '0.5rem 0.6rem',
+  color: '#f5f5f5',
+  fontSize: '0.875rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};
+
+const inputStyle: React.CSSProperties = {
+  background: '#0f0f13',
+  border: '1px solid #2a2a30',
+  borderRadius: 8,
+  padding: '0.55rem 0.75rem',
+  color: '#f5f5f5',
+  fontSize: '0.875rem',
+  fontFamily: 'inherit',
+  outline: 'none',
 };

--- a/apps/web/src/lib/api/http.ts
+++ b/apps/web/src/lib/api/http.ts
@@ -13,7 +13,8 @@ function makeError(
   return err;
 }
 
-export async function postJson<T>(
+async function requestJson<T>(
+  method: 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   path: string,
   body: unknown,
   signal?: AbortSignal,
@@ -32,11 +33,11 @@ export async function postJson<T>(
   let res: Response;
   try {
     res = await fetch(url, {
-      method: 'POST',
+      method,
       headers: { accept: 'application/json', 'content-type': 'application/json' },
       credentials: 'include',
       cache: 'no-store',
-      body: JSON.stringify(body),
+      body: body === undefined ? undefined : JSON.stringify(body),
       signal: controller.signal,
     });
   } catch (cause) {
@@ -68,4 +69,12 @@ export async function postJson<T>(
     throw makeError(envelope.error.message, { status: res.status, code: envelope.error.code });
   }
   return envelope.data;
+}
+
+export function postJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  return requestJson<T>('POST', path, body, signal);
+}
+
+export function putJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  return requestJson<T>('PUT', path, body, signal);
 }

--- a/apps/web/src/lib/api/provider-connections.ts
+++ b/apps/web/src/lib/api/provider-connections.ts
@@ -1,7 +1,20 @@
-import type { ApiResponse, ProviderConnection } from '@webapp/types';
+import type { AIProvider, ApiResponse, ProviderConnection } from '@webapp/types';
 import { API_PROVIDER_CONNECTIONS_PATH } from '@webapp/types';
 import { apiFetch, type ApiCallError } from '@/lib/api/client';
 import { getApiBaseUrl } from '@/lib/api/env';
+import { putJson } from '@/lib/api/http';
+
+export function upsertProviderConnection(
+  provider: AIProvider,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<ProviderConnection> {
+  return putJson<ProviderConnection>(
+    `${API_PROVIDER_CONNECTIONS_PATH}/${encodeURIComponent(provider)}`,
+    { apiKey },
+    signal,
+  );
+}
 
 export function listProviderConnections(signal?: AbortSignal): Promise<ProviderConnection[]> {
   return apiFetch<ProviderConnection[]>(


### PR DESCRIPTION
Closes #36

Plan approved upstream (option a: label field omitted until backend exposes it).

## Summary
Adds an **Add connection** form above the existing list on `/settings/providers`. Provider select + password key input. On submit: PUT `/v1/provider-connections/:provider`, clear key from state, refetch list, toast result. Key is never persisted client-side.

## Acceptance criteria
- [x] Form on `/settings/providers`: provider select, api key (password field)
  - Label input omitted: backend has no `label` column (see plan + delta-18-001)
- [x] On submit: POST (PUT in practice), clear key from state, refetch list
- [x] Key never written to localStorage, Redux, or URL

## UX decisions
- **Form placement**: boxed section above the table, same visual weight as the table. Makes the add flow discoverable without stealing focus.
- **Submit button gating**: disabled while empty OR while saving. "Saving…" label while in flight.
- **Inline validation**: empty-key submit sets `formError`; error clears as the user types again.
- **Two error surfaces**: inline text (for keyboard-focused flow) + toast (for background awareness). Both carry the backend `code + message` when available.
- **autoComplete="off"** + `spellCheck={false}` on the key input; type is `password`. No Apple Keychain prompt for a non-login password field.
- **Form behavior on success**: only the `apiKey` is cleared. Provider stays selected, so repeated adds for different providers require one click.

## Edge cases handled
| Case | Behavior |
|---|---|
| Empty key | Submit shows inline `API key is required.`; toast not fired |
| Whitespace-only key | Treated as empty (`trim()` before send) |
| Backend 400 (bad key format) | Inline error + toast with backend code/message |
| Backend 412/502 (provider error) | Inline error + toast with backend code/message |
| Network error | Same — code `network_error` |
| Duplicate existing provider | PUT is an upsert — silently overwrites, success toast |
| Typing after an error | Error clears on keystroke |
| User submits twice rapidly | Button disabled after first submit (`saving` flag); input also disabled |
| List refetch after save fails | Toast already fired for the upsert; table renders with its own `state.status === 'error'` path |

## Security posture
- Key lives in `useState` (local component scope) between keystroke and submit.
- Cleared to `''` immediately after successful PUT.
- Input is `type="password"` — DOM value is masked; `autoComplete="off"`.
- No dependency on global/shared state, no URL-encoding, no storage writes.

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green (`/settings/providers` 3.58 → 4.42 kB)
- `pnpm --filter @webapp/web lint` — `✔ No ESLint warnings or errors`
- Manual:
  - valid submit → success toast, row appears, password field cleared
  - invalid key → inline error + red toast with backend code
  - network drop → inline error + toast
  - DevTools: no `apiKey` in `localStorage`, `sessionStorage`, or URL

## Out of scope
- Masking / reveal of existing stored keys (never returned by backend).
- Label input + backend `label` column (tracked via `delta-18-001`).