### PR TITLE
feat(web): create project empty-state + modal

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Panel } from '@/components/Panel';
 import { listProjects as listMockProjects, listWorkspacesForProject } from '@/lib/data';
 import { getApiBaseUrl } from '@/lib/api/env';
 import { fetchProjects } from '@/lib/api/projects';
+import { CreateProjectEmptyState } from '@/features/projects/CreateProjectEmptyState';
 
 type ProjectsResult =
   | { source: 'api'; projects: Project[] }
@@ -34,7 +35,7 @@ export default async function HomePage() {
         {result.source === 'error' ? (
           <ErrorPanel message={result.message} />
         ) : result.projects.length === 0 ? (
-          <EmptyProjects />
+          <CreateProjectEmptyState />
         ) : (
           <ProjectGrid projects={result.projects} />
         )}
@@ -78,17 +79,6 @@ function ProjectGrid({ projects }: { projects: Project[] }) {
         );
       })}
     </div>
-  );
-}
-
-function EmptyProjects() {
-  return (
-    <Panel style={{ padding: '2rem', textAlign: 'center' }}>
-      <div style={{ color: '#e8e8ef', fontSize: '1rem' }}>No projects yet</div>
-      <div style={{ color: '#8a8a95', fontSize: '0.85rem', marginTop: 6 }}>
-        Create your first project to get started.
-      </div>
-    </Panel>
   );
 }
 

--- a/apps/web/src/features/projects/CreateProjectEmptyState.tsx
+++ b/apps/web/src/features/projects/CreateProjectEmptyState.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useCallback, useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/Button';
+import { Panel } from '@/components/Panel';
+import { useToast } from '@/components/ToastHost';
+import { createProject } from '@/lib/api/projects';
+
+export function CreateProjectEmptyState() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Panel style={{ padding: '2.5rem 2rem', textAlign: 'center' }}>
+        <div style={{ color: '#e8e8ef', fontSize: '1.1rem', fontWeight: 500 }}>No projects yet</div>
+        <div style={{ color: '#8a8a95', fontSize: '0.9rem', marginTop: 6, marginBottom: '1.25rem' }}>
+          Create your first project to start a workspace.
+        </div>
+        <Button onClick={() => setOpen(true)}>Create your first project</Button>
+      </Panel>
+      {open && <CreateProjectModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function CreateProjectModal({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = name.trim();
+      if (!trimmed || submitting) return;
+      setSubmitting(true);
+      try {
+        await createProject({ name: trimmed });
+        onClose();
+        router.refresh();
+      } catch (err) {
+        toast.pushError(err, 'create project');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [name, submitting, onClose, router, toast],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-project-title"
+      style={backdropStyle}
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        <h2 id="create-project-title" style={{ margin: 0, fontSize: '1.05rem' }}>
+          New project
+        </h2>
+        <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={{ fontSize: '0.78rem', color: '#8a8a95' }}>Project name</span>
+            <input
+              autoFocus
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={120}
+              disabled={submitting}
+              style={inputStyle}
+            />
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? 'Creating…' : 'Create'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  padding: '1.5rem',
+  width: '100%',
+  maxWidth: 420,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  color: '#f5f5f5',
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.55rem 0.7rem',
+  borderRadius: 6,
+  border: '1px solid #2a2a30',
+  background: '#0f0f13',
+  color: '#f5f5f5',
+  fontSize: '0.9rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};


### PR DESCRIPTION
## Summary
Authenticated users with zero projects had no path forward — the empty state was informational only. This PR adds a CTA + modal so the new-user loop closes: log in → see empty state → create first project → land on the populated grid.

## Scope (per ticket — nothing else)
- Homepage `/` empty state: title "No projects yet" + CTA `Create your first project`.
- Modal: single required `name` input, Cancel + Create buttons.
- On submit: `createProject({ name })` (existing helper from #19).
- On success: close modal + `router.refresh()` so the server-rendered list re-fetches and the new project appears.
- On error: `toast.pushError(err, 'create project')`; modal stays open with the input intact.

## Constraints honored
- `AppShell` stays a server component.
- Only `CreateProjectEmptyState.tsx` is `'use client'`.
- No design overkill — reuses existing `Panel`, `Button`, `ToastHost`, modal styles consistent with `/settings/providers`.
- No rename / delete UI (out of scope).

## Edge cases
| Case | Behavior |
|---|---|
| Empty / whitespace name | Submit disabled (`!name.trim()`) |
| Double submit | `submitting` flag blocks; both buttons disabled while in flight |
| Backdrop click during submit | Ignored (no-op) |
| API error | Toast surfaces backend `code — message`; modal stays open with input intact for retry |
| Mock mode (`NEXT_PUBLIC_API_URL` unset) | `createProject` throws `no_api_url`; toast shown — no fake state mutation |

## Test plan
- `pnpm --filter @webapp/web typecheck` — green
- `pnpm --filter @webapp/web build` — green
- `pnpm --filter @webapp/web lint` — `✔ No ESLint warnings or errors`
- Manual:
  - cold visit `/` with zero projects → CTA visible
  - submit empty → button disabled
  - submit valid name → modal closes, list re-fetches and shows the new project
  - kill API mid-submit → toast error, modal stays open