### PR TITLE
feat(web): session guard + logout in app shell (#17)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import '@/styles/globals.css';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { ToastHost } from '@/components/ToastHost';
+import { SessionProvider } from '@/features/auth/SessionContext';
 
 export const metadata: Metadata = {
   title: 'AI Workspace V1',
@@ -13,7 +15,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body>
         <ErrorBoundary>
-          <ToastHost>{children}</ToastHost>
+          <ToastHost>
+            <Suspense fallback={null}>
+              <SessionProvider>{children}</SessionProvider>
+            </Suspense>
+          </ToastHost>
         </ErrorBoundary>
       </body>
     </html>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { UserMenu } from '@/features/auth/UserMenu';
 
 interface AppShellProps {
   title?: string;
@@ -37,7 +38,10 @@ export function AppShell({ title = 'AI Workspace V1', subtitle, right, children 
             <span style={{ fontSize: '0.875rem', color: '#8a8a95' }}>{subtitle}</span>
           ) : null}
         </div>
-        <div>{right}</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          {right}
+          <UserMenu />
+        </div>
       </header>
       <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>{children}</main>
     </div>

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -1,12 +1,20 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState, type FormEvent } from 'react';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
 import { login, register } from '@/lib/api/auth';
 import type { ApiCallError } from '@/lib/api/client';
+import { useSession } from '@/features/auth/SessionContext';
+
+function isSafeNext(value: string | null): value is string {
+  if (!value) return false;
+  if (!value.startsWith('/')) return false;
+  if (value.startsWith('//')) return false;
+  return true;
+}
 
 type Mode = 'login' | 'register';
 
@@ -53,6 +61,8 @@ function messageFor(err: ApiCallError, mode: Mode): string {
 
 export function AuthForm({ mode }: AuthFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { refresh } = useSession();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
@@ -73,7 +83,10 @@ export function AuthForm({ mode }: AuthFormProps) {
           ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
         });
       }
-      router.push('/');
+      const nextParam = searchParams?.get('next') ?? null;
+      const target = isSafeNext(nextParam) ? nextParam : '/';
+      await refresh();
+      router.replace(target);
       router.refresh();
     } catch (err) {
       setError(messageFor(err as ApiCallError, mode));

--- a/apps/web/src/features/auth/SessionContext.tsx
+++ b/apps/web/src/features/auth/SessionContext.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { SafeUser } from '@webapp/types';
+import { logout as apiLogout, me as apiMe } from '@/lib/api/auth';
+import type { ApiCallError } from '@/lib/api/client';
+import { getApiBaseUrl } from '@/lib/api/env';
+
+const PUBLIC_PATHS = new Set<string>(['/login', '/register']);
+
+function isPublic(pathname: string | null): boolean {
+  if (!pathname) return false;
+  if (PUBLIC_PATHS.has(pathname)) return true;
+  return false;
+}
+
+function isSafeNext(value: string | null | undefined): value is string {
+  if (!value) return false;
+  if (!value.startsWith('/')) return false;
+  if (value.startsWith('//')) return false;
+  return true;
+}
+
+type SessionState =
+  | { status: 'loading' }
+  | { status: 'guest' }
+  | { status: 'authenticated'; user: SafeUser }
+  | { status: 'unauthenticated' }
+  | { status: 'error'; message: string };
+
+interface SessionContextValue {
+  state: SessionState;
+  user: SafeUser | null;
+  refresh: () => Promise<void>;
+  logout: () => Promise<void>;
+  loggingOut: boolean;
+}
+
+const SessionContext = createContext<SessionContextValue | null>(null);
+
+export function useSession(): SessionContextValue {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('useSession must be used within SessionProvider');
+  return ctx;
+}
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const apiConfigured = !!getApiBaseUrl();
+
+  const [state, setState] = useState<SessionState>(() =>
+    apiConfigured ? { status: 'loading' } : { status: 'guest' },
+  );
+  const [loggingOut, setLoggingOut] = useState(false);
+
+  const load = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!apiConfigured) {
+        setState({ status: 'guest' });
+        return;
+      }
+      setState((prev) => (prev.status === 'authenticated' ? prev : { status: 'loading' }));
+      try {
+        const user = await apiMe(signal);
+        if (signal?.aborted) return;
+        setState({ status: 'authenticated', user });
+      } catch (err) {
+        if (signal?.aborted) return;
+        const e = err as ApiCallError | undefined;
+        if (e?.code === 'unauthenticated' || e?.status === 401) {
+          setState({ status: 'unauthenticated' });
+          return;
+        }
+        setState({ status: 'error', message: e?.message ?? 'Unable to verify session' });
+      }
+    },
+    [apiConfigured],
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  useEffect(() => {
+    if (state.status !== 'unauthenticated') return;
+    if (isPublic(pathname)) return;
+    const nextParam = pathname && pathname !== '/' ? pathname : null;
+    const target = nextParam ? `/login?next=${encodeURIComponent(nextParam)}` : '/login';
+    router.replace(target);
+  }, [state.status, pathname, router]);
+
+  useEffect(() => {
+    if (state.status !== 'authenticated') return;
+    if (!isPublic(pathname)) return;
+    const next = searchParams?.get('next');
+    router.replace(isSafeNext(next) ? next : '/');
+  }, [state.status, pathname, router, searchParams]);
+
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  const logout = useCallback(async () => {
+    if (loggingOut) return;
+    setLoggingOut(true);
+    try {
+      await apiLogout();
+      setState({ status: 'unauthenticated' });
+      router.replace('/login');
+    } finally {
+      setLoggingOut(false);
+    }
+  }, [loggingOut, router]);
+
+  const value = useMemo<SessionContextValue>(
+    () => ({
+      state,
+      user: state.status === 'authenticated' ? state.user : null,
+      refresh,
+      logout,
+      loggingOut,
+    }),
+    [state, refresh, logout, loggingOut],
+  );
+
+  return (
+    <SessionContext.Provider value={value}>
+      <SessionGate state={state} pathname={pathname} onRetry={refresh}>
+        {children}
+      </SessionGate>
+    </SessionContext.Provider>
+  );
+}
+
+function SessionGate({
+  state,
+  pathname,
+  children,
+  onRetry,
+}: {
+  state: SessionState;
+  pathname: string | null;
+  children: ReactNode;
+  onRetry: () => void;
+}) {
+  if (state.status === 'guest') return <>{children}</>;
+  if (isPublic(pathname)) return <>{children}</>;
+  if (state.status === 'authenticated') return <>{children}</>;
+  if (state.status === 'loading' || state.status === 'unauthenticated') {
+    return <FullScreenLoader />;
+  }
+  return <FullScreenError message={state.message} onRetry={onRetry} />;
+}
+
+function FullScreenLoader() {
+  return (
+    <div role="status" aria-live="polite" style={loaderStyle}>
+      <div style={spinnerStyle} aria-hidden />
+      <span style={{ color: '#8a8a95', fontSize: '0.875rem' }}>Loading…</span>
+    </div>
+  );
+}
+
+function FullScreenError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div role="alert" style={errorScreenStyle}>
+      <h1 style={{ margin: 0, fontSize: '1.1rem' }}>Could not verify your session</h1>
+      <p style={{ margin: 0, color: '#c0c0cb', fontSize: '0.9rem' }}>{message}</p>
+      <button type="button" onClick={onRetry} style={retryButtonStyle}>
+        Try again
+      </button>
+    </div>
+  );
+}
+
+const loaderStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '100vh',
+  background: '#0b0b0d',
+};
+
+const spinnerStyle: React.CSSProperties = {
+  width: 28,
+  height: 28,
+  borderRadius: '50%',
+  border: '2px solid rgba(245,245,245,0.18)',
+  borderTopColor: '#f5f5f5',
+  animation: 'chat-spin 0.7s linear infinite',
+};
+
+const errorScreenStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minHeight: '100vh',
+  padding: '2rem',
+  textAlign: 'center',
+  color: '#f5f5f5',
+  background: '#0b0b0d',
+};
+
+const retryButtonStyle: React.CSSProperties = {
+  marginTop: '0.5rem',
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.55rem 1rem',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};

--- a/apps/web/src/features/auth/UserMenu.tsx
+++ b/apps/web/src/features/auth/UserMenu.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import { useToast } from '@/components/ToastHost';
+import { useSession } from '@/features/auth/SessionContext';
+
+export function UserMenu() {
+  const { user, logout, loggingOut } = useSession();
+  const toast = useToast();
+  const [open, setOpen] = useState(false);
+
+  if (!user) return null;
+
+  const display = user.displayName?.trim() || user.email;
+  const initial = display.slice(0, 1).toUpperCase();
+
+  const onLogout = async () => {
+    setOpen(false);
+    try {
+      await logout();
+    } catch (err) {
+      toast.pushError(err, 'logout');
+    }
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        title={user.email}
+        style={triggerStyle}
+      >
+        <span style={avatarStyle} aria-hidden>
+          {initial}
+        </span>
+        <span style={nameStyle}>{display}</span>
+        <span aria-hidden style={chevronStyle}>
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <>
+          <div
+            aria-hidden
+            onClick={() => setOpen(false)}
+            style={{ position: 'fixed', inset: 0, zIndex: 39 }}
+          />
+          <div role="menu" style={menuStyle}>
+            <div style={menuHeaderStyle}>
+              <div style={{ fontSize: '0.85rem', fontWeight: 500 }}>{display}</div>
+              <div style={{ fontSize: '0.75rem', color: '#8a8a95' }}>{user.email}</div>
+            </div>
+            <a href="/settings/providers" role="menuitem" style={menuItemStyle}>
+              Provider settings
+            </a>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={onLogout}
+              disabled={loggingOut}
+              style={{
+                ...menuItemStyle,
+                ...(loggingOut ? { color: '#8a8a95', cursor: 'wait' } : {}),
+              }}
+            >
+              {loggingOut ? 'Logging out…' : 'Log out'}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const triggerStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  background: 'transparent',
+  border: '1px solid #2a2a30',
+  borderRadius: 999,
+  padding: '0.3rem 0.7rem 0.3rem 0.3rem',
+  color: '#f5f5f5',
+  fontSize: '0.85rem',
+  fontWeight: 500,
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const avatarStyle: React.CSSProperties = {
+  width: 24,
+  height: 24,
+  borderRadius: '50%',
+  background: '#2b2b36',
+  color: '#f5f5f5',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+};
+
+const nameStyle: React.CSSProperties = {
+  maxWidth: 160,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+const chevronStyle: React.CSSProperties = {
+  fontSize: '0.65rem',
+  color: '#8a8a95',
+};
+
+const menuStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: 'calc(100% + 6px)',
+  right: 0,
+  minWidth: 220,
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 10,
+  padding: '0.4rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  boxShadow: '0 12px 32px rgba(0,0,0,0.45)',
+  zIndex: 40,
+};
+
+const menuHeaderStyle: React.CSSProperties = {
+  padding: '0.5rem 0.6rem 0.6rem',
+  borderBottom: '1px solid #1d1d22',
+  marginBottom: 4,
+  color: '#e8e8ef',
+};
+
+const menuItemStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  textAlign: 'left',
+  padding: '0.5rem 0.6rem',
+  color: '#e8e8ef',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  borderRadius: 6,
+  textDecoration: 'none',
+  display: 'block',
+};


### PR DESCRIPTION
Closes #17

## Summary
Layout-level `SessionProvider` gates `/` and `/project/*` behind `/v1/auth/me`, redirects unauthenticated users to `/login?next=<path>`, surfaces a `UserMenu` (avatar + dropdown with logout) in the `AppShell`, and bounces authenticated users away from `/login` and `/register`. Dev mode (`NEXT_PUBLIC_API_URL` unset) is a passthrough.

## Acceptance criteria
- [x] Layout fetches `/v1/auth/me`; unauth redirects to `/login` (`?next=` set when the path is non-trivial)
- [x] Logout action in `AppShell` (inside `UserMenu`), POSTs `/v1/auth/logout`, redirects to `/login`
- [x] Works when `NEXT_PUBLIC_API_URL` unset (skip guard, dev mode = `guest`)

## UX decisions
- **Full-screen loader during the initial `/v1/auth/me` round-trip** so users never see a flash of the protected UI before being kicked out.
- **`/login?next=<pathname>`** preserves intent. After login the user lands back where they were. `next` is validated to be a same-origin pathname (must start with `/`, must not start with `//`) — open redirects are rejected and fall back to `/`.
- **Authenticated users on `/login` or `/register`** are bounced to `next` or `/`. The auth pages remain reachable in case they're hit deliberately, but they never linger.
- **Transient errors don't log the user out.** A 5xx or network failure shows a *Could not verify your session* screen with a Retry button. Only an explicit 401 / `unauthenticated` triggers the redirect — keeps the experience stable across flaky networks.
- **UserMenu** is a pill-shaped avatar trigger that opens a dropdown with the display name, email, a link to provider settings (one-click into the settings flow), and Log out. The button shows a "Logging out…" state and is disabled during the request.
- **AppShell stays a server component**; only `UserMenu` is `'use client'`. The shell renders `UserMenu` next to the existing `right` slot so per-page badges (project source / workspace status) keep working unchanged.
- **AuthForm refreshes the SessionContext before redirecting** (`await refresh()` then `router.replace(target)`), so the protected route mounts with the user already in context — no second loader flash.

## Edge cases handled
| Case | Behavior |
|---|---|
| First visit, no cookie | `/v1/auth/me` 401 → unauthenticated → redirect to `/login` (no `next` because path is `/`) |
| Visit `/project/abc` cold | Redirect to `/login?next=%2Fproject%2Fabc`; after login, lands back on `/project/abc` |
| Open redirect attempt `?next=https://evil` or `?next=//evil` | Rejected by `isSafeNext`, falls back to `/` |
| Authenticated user navigates to `/login` | Auto-redirected to `next` or `/` |
| `NEXT_PUBLIC_API_URL` unset | State = `guest`, gate passthrough, UserMenu renders null |
| Network failure during `/v1/auth/me` | Full-screen retry, no logout |
| Logout while another request in flight | `loggingOut` flag prevents double-click; menu closes on click |
| Logout backend 5xx | Toast surfaced via `useToast().pushError`; user stays on the same page |
| Auth pages opened in a tab where session expired | `/v1/auth/me` 401 ignored on public paths; user can re-login normally |
| Suspense for `useSearchParams` | Wrapped at root layout (`<Suspense fallback={null}>`) — Next 15 requirement |

## Connecting product pieces
- **Auth → chat**: a logged-in user lands on `/project/[id]`, the page renders inside the gated tree, the message-POST flow (`#28`) and provider-key form (`#36`) inherit the same authenticated cookie context.
- **Provider settings discoverable from the shell**: UserMenu offers a direct link to `/settings/providers`. No more typing the URL by hand.
- **Coherent toast layer**: logout failures use the global `ToastHost` shipped in `#40`, same surface as test-connection/save-key feedback.

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green (`/login` + `/register` now prerendered alongside `/`, `/settings/providers`)
- `pnpm --filter @webapp/web lint` — `✔ No ESLint warnings or errors`
- Manual:
  - cold visit `/project/foo` → redirected to `/login?next=%2Fproject%2Ffoo` → after login, lands on `/project/foo`
  - open `/login` while logged in → redirected to `/`
  - log out from header → cookie cleared, lands on `/login`
  - kill API mid-session → full-screen retry until backend recovers
  - `unset NEXT_PUBLIC_API_URL && pnpm dev` → app loads in mock mode, no auth gate

## Out of scope
Remember-me.