### PR TITLE
feat(api): rename + delete endpoints for projects, workspaces, chat-windows

### DIFF
--- a/apps/api/src/controllers/chat-windows-db.controller.ts
+++ b/apps/api/src/controllers/chat-windows-db.controller.ts
@@ -6,13 +6,14 @@ import {
   respond,
   respondCreated,
   respondError,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
-import type { Db } from '../db/chat-windows.repo.js';
+import type { Db, ChatWindowPatch } from '../db/chat-windows.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
 
 // ── Internal DB row shape ──────────────────────────────────────────────────────
@@ -39,6 +40,8 @@ export interface ChatWindowsDeps {
   listChatWindows: (workspaceId: string, userId: string) => Promise<DbChatWindow[] | null>;
   createChatWindow: (workspaceId: string, userId: string, title: string, provider: AIProvider, model: string) => Promise<DbChatWindow | null>;
   findChatWindow: (id: string, userId: string) => Promise<DbChatWindow | null>;
+  updateChatWindow: (id: string, userId: string, patch: ChatWindowPatch) => Promise<DbChatWindow | null>;
+  deleteChatWindow: (id: string, userId: string) => Promise<boolean>;
 }
 
 export function makeChatWindowsDeps(db: Db, sessionDeps: SessionDeps): ChatWindowsDeps {
@@ -47,6 +50,8 @@ export function makeChatWindowsDeps(db: Db, sessionDeps: SessionDeps): ChatWindo
     listChatWindows:  (workspaceId, userId)               => chatWindowsRepo.listChatWindowsByWorkspaceAndUser(db, workspaceId, userId),
     createChatWindow: (workspaceId, userId, title, provider, model) => chatWindowsRepo.createChatWindow(db, workspaceId, userId, title, provider, model),
     findChatWindow:   (id, userId)                        => chatWindowsRepo.findChatWindowById(db, id, userId),
+    updateChatWindow: (id, userId, patch)                 => chatWindowsRepo.updateChatWindow(db, id, userId, patch),
+    deleteChatWindow: (id, userId)                        => chatWindowsRepo.deleteChatWindow(db, id, userId),
   };
 }
 
@@ -59,6 +64,11 @@ const CreateChatWindowDbBody = s.object({
   title:       s.string({ min: 1, max: 200, trim: true }),
   provider:    s.enumOf<AIProvider>(AI_PROVIDERS),
   model:       s.string({ min: 1, max: 200, trim: true }),
+});
+
+const PatchChatWindowDbBody = s.object({
+  title: s.optional(s.string({ min: 1, max: 200, trim: true })),
+  model: s.optional(s.string({ min: 1, max: 200, trim: true })),
 });
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -124,4 +134,31 @@ export async function getChatWindowDbController(
   const id = ctx.params['id'] ?? '';
   const row = await deps.findChatWindow(id, user.id);
   return row ? respond(toChatWindow(row)) : respondNotFound(`ChatWindow ${id} not found`);
+}
+
+export async function patchChatWindowDbController(
+  ctx: RequestContext,
+  deps: ChatWindowsDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const body = await parseJsonBody(ctx, PatchChatWindowDbBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const row = await deps.updateChatWindow(id, user.id, body.value);
+  return row ? respond(toChatWindow(row)) : respondNotFound(`ChatWindow ${id} not found`);
+}
+
+export async function deleteChatWindowDbController(
+  ctx: RequestContext,
+  deps: ChatWindowsDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const id = ctx.params['id'] ?? '';
+  const deleted = await deps.deleteChatWindow(id, user.id);
+  return deleted ? respondNoContent() : respondNotFound(`ChatWindow ${id} not found`);
 }

--- a/apps/api/src/controllers/chat-windows.controller.ts
+++ b/apps/api/src/controllers/chat-windows.controller.ts
@@ -5,12 +5,19 @@ import {
   respond,
   respondCreated,
   respondError,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
-import { createChatWindow, findChatWindow, listChatWindows } from '../services/chat-windows.service.js';
+import {
+  createChatWindow,
+  deleteChatWindow,
+  findChatWindow,
+  listChatWindows,
+  updateChatWindow,
+} from '../services/chat-windows.service.js';
 import { workspaceExists } from '../services/workspaces.service.js';
 
 const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
@@ -20,6 +27,11 @@ const CreateChatWindowBody = s.object({
   title:       s.string({ min: 1, max: 200, trim: true }),
   provider:    s.enumOf<AIProvider>(AI_PROVIDERS),
   model:       s.string({ min: 1, max: 200, trim: true }),
+});
+
+const PatchChatWindowBody = s.object({
+  title: s.optional(s.string({ min: 1, max: 200, trim: true })),
+  model: s.optional(s.string({ min: 1, max: 200, trim: true })),
 });
 
 export function listChatWindowsController(ctx: RequestContext): InternalResult {
@@ -51,4 +63,18 @@ export function getChatWindowController(ctx: RequestContext): InternalResult {
   const id = ctx.params['id'] ?? '';
   const cw = findChatWindow(id);
   return cw ? respond(cw) : respondNotFound(`ChatWindow ${id} not found`);
+}
+
+export async function patchChatWindowController(ctx: RequestContext): Promise<InternalResult> {
+  const body = await parseJsonBody(ctx, PatchChatWindowBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const updated = updateChatWindow(id, body.value);
+  return updated ? respond(updated) : respondNotFound(`ChatWindow ${id} not found`);
+}
+
+export function deleteChatWindowController(ctx: RequestContext): InternalResult {
+  const id = ctx.params['id'] ?? '';
+  return deleteChatWindow(id) ? respondNoContent() : respondNotFound(`ChatWindow ${id} not found`);
 }

--- a/apps/api/src/controllers/projects-db.controller.ts
+++ b/apps/api/src/controllers/projects-db.controller.ts
@@ -6,19 +6,25 @@ import {
   respond,
   respondCreated,
   respondError,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
-import type { Db } from '../db/projects.repo.js';
+import type { Db, ProjectPatch } from '../db/projects.repo.js';
 import * as projectsRepo from '../db/projects.repo.js';
 
 // ── Body schemas ──────────────────────────────────────────────────────────────
 
 const CreateProjectDbBody = s.object({
   name:        s.string({ min: 1, max: 200, trim: true }),
+  description: s.optional(s.nullable(s.string({ max: 2000 }))),
+});
+
+const PatchProjectDbBody = s.object({
+  name:        s.optional(s.string({ min: 1, max: 200, trim: true })),
   description: s.optional(s.nullable(s.string({ max: 2000 }))),
 });
 
@@ -45,6 +51,8 @@ export interface ProjectsDeps {
   listProjects: (userId: string) => Promise<DbProject[]>;
   createProject: (userId: string, name: string, description?: string) => Promise<DbProject>;
   findProject: (id: string, userId: string) => Promise<DbProject | null>;
+  updateProject: (id: string, userId: string, patch: ProjectPatch) => Promise<DbProject | null>;
+  deleteProject: (id: string, userId: string) => Promise<boolean>;
 }
 
 export function makeProjectsDeps(db: Db, sessionDeps: SessionDeps): ProjectsDeps {
@@ -52,7 +60,9 @@ export function makeProjectsDeps(db: Db, sessionDeps: SessionDeps): ProjectsDeps
     resolveUser:   (req)                       => resolveCurrentUser(req, sessionDeps),
     listProjects:  (userId)                    => projectsRepo.listProjectsByUserId(db, userId),
     createProject: (userId, name, description) => projectsRepo.createProject(db, userId, name, description),
-    findProject:   (id, userId)               => projectsRepo.findProjectById(db, id, userId),
+    findProject:   (id, userId)                => projectsRepo.findProjectById(db, id, userId),
+    updateProject: (id, userId, patch)         => projectsRepo.updateProject(db, id, userId, patch),
+    deleteProject: (id, userId)                => projectsRepo.deleteProject(db, id, userId),
   };
 }
 
@@ -106,4 +116,31 @@ export async function getProjectDbController(
   const id = ctx.params['id'] ?? '';
   const row = await deps.findProject(id, user.id);
   return row ? respond(toProject(row)) : respondNotFound(`Project ${id} not found`);
+}
+
+export async function patchProjectDbController(
+  ctx: RequestContext,
+  deps: ProjectsDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const body = await parseJsonBody(ctx, PatchProjectDbBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const row = await deps.updateProject(id, user.id, body.value);
+  return row ? respond(toProject(row)) : respondNotFound(`Project ${id} not found`);
+}
+
+export async function deleteProjectDbController(
+  ctx: RequestContext,
+  deps: ProjectsDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const id = ctx.params['id'] ?? '';
+  const deleted = await deps.deleteProject(id, user.id);
+  return deleted ? respondNoContent() : respondNotFound(`Project ${id} not found`);
 }

--- a/apps/api/src/controllers/projects.controller.ts
+++ b/apps/api/src/controllers/projects.controller.ts
@@ -4,15 +4,27 @@ import {
   parseJsonBody,
   respond,
   respondCreated,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
-import { createProject, findProject, listProjects } from '../services/projects.service.js';
+import {
+  createProject,
+  deleteProject,
+  findProject,
+  listProjects,
+  updateProject,
+} from '../services/projects.service.js';
 
 const CreateProjectBody = s.object({
   name:        s.string({ min: 1, max: 200, trim: true }),
+  description: s.optional(s.nullable(s.string({ max: 2000 }))),
+});
+
+const PatchProjectBody = s.object({
+  name:        s.optional(s.string({ min: 1, max: 200, trim: true })),
   description: s.optional(s.nullable(s.string({ max: 2000 }))),
 });
 
@@ -26,6 +38,20 @@ export async function createProjectController(ctx: RequestContext): Promise<Inte
 
   const project: Project = createProject(body.value.name, body.value.description ?? undefined);
   return respondCreated(project, getProjectPath(project.id));
+}
+
+export async function patchProjectController(ctx: RequestContext): Promise<InternalResult> {
+  const body = await parseJsonBody(ctx, PatchProjectBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const updated = updateProject(id, body.value);
+  return updated ? respond(updated) : respondNotFound(`Project ${id} not found`);
+}
+
+export function deleteProjectController(ctx: RequestContext): InternalResult {
+  const id = ctx.params['id'] ?? '';
+  return deleteProject(id) ? respondNoContent() : respondNotFound(`Project ${id} not found`);
 }
 
 export function getProjectController(ctx: RequestContext): InternalResult {

--- a/apps/api/src/controllers/workspaces-db.controller.ts
+++ b/apps/api/src/controllers/workspaces-db.controller.ts
@@ -6,20 +6,25 @@ import {
   respond,
   respondCreated,
   respondError,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { resolveCurrentUser } from '../lib/resolve-user.js';
+import type { Db, WorkspacePatch } from '../db/workspaces.repo.js';
+import * as workspacesRepo from '../db/workspaces.repo.js';
+import { listWindowIdsByWorkspaceIds } from '../db/chat-windows.repo.js';
 
 const CreateWorkspaceDbBody = s.object({
   projectId: s.string({ min: 1 }),
   name:      s.string({ min: 1, max: 200, trim: true }),
 });
-import { resolveCurrentUser } from '../lib/resolve-user.js';
-import type { Db } from '../db/workspaces.repo.js';
-import * as workspacesRepo from '../db/workspaces.repo.js';
-import { listWindowIdsByWorkspaceIds } from '../db/chat-windows.repo.js';
+
+const PatchWorkspaceDbBody = s.object({
+  name: s.optional(s.string({ min: 1, max: 200, trim: true })),
+});
 
 // ── Internal DB row shape ──────────────────────────────────────────────────────
 
@@ -43,6 +48,8 @@ export interface WorkspacesDeps {
   listWorkspaces: (projectId: string, userId: string) => Promise<DbWorkspace[] | null>;
   createWorkspace: (projectId: string, userId: string, name: string) => Promise<DbWorkspace | null>;
   findWorkspace: (id: string, userId: string) => Promise<DbWorkspace | null>;
+  updateWorkspace: (id: string, userId: string, patch: WorkspacePatch) => Promise<DbWorkspace | null>;
+  deleteWorkspace: (id: string, userId: string) => Promise<boolean>;
   listWindowIds: (workspaceIds: string[]) => Promise<Array<{ id: string; workspaceId: string }>>;
 }
 
@@ -52,6 +59,8 @@ export function makeWorkspacesDeps(db: Db, sessionDeps: SessionDeps): Workspaces
     listWorkspaces:  (projectId, userId)         => workspacesRepo.listWorkspacesByProjectAndUser(db, projectId, userId),
     createWorkspace: (projectId, userId, name)   => workspacesRepo.createWorkspace(db, projectId, userId, name),
     findWorkspace:   (id, userId)                => workspacesRepo.findWorkspaceById(db, id, userId),
+    updateWorkspace: (id, userId, patch)         => workspacesRepo.updateWorkspace(db, id, userId, patch),
+    deleteWorkspace: (id, userId)                => workspacesRepo.deleteWorkspace(db, id, userId),
     listWindowIds:   (workspaceIds)              => listWindowIdsByWorkspaceIds(db, workspaceIds),
   };
 }
@@ -125,4 +134,33 @@ export async function getWorkspaceDbController(
   if (!row) return respondNotFound(`Workspace ${id} not found`);
   const windowRows = await deps.listWindowIds([row.id]);
   return respond(toWorkspace(row, windowRows.map((cw) => cw.id)));
+}
+
+export async function patchWorkspaceDbController(
+  ctx: RequestContext,
+  deps: WorkspacesDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const body = await parseJsonBody(ctx, PatchWorkspaceDbBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const row = await deps.updateWorkspace(id, user.id, body.value);
+  if (!row) return respondNotFound(`Workspace ${id} not found`);
+  const windowRows = await deps.listWindowIds([row.id]);
+  return respond(toWorkspace(row, windowRows.map((cw) => cw.id)));
+}
+
+export async function deleteWorkspaceDbController(
+  ctx: RequestContext,
+  deps: WorkspacesDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const id = ctx.params['id'] ?? '';
+  const deleted = await deps.deleteWorkspace(id, user.id);
+  return deleted ? respondNoContent() : respondNotFound(`Workspace ${id} not found`);
 }

--- a/apps/api/src/controllers/workspaces.controller.ts
+++ b/apps/api/src/controllers/workspaces.controller.ts
@@ -5,17 +5,28 @@ import {
   respond,
   respondCreated,
   respondError,
+  respondNoContent,
   respondNotFound,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
 import { projectExists } from '../services/projects.service.js';
-import { createWorkspace, findWorkspace, listWorkspaces } from '../services/workspaces.service.js';
+import {
+  createWorkspace,
+  deleteWorkspace,
+  findWorkspace,
+  listWorkspaces,
+  updateWorkspace,
+} from '../services/workspaces.service.js';
 
 const CreateWorkspaceBody = s.object({
   projectId: s.string({ min: 1 }),
   name:      s.string({ min: 1, max: 200, trim: true }),
+});
+
+const PatchWorkspaceBody = s.object({
+  name: s.optional(s.string({ min: 1, max: 200, trim: true })),
 });
 
 export function listWorkspacesController(ctx: RequestContext): InternalResult {
@@ -42,4 +53,18 @@ export function getWorkspaceController(ctx: RequestContext): InternalResult {
   const id = ctx.params['id'] ?? '';
   const ws = findWorkspace(id);
   return ws ? respond(ws) : respondNotFound(`Workspace ${id} not found`);
+}
+
+export async function patchWorkspaceController(ctx: RequestContext): Promise<InternalResult> {
+  const body = await parseJsonBody(ctx, PatchWorkspaceBody);
+  if (!body.ok) return body.result;
+
+  const id = ctx.params['id'] ?? '';
+  const updated = updateWorkspace(id, body.value);
+  return updated ? respond(updated) : respondNotFound(`Workspace ${id} not found`);
+}
+
+export function deleteWorkspaceController(ctx: RequestContext): InternalResult {
+  const id = ctx.params['id'] ?? '';
+  return deleteWorkspace(id) ? respondNoContent() : respondNotFound(`Workspace ${id} not found`);
 }

--- a/apps/api/src/db/chat-windows.repo.ts
+++ b/apps/api/src/db/chat-windows.repo.ts
@@ -1,10 +1,15 @@
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { AIProvider } from '@webapp/types';
 import { chatWindows } from './schema.js';
 import { findWorkspaceById } from './workspaces.repo.js';
 
 export type Db = PostgresJsDatabase;
+
+export interface ChatWindowPatch {
+  title?: string;
+  model?: string;
+}
 
 /**
  * Returns chat windows for the workspace, or null if the workspace doesn't
@@ -69,4 +74,32 @@ export async function findChatWindowById(db: Db, id: string, userId: string) {
   if (!cw) return null;
   const ws = await findWorkspaceById(db, cw.workspaceId, userId);
   return ws ? cw : null;
+}
+
+/** Updates a chat window if owned. Returns the updated row, or null. */
+export async function updateChatWindow(
+  db: Db,
+  id: string,
+  userId: string,
+  patch: ChatWindowPatch,
+) {
+  const existing = await findChatWindowById(db, id, userId);
+  if (!existing) return null;
+  const setClauses: Record<string, unknown> = { updatedAt: sql`now()` };
+  if (patch.title !== undefined) setClauses['title'] = patch.title;
+  if (patch.model !== undefined) setClauses['model'] = patch.model;
+  const [row] = await db
+    .update(chatWindows)
+    .set(setClauses)
+    .where(eq(chatWindows.id, id))
+    .returning();
+  return row ?? null;
+}
+
+/** Deletes a chat window if owned. Returns true if deleted. Cascades to messages. */
+export async function deleteChatWindow(db: Db, id: string, userId: string): Promise<boolean> {
+  const existing = await findChatWindowById(db, id, userId);
+  if (!existing) return false;
+  await db.delete(chatWindows).where(eq(chatWindows.id, id));
+  return true;
 }

--- a/apps/api/src/db/projects.repo.ts
+++ b/apps/api/src/db/projects.repo.ts
@@ -1,8 +1,13 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { projects } from './schema.js';
 
 export type Db = PostgresJsDatabase;
+
+export interface ProjectPatch {
+  name?: string;
+  description?: string | null;
+}
 
 export async function listProjectsByUserId(db: Db, userId: string) {
   return db.select().from(projects).where(eq(projects.userId, userId));
@@ -23,4 +28,29 @@ export async function findProjectById(db: Db, id: string, userId: string) {
     .where(and(eq(projects.id, id), eq(projects.userId, userId)))
     .limit(1);
   return row ?? null;
+}
+
+export async function updateProject(
+  db: Db,
+  id: string,
+  userId: string,
+  patch: ProjectPatch,
+) {
+  const setClauses: Record<string, unknown> = { updatedAt: sql`now()` };
+  if (patch.name !== undefined)        setClauses['name'] = patch.name;
+  if (patch.description !== undefined) setClauses['description'] = patch.description;
+  const [row] = await db
+    .update(projects)
+    .set(setClauses)
+    .where(and(eq(projects.id, id), eq(projects.userId, userId)))
+    .returning();
+  return row ?? null;
+}
+
+export async function deleteProject(db: Db, id: string, userId: string): Promise<boolean> {
+  const rows = await db
+    .delete(projects)
+    .where(and(eq(projects.id, id), eq(projects.userId, userId)))
+    .returning({ id: projects.id });
+  return rows.length > 0;
 }

--- a/apps/api/src/db/workspaces.repo.ts
+++ b/apps/api/src/db/workspaces.repo.ts
@@ -1,9 +1,13 @@
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { workspaces } from './schema.js';
 import { findProjectById } from './projects.repo.js';
 
 export type Db = PostgresJsDatabase;
+
+export interface WorkspacePatch {
+  name?: string;
+}
 
 /**
  * Returns workspaces for the project, or null if the project doesn't exist
@@ -48,4 +52,31 @@ export async function findWorkspaceById(db: Db, id: string, userId: string) {
   if (!ws) return null;
   const project = await findProjectById(db, ws.projectId, userId);
   return project ? ws : null;
+}
+
+/** Updates a workspace if owned (via project). Returns the updated row, or null. */
+export async function updateWorkspace(
+  db: Db,
+  id: string,
+  userId: string,
+  patch: WorkspacePatch,
+) {
+  const existing = await findWorkspaceById(db, id, userId);
+  if (!existing) return null;
+  const setClauses: Record<string, unknown> = { updatedAt: sql`now()` };
+  if (patch.name !== undefined) setClauses['name'] = patch.name;
+  const [row] = await db
+    .update(workspaces)
+    .set(setClauses)
+    .where(eq(workspaces.id, id))
+    .returning();
+  return row ?? null;
+}
+
+/** Deletes a workspace if owned. Returns true if deleted. Cascades via FK. */
+export async function deleteWorkspace(db: Db, id: string, userId: string): Promise<boolean> {
+  const existing = await findWorkspaceById(db, id, userId);
+  if (!existing) return false;
+  await db.delete(workspaces).where(eq(workspaces.id, id));
+  return true;
 }

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -54,6 +54,10 @@ export function respondNotFound(message: string): InternalResult {
   return { httpStatus: 404, body: fail('not_found', message) };
 }
 
+export function respondNoContent(): InternalResult {
+  return { httpStatus: 204, body: { ok: true, data: null } };
+}
+
 export function respondRateLimited(retryAfterSecs: number): InternalResult {
   return {
     httpStatus: 429,
@@ -75,6 +79,15 @@ export function writeJson(
   requestId: string,
   extraHeaders?: Record<string, string>,
 ): void {
+  if (status === 204) {
+    res.writeHead(204, {
+      'Cache-Control': 'no-store',
+      'X-Request-Id': requestId,
+      ...extraHeaders,
+    });
+    res.end();
+    return;
+  }
   res.writeHead(status, {
     'Content-Type': 'application/json; charset=utf-8',
     'Cache-Control': 'no-store',

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -34,6 +34,8 @@ function makeDeps(overrides: Partial<ChatWindowsDeps> = {}): ChatWindowsDeps {
     createChatWindow: async (workspaceId, _userId, title, provider, model) =>
       mockChatWindow(workspaceId, { title, provider, model }),
     findChatWindow:   async () => null,
+    updateChatWindow: async () => null,
+    deleteChatWindow: async () => false,
     ...overrides,
   };
 }
@@ -62,6 +64,18 @@ function post(base: string, path: string, body: unknown) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+function patch(base: string, path: string, body: unknown) {
+  return fetch(`${base}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function del(base: string, path: string) {
+  return fetch(`${base}${path}`, { method: 'DELETE' });
 }
 
 // ── Unauthenticated access ────────────────────────────────────────────────────
@@ -225,3 +239,79 @@ describe('GET /v1/chat-windows/:id — user isolation', () => {
     await close();
   });
 });
+
+
+describe("PATCH /v1/chat-windows/:id — authenticated", () => {
+  it("renames a chat window owned by the user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:      async () => USER_1,
+      updateChatWindow: async (id, _userId, patchBody) =>
+        mockChatWindow("ws-1", { id, title: patchBody.title ?? "CW" }),
+    }));
+    const res = await patch(baseUrl, "/v1/chat-windows/cw-1", { title: "Renamed" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<ChatWindow>;
+    if (!body.ok) throw new Error("expected ok");
+    expect(body.data.title).toBe("Renamed");
+    await close();
+  });
+
+  it("returns 404 when chat window belongs to another user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:      async () => USER_1,
+      updateChatWindow: async () => null,
+    }));
+    const res = await patch(baseUrl, "/v1/chat-windows/u2-cw", { title: "X" });
+    expect(res.status).toBe(404);
+    await close();
+  });
+
+  it("returns 400 invalid_body for empty title", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
+    const res = await patch(baseUrl, "/v1/chat-windows/cw-1", { title: "" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error("expected error");
+    expect(body.error.code).toBe("invalid_body");
+    await close();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await patch(baseUrl, "/v1/chat-windows/cw-1", { title: "X" });
+    expect(res.status).toBe(401);
+    await close();
+  });
+});
+
+describe("DELETE /v1/chat-windows/:id — authenticated", () => {
+  it("returns 204 with empty body", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:      async () => USER_1,
+      deleteChatWindow: async () => true,
+    }));
+    const res = await del(baseUrl, "/v1/chat-windows/cw-1");
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+    await close();
+  });
+
+  it("returns 404 when chat window belongs to another user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:      async () => USER_1,
+      deleteChatWindow: async () => false,
+    }));
+    const res = await del(baseUrl, "/v1/chat-windows/u2-cw");
+    expect(res.status).toBe(404);
+    await close();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await del(baseUrl, "/v1/chat-windows/cw-1");
+    expect(res.status).toBe(401);
+    await close();
+  });
+});
+
+

--- a/apps/api/src/routes/chat-windows-db.ts
+++ b/apps/api/src/routes/chat-windows-db.ts
@@ -4,13 +4,17 @@ import {
   listChatWindowsDbController,
   createChatWindowDbController,
   getChatWindowDbController,
+  patchChatWindowDbController,
+  deleteChatWindowDbController,
 } from '../controllers/chat-windows-db.controller.js';
 import { API_CHAT_WINDOWS_PATH } from '@webapp/types';
 
 export function makeChatWindowDbRoutes(deps: ChatWindowsDeps): RouteDefinition[] {
   return [
-    { method: 'GET',  path: API_CHAT_WINDOWS_PATH,            handler: (ctx) => listChatWindowsDbController(ctx, deps) },
-    { method: 'POST', path: API_CHAT_WINDOWS_PATH,            handler: (ctx) => createChatWindowDbController(ctx, deps) },
-    { method: 'GET',  path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: (ctx) => getChatWindowDbController(ctx, deps) },
+    { method: 'GET',    path: API_CHAT_WINDOWS_PATH,            handler: (ctx) => listChatWindowsDbController(ctx, deps) },
+    { method: 'POST',   path: API_CHAT_WINDOWS_PATH,            handler: (ctx) => createChatWindowDbController(ctx, deps) },
+    { method: 'GET',    path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: (ctx) => getChatWindowDbController(ctx, deps) },
+    { method: 'PATCH',  path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: (ctx) => patchChatWindowDbController(ctx, deps) },
+    { method: 'DELETE', path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: (ctx) => deleteChatWindowDbController(ctx, deps) },
   ];
 }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,9 +1,27 @@
 import { healthController } from '../controllers/health.controller.js';
-import { createChatWindowController, getChatWindowController, listChatWindowsController } from '../controllers/chat-windows.controller.js';
+import {
+  createChatWindowController,
+  deleteChatWindowController,
+  getChatWindowController,
+  listChatWindowsController,
+  patchChatWindowController,
+} from '../controllers/chat-windows.controller.js';
 import { createMessageController, getMessageController, listMessagesController } from '../controllers/messages.controller.js';
-import { createProjectController, getProjectController, listProjectsController } from '../controllers/projects.controller.js';
+import {
+  createProjectController,
+  deleteProjectController,
+  getProjectController,
+  listProjectsController,
+  patchProjectController,
+} from '../controllers/projects.controller.js';
 import { stateController } from '../controllers/state.controller.js';
-import { createWorkspaceController, getWorkspaceController, listWorkspacesController } from '../controllers/workspaces.controller.js';
+import {
+  createWorkspaceController,
+  deleteWorkspaceController,
+  getWorkspaceController,
+  listWorkspacesController,
+  patchWorkspaceController,
+} from '../controllers/workspaces.controller.js';
 import { makeAuthDeps } from '../controllers/auth.controller.js';
 import { makeProjectsDeps } from '../controllers/projects-db.controller.js';
 import { makeWorkspacesDeps } from '../controllers/workspaces-db.controller.js';
@@ -46,27 +64,33 @@ const authRoutes: RouteDefinition[] = authDeps
 const projectRoutes: RouteDefinition[] = (db && authDeps)
   ? makeProjectDbRoutes(makeProjectsDeps(db, authDeps))
   : [
-    { method: 'GET',  path: API_PROJECTS_PATH,          handler: listProjectsController },
-    { method: 'POST', path: API_PROJECTS_PATH,          handler: createProjectController },
-    { method: 'GET',  path: `${API_PROJECTS_PATH}/:id`, handler: getProjectController },
+    { method: 'GET',    path: API_PROJECTS_PATH,          handler: listProjectsController },
+    { method: 'POST',   path: API_PROJECTS_PATH,          handler: createProjectController },
+    { method: 'GET',    path: `${API_PROJECTS_PATH}/:id`, handler: getProjectController },
+    { method: 'PATCH',  path: `${API_PROJECTS_PATH}/:id`, handler: patchProjectController },
+    { method: 'DELETE', path: `${API_PROJECTS_PATH}/:id`, handler: deleteProjectController },
   ];
 
 // Workspace routes: DB-backed user-scoped when DB is available, in-memory fallback otherwise.
 const workspaceRoutes: RouteDefinition[] = (db && authDeps)
   ? makeWorkspaceDbRoutes(makeWorkspacesDeps(db, authDeps))
   : [
-    { method: 'GET',  path: API_WORKSPACES_PATH,            handler: listWorkspacesController },
-    { method: 'POST', path: API_WORKSPACES_PATH,            handler: createWorkspaceController },
-    { method: 'GET',  path: `${API_WORKSPACES_PATH}/:id`,   handler: getWorkspaceController },
+    { method: 'GET',    path: API_WORKSPACES_PATH,            handler: listWorkspacesController },
+    { method: 'POST',   path: API_WORKSPACES_PATH,            handler: createWorkspaceController },
+    { method: 'GET',    path: `${API_WORKSPACES_PATH}/:id`,   handler: getWorkspaceController },
+    { method: 'PATCH',  path: `${API_WORKSPACES_PATH}/:id`,   handler: patchWorkspaceController },
+    { method: 'DELETE', path: `${API_WORKSPACES_PATH}/:id`,   handler: deleteWorkspaceController },
   ];
 
 // Chat-window routes: DB-backed user-scoped when DB is available, in-memory fallback otherwise.
 const chatWindowRoutes: RouteDefinition[] = (db && authDeps)
   ? makeChatWindowDbRoutes(makeChatWindowsDeps(db, authDeps))
   : [
-    { method: 'GET',  path: API_CHAT_WINDOWS_PATH,            handler: listChatWindowsController },
-    { method: 'POST', path: API_CHAT_WINDOWS_PATH,            handler: createChatWindowController },
-    { method: 'GET',  path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: getChatWindowController },
+    { method: 'GET',    path: API_CHAT_WINDOWS_PATH,            handler: listChatWindowsController },
+    { method: 'POST',   path: API_CHAT_WINDOWS_PATH,            handler: createChatWindowController },
+    { method: 'GET',    path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: getChatWindowController },
+    { method: 'PATCH',  path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: patchChatWindowController },
+    { method: 'DELETE', path: `${API_CHAT_WINDOWS_PATH}/:id`,   handler: deleteChatWindowController },
   ];
 
 // Message routes: DB-backed user-scoped when DB is available, in-memory fallback otherwise.

--- a/apps/api/src/routes/projects-db.test.ts
+++ b/apps/api/src/routes/projects-db.test.ts
@@ -32,6 +32,8 @@ function makeDeps(overrides: Partial<ProjectsDeps> = {}): ProjectsDeps {
     listProjects:  async () => [],
     createProject: async (userId, name, description) => mockProject(userId, { name, description: description ?? null }),
     findProject:   async () => null,
+    updateProject: async () => null,
+    deleteProject: async () => false,
     ...overrides,
   };
 }
@@ -60,6 +62,18 @@ function post(base: string, path: string, body: unknown) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+function patch(base: string, path: string, body: unknown) {
+  return fetch(`${base}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function del(base: string, path: string) {
+  return fetch(`${base}${path}`, { method: 'DELETE' });
 }
 
 // ── Unauthenticated access ────────────────────────────────────────────────────
@@ -187,6 +201,94 @@ describe('GET /v1/projects/:id — user isolation', () => {
   it('returns 404 for non-existent project', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await get(baseUrl, '/v1/projects/does-not-exist');
+    expect(res.status).toBe(404);
+    await close();
+  });
+});
+
+describe('PATCH /v1/projects/:id — authenticated', () => {
+  it('renames a project owned by the user', async () => {
+    let received: { id: string; userId: string; patch: { name?: string; description?: string | null } } | null = null;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      updateProject: async (id, userId, patchBody) => {
+        received = { id, userId, patch: patchBody };
+        return mockProject(userId, { id, name: patchBody.name ?? 'My Project' });
+      },
+    }));
+    const res = await patch(baseUrl, '/v1/projects/proj-1', { name: 'Renamed' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<Project>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.name).toBe('Renamed');
+    expect(received).toEqual({ id: 'proj-1', userId: USER_1.id, patch: { name: 'Renamed' } });
+    await close();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await patch(baseUrl, '/v1/projects/proj-1', { name: 'X' });
+    expect(res.status).toBe(401);
+    await close();
+  });
+
+  it('returns 404 when project belongs to another user (no existence leak)', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      updateProject: async () => null,
+    }));
+    const res = await patch(baseUrl, '/v1/projects/u2-proj', { name: 'X' });
+    expect(res.status).toBe(404);
+    await close();
+  });
+
+  it('returns 400 invalid_body when name is empty', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
+    const res = await patch(baseUrl, '/v1/projects/proj-1', { name: '' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('invalid_body');
+    await close();
+  });
+
+  it('accepts a description-only patch (name optional)', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      updateProject: async (id, userId, patchBody) =>
+        mockProject(userId, { id, description: patchBody.description ?? null }),
+    }));
+    const res = await patch(baseUrl, '/v1/projects/proj-1', { description: 'updated' });
+    expect(res.status).toBe(200);
+    await close();
+  });
+});
+
+describe('DELETE /v1/projects/:id — authenticated', () => {
+  it('returns 204 No Content with empty body when delete succeeds', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      deleteProject: async () => true,
+    }));
+    const res = await del(baseUrl, '/v1/projects/proj-1');
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe('');
+    await close();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await del(baseUrl, '/v1/projects/proj-1');
+    expect(res.status).toBe(401);
+    await close();
+  });
+
+  it('returns 404 when project belongs to another user (no existence leak)', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      deleteProject: async () => false,
+    }));
+    const res = await del(baseUrl, '/v1/projects/u2-proj');
     expect(res.status).toBe(404);
     await close();
   });

--- a/apps/api/src/routes/projects-db.ts
+++ b/apps/api/src/routes/projects-db.ts
@@ -4,13 +4,17 @@ import {
   listProjectsDbController,
   createProjectDbController,
   getProjectDbController,
+  patchProjectDbController,
+  deleteProjectDbController,
 } from '../controllers/projects-db.controller.js';
 import { API_PROJECTS_PATH } from '@webapp/types';
 
 export function makeProjectDbRoutes(deps: ProjectsDeps): RouteDefinition[] {
   return [
-    { method: 'GET',  path: API_PROJECTS_PATH,          handler: (ctx) => listProjectsDbController(ctx, deps) },
-    { method: 'POST', path: API_PROJECTS_PATH,          handler: (ctx) => createProjectDbController(ctx, deps) },
-    { method: 'GET',  path: `${API_PROJECTS_PATH}/:id`, handler: (ctx) => getProjectDbController(ctx, deps) },
+    { method: 'GET',    path: API_PROJECTS_PATH,          handler: (ctx) => listProjectsDbController(ctx, deps) },
+    { method: 'POST',   path: API_PROJECTS_PATH,          handler: (ctx) => createProjectDbController(ctx, deps) },
+    { method: 'GET',    path: `${API_PROJECTS_PATH}/:id`, handler: (ctx) => getProjectDbController(ctx, deps) },
+    { method: 'PATCH',  path: `${API_PROJECTS_PATH}/:id`, handler: (ctx) => patchProjectDbController(ctx, deps) },
+    { method: 'DELETE', path: `${API_PROJECTS_PATH}/:id`, handler: (ctx) => deleteProjectDbController(ctx, deps) },
   ];
 }

--- a/apps/api/src/routes/workspaces-db.test.ts
+++ b/apps/api/src/routes/workspaces-db.test.ts
@@ -31,6 +31,8 @@ function makeDeps(overrides: Partial<WorkspacesDeps> = {}): WorkspacesDeps {
     listWorkspaces:  async () => null,
     createWorkspace: async (projectId, _userId, name) => mockWorkspace(projectId, { name }),
     findWorkspace:   async () => null,
+    updateWorkspace: async () => null,
+    deleteWorkspace: async () => false,
     listWindowIds:   async () => [],
     ...overrides,
   };
@@ -60,6 +62,18 @@ function post(base: string, path: string, body: unknown) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+}
+
+function patch(base: string, path: string, body: unknown) {
+  return fetch(`${base}${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function del(base: string, path: string) {
+  return fetch(`${base}${path}`, { method: 'DELETE' });
 }
 
 // ── Unauthenticated access ────────────────────────────────────────────────────
@@ -271,3 +285,79 @@ describe('GET /v1/workspaces — windowIds derived from chat windows', () => {
     await close();
   });
 });
+
+
+describe("PATCH /v1/workspaces/:id — authenticated", () => {
+  it("renames a workspace owned by the user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:     async () => USER_1,
+      updateWorkspace: async (id, _userId, patchBody) =>
+        mockWorkspace("proj-1", { id, name: patchBody.name ?? "WS" }),
+      listWindowIds:   async () => [],
+    }));
+    const res = await patch(baseUrl, "/v1/workspaces/ws-1", { name: "Renamed" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<Workspace>;
+    if (!body.ok) throw new Error("expected ok");
+    expect(body.data.name).toBe("Renamed");
+    await close();
+  });
+
+  it("returns 404 when workspace belongs to another user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:     async () => USER_1,
+      updateWorkspace: async () => null,
+    }));
+    const res = await patch(baseUrl, "/v1/workspaces/u2-ws", { name: "X" });
+    expect(res.status).toBe(404);
+    await close();
+  });
+
+  it("returns 400 invalid_body when name is empty string", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
+    const res = await patch(baseUrl, "/v1/workspaces/ws-1", { name: "" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error("expected error");
+    expect(body.error.code).toBe("invalid_body");
+    await close();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await patch(baseUrl, "/v1/workspaces/ws-1", { name: "X" });
+    expect(res.status).toBe(401);
+    await close();
+  });
+});
+
+describe("DELETE /v1/workspaces/:id — authenticated", () => {
+  it("returns 204 with empty body when delete succeeds", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:     async () => USER_1,
+      deleteWorkspace: async () => true,
+    }));
+    const res = await del(baseUrl, "/v1/workspaces/ws-1");
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+    await close();
+  });
+
+  it("returns 404 when workspace belongs to another user", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:     async () => USER_1,
+      deleteWorkspace: async () => false,
+    }));
+    const res = await del(baseUrl, "/v1/workspaces/u2-ws");
+    expect(res.status).toBe(404);
+    await close();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => null }));
+    const res = await del(baseUrl, "/v1/workspaces/ws-1");
+    expect(res.status).toBe(401);
+    await close();
+  });
+});
+

--- a/apps/api/src/routes/workspaces-db.ts
+++ b/apps/api/src/routes/workspaces-db.ts
@@ -4,13 +4,17 @@ import {
   listWorkspacesDbController,
   createWorkspaceDbController,
   getWorkspaceDbController,
+  patchWorkspaceDbController,
+  deleteWorkspaceDbController,
 } from '../controllers/workspaces-db.controller.js';
 import { API_WORKSPACES_PATH } from '@webapp/types';
 
 export function makeWorkspaceDbRoutes(deps: WorkspacesDeps): RouteDefinition[] {
   return [
-    { method: 'GET',  path: API_WORKSPACES_PATH,            handler: (ctx) => listWorkspacesDbController(ctx, deps) },
-    { method: 'POST', path: API_WORKSPACES_PATH,            handler: (ctx) => createWorkspaceDbController(ctx, deps) },
-    { method: 'GET',  path: `${API_WORKSPACES_PATH}/:id`,   handler: (ctx) => getWorkspaceDbController(ctx, deps) },
+    { method: 'GET',    path: API_WORKSPACES_PATH,            handler: (ctx) => listWorkspacesDbController(ctx, deps) },
+    { method: 'POST',   path: API_WORKSPACES_PATH,            handler: (ctx) => createWorkspaceDbController(ctx, deps) },
+    { method: 'GET',    path: `${API_WORKSPACES_PATH}/:id`,   handler: (ctx) => getWorkspaceDbController(ctx, deps) },
+    { method: 'PATCH',  path: `${API_WORKSPACES_PATH}/:id`,   handler: (ctx) => patchWorkspaceDbController(ctx, deps) },
+    { method: 'DELETE', path: `${API_WORKSPACES_PATH}/:id`,   handler: (ctx) => deleteWorkspaceDbController(ctx, deps) },
   ];
 }

--- a/apps/api/src/services/chat-windows.service.ts
+++ b/apps/api/src/services/chat-windows.service.ts
@@ -33,6 +33,25 @@ export function chatWindowExists(id: string): boolean {
   return store.some((w) => w.id === id);
 }
 
+export function updateChatWindow(
+  id: string,
+  patch: { title?: string; model?: string },
+): ChatWindow | undefined {
+  const cw = store.find((w) => w.id === id);
+  if (!cw) return undefined;
+  if (patch.title !== undefined) cw.title = patch.title;
+  if (patch.model !== undefined) cw.model = patch.model;
+  cw.updatedAt = new Date().toISOString();
+  return { ...cw };
+}
+
+export function deleteChatWindow(id: string): boolean {
+  const i = store.findIndex((w) => w.id === id);
+  if (i === -1) return false;
+  store.splice(i, 1);
+  return true;
+}
+
 export function resetChatWindowsStore(): void {
   store = [];
 }

--- a/apps/api/src/services/projects.service.ts
+++ b/apps/api/src/services/projects.service.ts
@@ -30,6 +30,25 @@ export function projectExists(id: string): boolean {
   return store.some((p) => p.id === id);
 }
 
+export function updateProject(
+  id: string,
+  patch: { name?: string; description?: string | null },
+): Project | undefined {
+  const p = store.find((p) => p.id === id);
+  if (!p) return undefined;
+  if (patch.name !== undefined) p.name = patch.name;
+  if (patch.description !== undefined) p.description = patch.description ?? undefined;
+  p.updatedAt = new Date().toISOString();
+  return { ...p };
+}
+
+export function deleteProject(id: string): boolean {
+  const i = store.findIndex((p) => p.id === id);
+  if (i === -1) return false;
+  store.splice(i, 1);
+  return true;
+}
+
 export function resetProjectsStore(): void {
   store = [];
 }

--- a/apps/api/src/services/workspaces.service.ts
+++ b/apps/api/src/services/workspaces.service.ts
@@ -31,6 +31,21 @@ export function appendWindowId(workspaceId: string, windowId: string): void {
   if (ws) ws.windowIds.push(windowId);
 }
 
+export function updateWorkspace(id: string, patch: { name?: string }): Workspace | undefined {
+  const ws = store.find((w) => w.id === id);
+  if (!ws) return undefined;
+  if (patch.name !== undefined) ws.name = patch.name;
+  ws.updatedAt = new Date().toISOString();
+  return { ...ws, windowIds: [...ws.windowIds] };
+}
+
+export function deleteWorkspace(id: string): boolean {
+  const i = store.findIndex((w) => w.id === id);
+  if (i === -1) return false;
+  store.splice(i, 1);
+  return true;
+}
+
 export function resetWorkspacesStore(): void {
   store = [];
 }


### PR DESCRIPTION
Closes #83

## Summary
Adds **PATCH** and **DELETE** endpoints for `projects`, `workspaces`, and `chat-windows` in both DB and in-memory route sets. Unblocks frontend issue #20 (rename / delete UX).

| Method | Path | Behaviour |
|---|---|---|
| `PATCH /v1/projects/:id` | rename `name` and/or update `description`; 200 returns updated `Project` |
| `DELETE /v1/projects/:id` | 204 No Content; cascades via FK to workspaces, chat-windows, messages |
| `PATCH /v1/workspaces/:id` | rename `name`; 200 returns updated `Workspace` |
| `DELETE /v1/workspaces/:id` | 204 No Content; cascades to chat-windows, messages |
| `PATCH /v1/chat-windows/:id` | update `title` and/or `model`; 200 returns updated `ChatWindow` |
| `DELETE /v1/chat-windows/:id` | 204 No Content; cascades to messages |

## Design notes
- **Cascade is at the DB level.** `onDelete: 'cascade'` is already on every FK in `schema.ts`, so DELETE is a single statement that the database walks down. No application-level cleanup loop, no transaction needed.
- **Cross-user 404, not 403.** The repo layer scopes every read/write by `userId` via the existing ownership chain (projects.userId → workspaces.projectId → chat-windows.workspaceId). A foreign row therefore looks like a missing row to the requester — no existence leak. Every new test asserts this explicitly.
- **All bodies validated via `parseJsonBody` + optional-fields schemas** (#30 contract). Bad payloads → `invalid_body` 400 with `fields` list. Tests assert this for each new PATCH route.
- **204 No Content with truly empty body.** `respondNoContent()` returns the canonical envelope; `writeJson` was taught to skip both the body and the `Content-Type` header when status === 204. Tests verify the empty body.
- **In-memory parity.** Both routing modes get the new verbs; service helpers (`updateProject`, `deleteProject`, etc.) added alongside.

## Test plan
- 22 new tests across `projects-db.test.ts`, `workspaces-db.test.ts`, `chat-windows-db.test.ts` covering: rename happy path, cross-user 404, invalid_body 400, 401 unauthenticated, DELETE 204 with empty body, DELETE 404 on foreign-user resource.
- `pnpm --filter @webapp/api test` → **265/265 passing** (243 pre-existing + 22 new).
- `pnpm typecheck` and `pnpm build` green.

## Out of scope
- Soft delete / undo.
- Reordering or moving across parents (workspace → different project, etc.).
- Bulk operations.
- Audit log.