### PR TITLE
feat(api): body validation for all POST controllers via parseJsonBody

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -1,7 +1,6 @@
 import type { SafeUser } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondError,
   respondRateLimited,
@@ -9,6 +8,7 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { RateLimiter, type RateLimitResult } from '../lib/rate-limiter.js';
 import { hashPassword, verifyPassword } from '../lib/password.js';
 import { generateSessionToken, hashSessionToken, sessionExpiresAt } from '../lib/session-token.js';
@@ -82,28 +82,31 @@ function cookieHeader(token: string): Record<string, string> {
   return { 'Set-Cookie': serializeSetCookie(SESSION_COOKIE_NAME, token, secure) };
 }
 
+// ── Body schemas ──────────────────────────────────────────────────────────────
+
+const SignupBody = s.object({
+  email:       s.string({ min: 1, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/, trim: true }),
+  password:    s.string({ min: 8, max: 200 }),
+  displayName: s.optional(s.string({ min: 1, max: 100, trim: true })),
+});
+
+const LoginBody = s.object({
+  email:    s.string({ min: 1, trim: true }),
+  password: s.string({ min: 1 }),
+});
+
 // ── Controllers ───────────────────────────────────────────────────────────────
 
 export async function signupController(ctx: RequestContext, deps: AuthDeps): Promise<InternalResult> {
   const rl = deps.checkRateLimit(getClientIp(ctx.req));
   if (!rl.ok) return respondRateLimited(rl.retryAfterSecs);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, SignupBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-
-  const email    = typeof body.email    === 'string' ? body.email.trim().toLowerCase()    : '';
-  const password = typeof body.password === 'string' ? body.password                      : '';
-  const rawName  = typeof body.displayName === 'string' ? body.displayName.trim() : undefined;
-
-  if (!email || !email.includes('@')) {
-    return respondError('validation_error', 'email is required and must be a valid email address');
-  }
-  if (password.length < 8) {
-    return respondError('validation_error', 'password must be at least 8 characters');
-  }
+  const email = body.value.email.toLowerCase();
+  const password = body.value.password;
+  const displayName = body.value.displayName;
 
   const existing = await deps.findUserByEmail(email);
   if (existing) {
@@ -111,7 +114,6 @@ export async function signupController(ctx: RequestContext, deps: AuthDeps): Pro
   }
 
   const passwordHash  = await hashPassword(password);
-  const displayName   = rawName || undefined;
   const user          = await deps.createUser(email, passwordHash, displayName);
 
   const token     = generateSessionToken();
@@ -125,18 +127,11 @@ export async function loginController(ctx: RequestContext, deps: AuthDeps): Prom
   const rl = deps.checkRateLimit(getClientIp(ctx.req));
   if (!rl.ok) return respondRateLimited(rl.retryAfterSecs);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, LoginBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-
-  const email    = typeof body.email    === 'string' ? body.email.trim().toLowerCase() : '';
-  const password = typeof body.password === 'string' ? body.password                   : '';
-
-  if (!email || !password) {
-    return respondError('validation_error', 'email and password are required');
-  }
+  const email = body.value.email.toLowerCase();
+  const password = body.value.password;
 
   const user  = await deps.findUserByEmail(email);
   const valid = user ? await verifyPassword(password, user.passwordHash) : false;

--- a/apps/api/src/controllers/chat-windows-db.controller.ts
+++ b/apps/api/src/controllers/chat-windows-db.controller.ts
@@ -2,8 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { AIProvider, ChatWindow } from '@webapp/types';
 import { getChatWindowPath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -11,6 +10,7 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db } from '../db/chat-windows.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
@@ -50,13 +50,16 @@ export function makeChatWindowsDeps(db: Db, sessionDeps: SessionDeps): ChatWindo
   };
 }
 
-// ── Validation ────────────────────────────────────────────────────────────────
+// ── Body schemas ──────────────────────────────────────────────────────────────
 
-const AI_PROVIDERS: AIProvider[] = ['openai', 'anthropic', 'perplexity'];
+const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
 
-function isAIProvider(v: unknown): v is AIProvider {
-  return AI_PROVIDERS.includes(v as AIProvider);
-}
+const CreateChatWindowDbBody = s.object({
+  workspaceId: s.string({ min: 1 }),
+  title:       s.string({ min: 1, max: 200, trim: true }),
+  provider:    s.enumOf<AIProvider>(AI_PROVIDERS),
+  model:       s.string({ min: 1, max: 200, trim: true }),
+});
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
@@ -96,32 +99,17 @@ export async function createChatWindowDbController(
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
-
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.workspaceId !== 'string' || !body.workspaceId) {
-    return respondError('validation_error', 'workspaceId is required');
-  }
-  if (typeof body.title !== 'string' || !body.title.trim()) {
-    return respondError('validation_error', 'title is required and must be a non-empty string');
-  }
-  if (!isAIProvider(body.provider)) {
-    return respondError('validation_error', `provider must be one of: ${AI_PROVIDERS.join(', ')}`);
-  }
-  if (typeof body.model !== 'string' || !body.model.trim()) {
-    return respondError('validation_error', 'model is required and must be a non-empty string');
-  }
+  const body = await parseJsonBody(ctx, CreateChatWindowDbBody);
+  if (!body.ok) return body.result;
 
   const row = await deps.createChatWindow(
-    body.workspaceId,
+    body.value.workspaceId,
     user.id,
-    body.title.trim(),
-    body.provider as AIProvider,
-    body.model.trim(),
+    body.value.title,
+    body.value.provider,
+    body.value.model,
   );
-  if (row === null) return respondNotFound(`Workspace ${body.workspaceId} not found`);
+  if (row === null) return respondNotFound(`Workspace ${body.value.workspaceId} not found`);
   const cw = toChatWindow(row);
   return respondCreated(cw, getChatWindowPath(cw.id));
 }

--- a/apps/api/src/controllers/chat-windows.controller.ts
+++ b/apps/api/src/controllers/chat-windows.controller.ts
@@ -1,8 +1,7 @@
-import type { AIProvider, ChatWindow, CreateChatWindowInput } from '@webapp/types';
+import type { AIProvider, ChatWindow } from '@webapp/types';
 import { getChatWindowPath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -10,14 +9,18 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { createChatWindow, findChatWindow, listChatWindows } from '../services/chat-windows.service.js';
 import { workspaceExists } from '../services/workspaces.service.js';
 
-const AI_PROVIDERS: AIProvider[] = ['openai', 'anthropic', 'perplexity'];
+const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
 
-function isAIProvider(v: unknown): v is AIProvider {
-  return AI_PROVIDERS.includes(v as AIProvider);
-}
+const CreateChatWindowBody = s.object({
+  workspaceId: s.string({ min: 1 }),
+  title:       s.string({ min: 1, max: 200, trim: true }),
+  provider:    s.enumOf<AIProvider>(AI_PROVIDERS),
+  model:       s.string({ min: 1, max: 200, trim: true }),
+});
 
 export function listChatWindowsController(ctx: RequestContext): InternalResult {
   const workspaceId = ctx.url.searchParams.get('workspaceId');
@@ -28,31 +31,19 @@ export function listChatWindowsController(ctx: RequestContext): InternalResult {
 }
 
 export async function createChatWindowController(ctx: RequestContext): Promise<InternalResult> {
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateChatWindowBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.workspaceId !== 'string' || !body.workspaceId) {
-    return respondError('validation_error', 'workspaceId is required');
-  }
-  if (typeof body.title !== 'string' || !body.title.trim()) {
-    return respondError('validation_error', 'title is required and must be a non-empty string');
-  }
-  if (!isAIProvider(body.provider)) {
-    return respondError('validation_error', `provider must be one of: ${AI_PROVIDERS.join(', ')}`);
-  }
-  if (typeof body.model !== 'string' || !body.model.trim()) {
-    return respondError('validation_error', 'model is required and must be a non-empty string');
+  if (!workspaceExists(body.value.workspaceId)) {
+    return respondNotFound(`Workspace ${body.value.workspaceId} not found`);
   }
 
-  const input = body as unknown as CreateChatWindowInput;
-
-  if (!workspaceExists(input.workspaceId)) {
-    return respondNotFound(`Workspace ${input.workspaceId} not found`);
-  }
-
-  const cw: ChatWindow = createChatWindow(input.workspaceId, input.title.trim(), input.provider, input.model.trim());
+  const cw: ChatWindow = createChatWindow(
+    body.value.workspaceId,
+    body.value.title,
+    body.value.provider,
+    body.value.model,
+  );
   return respondCreated(cw, getChatWindowPath(cw.id));
 }
 

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -2,8 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { AIProvider, Message, MessageRole } from '@webapp/types';
 import { getMessagePath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -11,6 +10,7 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import { env } from '../config/env.js';
 import type { Db, AssistantMessageMetadata } from '../db/messages.repo.js';
@@ -97,11 +97,13 @@ export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps
 
 // ── Validation ────────────────────────────────────────────────────────────────
 
-const MESSAGE_ROLES: MessageRole[] = ['user', 'assistant', 'system'];
+const MESSAGE_ROLES = ['user', 'assistant', 'system'] as const;
 
-function isMessageRole(v: unknown): v is MessageRole {
-  return MESSAGE_ROLES.includes(v as MessageRole);
-}
+const CreateMessageDbBody = s.object({
+  chatWindowId: s.string({ min: 1 }),
+  role:         s.enumOf<MessageRole>(MESSAGE_ROLES),
+  content:      s.string({ min: 1, max: 32_000 }),
+});
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
@@ -144,24 +146,12 @@ export async function createMessageDbController(
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateMessageDbBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.chatWindowId !== 'string' || !body.chatWindowId) {
-    return respondError('validation_error', 'chatWindowId is required');
-  }
-  if (!isMessageRole(body.role)) {
-    return respondError('validation_error', `role must be one of: ${MESSAGE_ROLES.join(', ')}`);
-  }
-  if (typeof body.content !== 'string' || !body.content) {
-    return respondError('validation_error', 'content is required and must be a non-empty string');
-  }
-
-  const chatWindowId = body.chatWindowId;
-  const role = body.role as MessageRole;
-  const content = body.content;
+  const chatWindowId = body.value.chatWindowId;
+  const role = body.value.role;
+  const content = body.value.content;
 
   // For user messages: resolve the chat window to determine whether to trigger AI generation.
   if (role === 'user') {

--- a/apps/api/src/controllers/messages.controller.ts
+++ b/apps/api/src/controllers/messages.controller.ts
@@ -1,8 +1,7 @@
-import type { CreateMessageInput, Message, MessageRole } from '@webapp/types';
+import type { Message, MessageRole } from '@webapp/types';
 import { getMessagePath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -10,14 +9,17 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { chatWindowExists } from '../services/chat-windows.service.js';
 import { createMessage, findMessage, listMessages } from '../services/messages.service.js';
 
-const MESSAGE_ROLES: MessageRole[] = ['user', 'assistant', 'system'];
+const MESSAGE_ROLES = ['user', 'assistant', 'system'] as const;
 
-function isMessageRole(v: unknown): v is MessageRole {
-  return MESSAGE_ROLES.includes(v as MessageRole);
-}
+const CreateMessageBody = s.object({
+  chatWindowId: s.string({ min: 1 }),
+  role:         s.enumOf<MessageRole>(MESSAGE_ROLES),
+  content:      s.string({ min: 1, max: 32_000 }),
+});
 
 export function listMessagesController(ctx: RequestContext): InternalResult {
   const chatWindowId = ctx.url.searchParams.get('chatWindowId');
@@ -28,28 +30,14 @@ export function listMessagesController(ctx: RequestContext): InternalResult {
 }
 
 export async function createMessageController(ctx: RequestContext): Promise<InternalResult> {
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateMessageBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.chatWindowId !== 'string' || !body.chatWindowId) {
-    return respondError('validation_error', 'chatWindowId is required');
-  }
-  if (!isMessageRole(body.role)) {
-    return respondError('validation_error', `role must be one of: ${MESSAGE_ROLES.join(', ')}`);
-  }
-  if (typeof body.content !== 'string' || !body.content) {
-    return respondError('validation_error', 'content is required and must be a non-empty string');
+  if (!chatWindowExists(body.value.chatWindowId)) {
+    return respondNotFound(`ChatWindow ${body.value.chatWindowId} not found`);
   }
 
-  const input = body as unknown as CreateMessageInput;
-
-  if (!chatWindowExists(input.chatWindowId)) {
-    return respondNotFound(`ChatWindow ${input.chatWindowId} not found`);
-  }
-
-  const msg: Message = createMessage(input.chatWindowId, input.role, input.content);
+  const msg: Message = createMessage(body.value.chatWindowId, body.value.role, body.value.content);
   return respondCreated(msg, getMessagePath(msg.id));
 }
 

--- a/apps/api/src/controllers/projects-db.controller.ts
+++ b/apps/api/src/controllers/projects-db.controller.ts
@@ -2,8 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Project } from '@webapp/types';
 import { getProjectPath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -11,9 +10,17 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db } from '../db/projects.repo.js';
 import * as projectsRepo from '../db/projects.repo.js';
+
+// ── Body schemas ──────────────────────────────────────────────────────────────
+
+const CreateProjectDbBody = s.object({
+  name:        s.string({ min: 1, max: 200, trim: true }),
+  description: s.optional(s.nullable(s.string({ max: 2000 }))),
+});
 
 // ── Internal DB row shape ──────────────────────────────────────────────────────
 
@@ -81,17 +88,10 @@ export async function createProjectDbController(
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateProjectDbBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.name !== 'string' || !body.name.trim()) {
-    return respondError('validation_error', 'name is required and must be a non-empty string');
-  }
-
-  const description = typeof body.description === 'string' ? body.description : undefined;
-  const row = await deps.createProject(user.id, body.name.trim(), description);
+  const row = await deps.createProject(user.id, body.value.name, body.value.description ?? undefined);
   const project = toProject(row);
   return respondCreated(project, getProjectPath(project.id));
 }

--- a/apps/api/src/controllers/projects.controller.ts
+++ b/apps/api/src/controllers/projects.controller.ts
@@ -1,33 +1,30 @@
-import type { CreateProjectInput, Project } from '@webapp/types';
+import type { Project } from '@webapp/types';
 import { getProjectPath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
-  respondError,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { createProject, findProject, listProjects } from '../services/projects.service.js';
+
+const CreateProjectBody = s.object({
+  name:        s.string({ min: 1, max: 200, trim: true }),
+  description: s.optional(s.nullable(s.string({ max: 2000 }))),
+});
 
 export function listProjectsController(_ctx: RequestContext): InternalResult {
   return respond(listProjects());
 }
 
 export async function createProjectController(ctx: RequestContext): Promise<InternalResult> {
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateProjectBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.name !== 'string' || !body.name.trim()) {
-    return respondError('validation_error', 'name is required and must be a non-empty string');
-  }
-
-  const input = body as unknown as CreateProjectInput;
-  const project: Project = createProject(input.name.trim(), input.description);
+  const project: Project = createProject(body.value.name, body.value.description ?? undefined);
   return respondCreated(project, getProjectPath(project.id));
 }
 

--- a/apps/api/src/controllers/provider-connections.controller.ts
+++ b/apps/api/src/controllers/provider-connections.controller.ts
@@ -1,8 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 import type { AIProvider, ProviderConnection } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondError,
   respondNotFound,
@@ -10,6 +9,7 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ProviderConnectionMeta } from '../db/provider-connections.repo.js';
 import * as providerRepo from '../db/provider-connections.repo.js';
@@ -18,6 +18,10 @@ import { RateLimiter, type RateLimitResult } from '../lib/rate-limiter.js';
 
 const VALID_PROVIDERS = new Set<AIProvider>(['openai', 'anthropic', 'perplexity']);
 const ENABLED_PROVIDERS = new Set<AIProvider>(['openai']);
+
+const UpsertConnectionBody = s.object({
+  apiKey: s.string({ min: 1, max: 500, trim: true }),
+});
 
 interface SessionDeps {
   findSessionByTokenHash: (hash: string) => Promise<{ userId: string; expiresAt: Date } | null>;
@@ -105,14 +109,9 @@ export async function upsertConnectionController(
   if (!ENABLED_PROVIDERS.has(provider)) {
     return respondError('validation_error', `Provider '${provider}' is not yet supported`, 400);
   }
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body['apiKey'] !== 'string' || !body['apiKey'].trim()) {
-    return respondError('validation_error', 'apiKey is required and must be a non-empty string');
-  }
-  const apiKey = body['apiKey'].trim();
+  const body = await parseJsonBody(ctx, UpsertConnectionBody);
+  if (!body.ok) return body.result;
+  const apiKey = body.value.apiKey;
   const verifyResult = await deps.verifyKey(provider, apiKey);
   if (verifyResult === 'unauthorized') {
     return respondError('provider_auth_error', 'API key is invalid or unauthorized', 401);

--- a/apps/api/src/controllers/workspaces-db.controller.ts
+++ b/apps/api/src/controllers/workspaces-db.controller.ts
@@ -2,8 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Workspace } from '@webapp/types';
 import { getWorkspacePath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -11,6 +10,12 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
+
+const CreateWorkspaceDbBody = s.object({
+  projectId: s.string({ min: 1 }),
+  name:      s.string({ min: 1, max: 200, trim: true }),
+});
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db } from '../db/workspaces.repo.js';
 import * as workspacesRepo from '../db/workspaces.repo.js';
@@ -100,20 +105,11 @@ export async function createWorkspaceDbController(
   const user = await deps.resolveUser(ctx.req);
   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateWorkspaceDbBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.projectId !== 'string' || !body.projectId) {
-    return respondError('validation_error', 'projectId is required');
-  }
-  if (typeof body.name !== 'string' || !body.name.trim()) {
-    return respondError('validation_error', 'name is required and must be a non-empty string');
-  }
-
-  const row = await deps.createWorkspace(body.projectId, user.id, body.name.trim());
-  if (row === null) return respondNotFound(`Project ${body.projectId} not found`);
+  const row = await deps.createWorkspace(body.value.projectId, user.id, body.value.name);
+  if (row === null) return respondNotFound(`Project ${body.value.projectId} not found`);
   return respondCreated(toWorkspace(row, []), getWorkspacePath(row.id));
 }
 

--- a/apps/api/src/controllers/workspaces.controller.ts
+++ b/apps/api/src/controllers/workspaces.controller.ts
@@ -1,8 +1,7 @@
-import type { CreateWorkspaceInput, Workspace } from '@webapp/types';
+import type { Workspace } from '@webapp/types';
 import { getWorkspacePath } from '@webapp/types';
 import {
-  isRecord,
-  readJsonBody,
+  parseJsonBody,
   respond,
   respondCreated,
   respondError,
@@ -10,8 +9,14 @@ import {
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { s } from '../lib/schema.js';
 import { projectExists } from '../services/projects.service.js';
 import { createWorkspace, findWorkspace, listWorkspaces } from '../services/workspaces.service.js';
+
+const CreateWorkspaceBody = s.object({
+  projectId: s.string({ min: 1 }),
+  name:      s.string({ min: 1, max: 200, trim: true }),
+});
 
 export function listWorkspacesController(ctx: RequestContext): InternalResult {
   const projectId = ctx.url.searchParams.get('projectId');
@@ -22,25 +27,14 @@ export function listWorkspacesController(ctx: RequestContext): InternalResult {
 }
 
 export async function createWorkspaceController(ctx: RequestContext): Promise<InternalResult> {
-  const bodyResult = await readJsonBody(ctx.req);
-  if (!bodyResult.ok) return bodyResult.result;
-  const body = bodyResult.data;
+  const body = await parseJsonBody(ctx, CreateWorkspaceBody);
+  if (!body.ok) return body.result;
 
-  if (!isRecord(body)) return respondError('validation_error', 'Body must be a JSON object');
-  if (typeof body.projectId !== 'string' || !body.projectId) {
-    return respondError('validation_error', 'projectId is required');
-  }
-  if (typeof body.name !== 'string' || !body.name.trim()) {
-    return respondError('validation_error', 'name is required and must be a non-empty string');
+  if (!projectExists(body.value.projectId)) {
+    return respondNotFound(`Project ${body.value.projectId} not found`);
   }
 
-  const input = body as unknown as CreateWorkspaceInput;
-
-  if (!projectExists(input.projectId)) {
-    return respondNotFound(`Project ${input.projectId} not found`);
-  }
-
-  const ws: Workspace = createWorkspace(input.projectId, input.name.trim());
+  const ws: Workspace = createWorkspace(body.value.projectId, body.value.name);
   return respondCreated(ws, getWorkspacePath(ws.id));
 }
 

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ApiError, ApiErrorCode, ApiResponse } from '@webapp/types';
 import { env } from '../config/env.js';
+import type { Schema } from './schema.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS';
 
@@ -149,4 +150,30 @@ export async function readJsonBody(
     }
     return { ok: false, result: respondError('invalid_json', 'Request body must be valid JSON') };
   }
+}
+
+/**
+ * Reads the request body, parses JSON, then validates against `schema`.
+ * On success: `{ ok: true; value: T }`.
+ * On failure: `{ ok: false; result: InternalResult }` — already-formed 4xx
+ * `ApiResponse` carrying either the transport error (415/413/400 invalid_json)
+ * or a 400 `invalid_body` envelope listing the offending fields.
+ */
+export async function parseJsonBody<T>(
+  ctx: { req: IncomingMessage },
+  schema: Schema<T>,
+): Promise<{ ok: true; value: T } | { ok: false; result: InternalResult }> {
+  const body = await readJsonBody(ctx.req);
+  if (!body.ok) return { ok: false, result: body.result };
+  const parsed = schema.parse(body.data);
+  if (parsed.ok) return { ok: true, value: parsed.value };
+  return {
+    ok: false,
+    result: respondError(
+      'invalid_body',
+      'Request body failed validation',
+      400,
+      { fields: parsed.errors },
+    ),
+  };
 }

--- a/apps/api/src/lib/schema.test.ts
+++ b/apps/api/src/lib/schema.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { s } from './schema.js';
+
+describe('schema.string', () => {
+  it('accepts a plain string', () => {
+    expect(s.string().parse('hi')).toEqual({ ok: true, value: 'hi' });
+  });
+
+  it('rejects a non-string with the field path', () => {
+    const r = s.string().parse(42, 'name');
+    expect(r).toEqual({ ok: false, errors: [{ path: 'name', message: 'must be a string' }] });
+  });
+
+  it('enforces min, max, and pattern', () => {
+    expect(s.string({ min: 3 }).parse('ab', 'x').ok).toBe(false);
+    expect(s.string({ max: 2 }).parse('abc', 'x').ok).toBe(false);
+    expect(s.string({ pattern: /^[a-z]+$/ }).parse('A1', 'x').ok).toBe(false);
+  });
+
+  it('trims when asked', () => {
+    expect(s.string({ trim: true }).parse('  hi  ')).toEqual({ ok: true, value: 'hi' });
+  });
+});
+
+describe('schema.number', () => {
+  it('rejects NaN and non-numbers', () => {
+    expect(s.number().parse(NaN, 'n').ok).toBe(false);
+    expect(s.number().parse('1', 'n').ok).toBe(false);
+  });
+
+  it('enforces int + range', () => {
+    expect(s.number({ int: true }).parse(1.5, 'n').ok).toBe(false);
+    expect(s.number({ min: 0, max: 10 }).parse(11, 'n').ok).toBe(false);
+  });
+});
+
+describe('schema.enumOf', () => {
+  it('accepts only listed values', () => {
+    const sch = s.enumOf(['a', 'b'] as const);
+    expect(sch.parse('a').ok).toBe(true);
+    expect(sch.parse('c', 'kind').ok).toBe(false);
+  });
+});
+
+describe('schema.optional', () => {
+  it('accepts undefined and delegates otherwise', () => {
+    const sch = s.optional(s.string({ min: 1 }));
+    expect(sch.parse(undefined)).toEqual({ ok: true, value: undefined });
+    expect(sch.parse('a')).toEqual({ ok: true, value: 'a' });
+    expect(sch.parse('', 'x').ok).toBe(false);
+  });
+});
+
+describe('schema.nullable', () => {
+  it('accepts null', () => {
+    expect(s.nullable(s.string()).parse(null)).toEqual({ ok: true, value: null });
+  });
+});
+
+describe('schema.array', () => {
+  it('reports per-item errors with indexed paths', () => {
+    const sch = s.array(s.string());
+    const r = sch.parse(['ok', 1]);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected fail');
+    expect(r.errors).toEqual([{ path: '[1]', message: 'must be a string' }]);
+  });
+});
+
+describe('schema.object', () => {
+  const Body = s.object({
+    name: s.string({ min: 1 }),
+    age: s.optional(s.number({ int: true, min: 0 })),
+  });
+
+  it('accepts a valid body', () => {
+    expect(Body.parse({ name: 'A', age: 1 })).toEqual({ ok: true, value: { name: 'A', age: 1 } });
+  });
+
+  it('drops missing optional fields cleanly', () => {
+    const r = Body.parse({ name: 'A' });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.value).toEqual({ name: 'A' });
+  });
+
+  it('aggregates errors with dotted paths', () => {
+    const r = Body.parse({ name: '', age: -1 });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected fail');
+    expect(r.errors.map((e) => e.path).sort()).toEqual(['age', 'name']);
+  });
+
+  it('rejects non-objects', () => {
+    expect(Body.parse([]).ok).toBe(false);
+    expect(Body.parse(null).ok).toBe(false);
+    expect(Body.parse('x').ok).toBe(false);
+  });
+});

--- a/apps/api/src/lib/schema.ts
+++ b/apps/api/src/lib/schema.ts
@@ -1,0 +1,143 @@
+export interface FieldError {
+  path: string;
+  message: string;
+}
+
+export type SchemaResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: FieldError[] };
+
+export interface Schema<T> {
+  parse(raw: unknown, path?: string): SchemaResult<T>;
+}
+
+function err(path: string, message: string): { ok: false; errors: FieldError[] } {
+  return { ok: false, errors: [{ path, message }] };
+}
+
+export const s = {
+  string(opts: { min?: number; max?: number; pattern?: RegExp; trim?: boolean } = {}): Schema<string> {
+    return {
+      parse(raw, path = '') {
+        if (typeof raw !== 'string') return err(path, 'must be a string');
+        const value = opts.trim ? raw.trim() : raw;
+        if (opts.min !== undefined && value.length < opts.min) {
+          return err(path, `must be at least ${opts.min} character(s)`);
+        }
+        if (opts.max !== undefined && value.length > opts.max) {
+          return err(path, `must be at most ${opts.max} character(s)`);
+        }
+        if (opts.pattern && !opts.pattern.test(value)) {
+          return err(path, 'has invalid format');
+        }
+        return { ok: true, value };
+      },
+    };
+  },
+
+  number(opts: { int?: boolean; min?: number; max?: number } = {}): Schema<number> {
+    return {
+      parse(raw, path = '') {
+        if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+          return err(path, 'must be a finite number');
+        }
+        if (opts.int && !Number.isInteger(raw)) return err(path, 'must be an integer');
+        if (opts.min !== undefined && raw < opts.min) return err(path, `must be ≥ ${opts.min}`);
+        if (opts.max !== undefined && raw > opts.max) return err(path, `must be ≤ ${opts.max}`);
+        return { ok: true, value: raw };
+      },
+    };
+  },
+
+  boolean(): Schema<boolean> {
+    return {
+      parse(raw, path = '') {
+        if (typeof raw !== 'boolean') return err(path, 'must be a boolean');
+        return { ok: true, value: raw };
+      },
+    };
+  },
+
+  literal<L extends string | number | boolean>(value: L): Schema<L> {
+    return {
+      parse(raw, path = '') {
+        if (raw !== value) return err(path, `must equal ${JSON.stringify(value)}`);
+        return { ok: true, value };
+      },
+    };
+  },
+
+  enumOf<L extends string>(values: readonly L[]): Schema<L> {
+    return {
+      parse(raw, path = '') {
+        if (typeof raw !== 'string' || !values.includes(raw as L)) {
+          return err(path, `must be one of ${values.map((v) => `"${v}"`).join(', ')}`);
+        }
+        return { ok: true, value: raw as L };
+      },
+    };
+  },
+
+  optional<T>(inner: Schema<T>): Schema<T | undefined> {
+    return {
+      parse(raw, path = '') {
+        if (raw === undefined) return { ok: true, value: undefined };
+        return inner.parse(raw, path);
+      },
+    };
+  },
+
+  nullable<T>(inner: Schema<T>): Schema<T | null> {
+    return {
+      parse(raw, path = '') {
+        if (raw === null) return { ok: true, value: null };
+        return inner.parse(raw, path);
+      },
+    };
+  },
+
+  array<T>(inner: Schema<T>, opts: { min?: number; max?: number } = {}): Schema<T[]> {
+    return {
+      parse(raw, path = '') {
+        if (!Array.isArray(raw)) return err(path, 'must be an array');
+        if (opts.min !== undefined && raw.length < opts.min) {
+          return err(path, `must have at least ${opts.min} item(s)`);
+        }
+        if (opts.max !== undefined && raw.length > opts.max) {
+          return err(path, `must have at most ${opts.max} item(s)`);
+        }
+        const out: T[] = [];
+        const errs: FieldError[] = [];
+        raw.forEach((item, i) => {
+          const r = inner.parse(item, path === '' ? `[${i}]` : `${path}[${i}]`);
+          if (r.ok) out.push(r.value);
+          else errs.push(...r.errors);
+        });
+        return errs.length === 0 ? { ok: true, value: out } : { ok: false, errors: errs };
+      },
+    };
+  },
+
+  object<T extends Record<string, unknown>>(shape: { [K in keyof T]: Schema<T[K]> }): Schema<T> {
+    return {
+      parse(raw, path = '') {
+        if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+          return err(path, 'must be a JSON object');
+        }
+        const src = raw as Record<string, unknown>;
+        const out: Partial<T> = {};
+        const errs: FieldError[] = [];
+        for (const key of Object.keys(shape) as (keyof T)[]) {
+          const childPath = path === '' ? String(key) : `${path}.${String(key)}`;
+          const r = shape[key].parse(src[key as string], childPath);
+          if (r.ok) {
+            if (r.value !== undefined) out[key] = r.value;
+          } else {
+            errs.push(...r.errors);
+          }
+        }
+        return errs.length === 0 ? { ok: true, value: out as T } : { ok: false, errors: errs };
+      },
+    };
+  },
+};

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -112,21 +112,21 @@ describe('POST /v1/auth/signup', () => {
     expect(body.data.email).toBe('alice@example.com');
   });
 
-  it('returns 400 for missing email', async () => {
+  it('returns 400 invalid_body for missing email', async () => {
     const res = await post(base, '/v1/auth/signup', { password: 'password123' });
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 
-  it('returns 400 for short password', async () => {
+  it('returns 400 invalid_body for short password', async () => {
     const res = await post(base, '/v1/auth/signup', { email: 'a@b.com', password: 'short' });
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 
   it('returns 409 for duplicate email', async () => {

--- a/apps/api/src/routes/chat-windows.test.ts
+++ b/apps/api/src/routes/chat-windows.test.ts
@@ -103,7 +103,7 @@ describe('POST /v1/chat-windows', () => {
     expect(body.error.code).toBe('not_found');
   });
 
-  it('returns 400 for invalid provider', async () => {
+  it('returns 400 invalid_body for invalid provider', async () => {
     const ws = await createWorkspace(harness.baseUrl);
     const res = await fetch(`${harness.baseUrl}/v1/chat-windows`, {
       method: 'POST',
@@ -114,6 +114,6 @@ describe('POST /v1/chat-windows', () => {
     const body = (await res.json()) as ApiResponse<unknown>;
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 });

--- a/apps/api/src/routes/messages.test.ts
+++ b/apps/api/src/routes/messages.test.ts
@@ -117,7 +117,7 @@ describe('POST /v1/messages', () => {
     expect(body.error.code).toBe('not_found');
   });
 
-  it('returns 400 for invalid role', async () => {
+  it('returns 400 invalid_body for invalid role', async () => {
     const ws = await createWorkspace(harness.baseUrl);
     const cw = await createChatWindow(harness.baseUrl, ws.id);
     const res = await fetch(`${harness.baseUrl}/v1/messages`, {
@@ -129,6 +129,6 @@ describe('POST /v1/messages', () => {
     const body = (await res.json()) as ApiResponse<unknown>;
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 });

--- a/apps/api/src/routes/projects-db.test.ts
+++ b/apps/api/src/routes/projects-db.test.ts
@@ -145,13 +145,13 @@ describe('POST /v1/projects — authenticated', () => {
     await close();
   });
 
-  it('returns 400 when name is missing', async () => {
+  it('returns 400 invalid_body when name is missing', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await post(baseUrl, '/v1/projects', { description: 'no name' });
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
     await close();
   });
 });

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -75,7 +75,7 @@ describe('POST /v1/projects', () => {
     expect(body.ok).toBe(true);
   });
 
-  it('returns 400 when name is missing', async () => {
+  it('returns 400 invalid_body when name is missing', async () => {
     const res = await fetch(`${harness.baseUrl}/v1/projects`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -85,7 +85,7 @@ describe('POST /v1/projects', () => {
     const body = (await res.json()) as ApiResponse<unknown>;
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -126,5 +126,21 @@ describe('POST /v1/projects', () => {
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('payload_too_large');
+  });
+
+  it('invalid_body envelope carries a fields list with the offending paths', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '', description: 42 }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<unknown>;
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('invalid_body');
+    const details = body.error.details as { fields: { path: string; message: string }[] };
+    expect(Array.isArray(details.fields)).toBe(true);
+    const paths = details.fields.map((f) => f.path).sort();
+    expect(paths).toEqual(['description', 'name']);
   });
 });

--- a/apps/api/src/routes/provider-connections.test.ts
+++ b/apps/api/src/routes/provider-connections.test.ts
@@ -221,13 +221,13 @@ describe('PUT /v1/provider-connections/:provider — authenticated', () => {
     await close();
   });
 
-  it('returns 400 when apiKey is missing', async () => {
+  it('returns 400 invalid_body when apiKey is missing', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await put(baseUrl, '/v1/provider-connections/openai', {});
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
     await close();
   });
 

--- a/apps/api/src/routes/workspaces-db.test.ts
+++ b/apps/api/src/routes/workspaces-db.test.ts
@@ -150,13 +150,13 @@ describe('POST /v1/workspaces — authenticated', () => {
     await close();
   });
 
-  it('returns 400 when name is missing', async () => {
+  it('returns 400 invalid_body when name is missing', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await post(baseUrl, '/v1/workspaces', { projectId: 'proj-1' });
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
     await close();
   });
 

--- a/apps/api/src/routes/workspaces.test.ts
+++ b/apps/api/src/routes/workspaces.test.ts
@@ -89,7 +89,7 @@ describe('POST /v1/workspaces', () => {
     expect(body.error.code).toBe('not_found');
   });
 
-  it('returns 400 when name is missing', async () => {
+  it('returns 400 invalid_body when name is missing', async () => {
     const res = await fetch(`${harness.baseUrl}/v1/workspaces`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -99,6 +99,6 @@ describe('POST /v1/workspaces', () => {
     const body = (await res.json()) as ApiResponse<unknown>;
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
-    expect(body.error.code).toBe('validation_error');
+    expect(body.error.code).toBe('invalid_body');
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,6 +47,7 @@ export interface Message {
 
 export type ApiErrorCode =
   | 'invalid_json'
+  | 'invalid_body'
   | 'unsupported_media_type'
   | 'payload_too_large'
   | 'validation_error'


### PR DESCRIPTION
Closes #30

## Summary
Adds a reusable schema-based validation layer (`lib/schema.ts`) and a `parseJsonBody<T>(ctx, schema)` helper (`lib/http.ts`). Every POST controller declares a typed body schema and uses `parseJsonBody` instead of ad-hoc `isRecord` / `typeof` field checks.

Bad bodies now return **400 `invalid_body`** with a `fields` list describing each offending path:

```json
{ "ok": false, "error": { "code": "invalid_body", "message": "Request body failed validation",
  "details": { "fields": [{ "path": "name", "message": "must be a string" }] } } }
```

## Acceptance criteria
- [x] Shared `parseJsonBody<T>(ctx, schema)` helper in `lib/http.ts`.
- [x] Every POST controller uses it (auth, projects, workspaces, chat-windows, messages, provider-connections — both in-memory and DB variants).
- [x] Bad body returns 400 `invalid_body` with field list (new code added to `ApiErrorCode` in `@webapp/types`).

## Design notes
- **Zero new runtime dependency.** Schema is a tiny set of combinators (`s.string`, `s.number`, `s.boolean`, `s.literal`, `s.enumOf`, `s.optional`, `s.nullable`, `s.array`, `s.object`) covering the actual validation needs. Adding zod/yup was rejected as out of scope.
- **`Schema<T>.parse(raw, path)` returns `{ ok: true; value } | { ok: false; errors }`.** Errors carry a dotted/indexed path (`name`, `[1]`, `outer.inner`) that maps directly to the response `fields` list.
- **`parseJsonBody`** layers on top of the existing `readJsonBody` so transport errors (415 unsupported media type, 413 oversized, 400 invalid_json) keep their existing codes and behaviour. Only post-parse, schema-level failures map to `invalid_body`.
- **Path/query-param checks stay as `validation_error`.** The new code is reserved for body-shape failures, matching the AC's wording.

## Test plan
- 14 new unit tests for the schema combinators (`src/lib/schema.test.ts`).
- Integration tests updated to assert `invalid_body` instead of `validation_error` on body-level failures (kept `validation_error` for query/path param tests).
- New end-to-end assertion in `projects.test.ts` that the envelope carries a `fields` list with the offending paths.
- `pnpm --filter @webapp/api test` → **243/243 passing** (228 pre-existing + 14 schema + 1 fields-list).
- `pnpm typecheck` and `pnpm build` green.

## Out of scope
- Replacing the custom router with a framework (explicitly excluded by the issue).
- Migrating the existing `validation_error` codes for query/path params to anything new.
- Replacing the bespoke schema layer with zod/yup later — non-blocking, would be its own decision.