### PR TITLE
feat(web): send message + basic chat UI

### DIFF
--- a/apps/web/src/app/project/[id]/page.tsx
+++ b/apps/web/src/app/project/[id]/page.tsx
@@ -4,6 +4,7 @@ import type { Project, Workspace as WorkspaceType } from '@webapp/types';
 import { AppShell } from '@/components/AppShell';
 import { Panel } from '@/components/Panel';
 import { Workspace } from '@/features/workspace/Workspace';
+import { CreateWorkspaceCTA } from '@/features/workspace/CreateWorkspaceCTA';
 import {
   getProject as getMockProject,
   listWorkspacesForProject,
@@ -153,10 +154,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
         {wsLoad.source === 'api error' ? (
           <ErrorPanel title="Using cached workspaces" message={wsLoad.message ?? ''} />
         ) : null}
-        <CenteredMessage
-          title={project.name}
-          subtitle="No workspace exists for this project yet."
-        />
+        <CreateWorkspaceCTA projectId={project.id} />
       </AppShell>
     );
   }

--- a/apps/web/src/features/chat/useChatSessions.ts
+++ b/apps/web/src/features/chat/useChatSessions.ts
@@ -14,6 +14,10 @@ export interface ChatSessionsApi {
   cancel: (chatWindowId: string) => void;
 }
 
+export interface UseChatSessionsOptions {
+  onError?: (chatWindowId: string, error: ApiCallError) => void;
+}
+
 interface SessionState {
   messages: MockMessage[];
   pendingTempId: string | null;
@@ -43,11 +47,16 @@ function asApiCallError(err: unknown): ApiCallError {
   return new Error(typeof err === 'string' ? err : 'Unknown error') as ApiCallError;
 }
 
-export function useChatSessions(initial: Record<string, MockMessage[]>): ChatSessionsApi {
+export function useChatSessions(
+  initial: Record<string, MockMessage[]>,
+  options?: UseChatSessionsOptions,
+): ChatSessionsApi {
   const [sessions, setSessions] = useState<Sessions>(() => toSessions(initial));
   const controllers = useRef<Map<string, AbortController>>(new Map());
   const sessionsRef = useRef<Sessions>(sessions);
   sessionsRef.current = sessions;
+  const onErrorRef = useRef(options?.onError);
+  onErrorRef.current = options?.onError;
 
   useEffect(() => {
     const map = controllers.current;
@@ -115,6 +124,7 @@ export function useChatSessions(initial: Record<string, MockMessage[]>): ChatSes
   const fulfillError = useCallback(
     (chatWindowId: string, tempId: string, err: unknown) => {
       const e = asApiCallError(err);
+      if (e.code !== 'canceled') onErrorRef.current?.(chatWindowId, e);
       setSessions((prev) => {
         const current = prev[chatWindowId];
         if (!current) return prev;

--- a/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
+++ b/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useCallback, useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import type { AIProvider } from '@webapp/types';
+import { Button } from '@/components/Button';
+import { useToast } from '@/components/ToastHost';
+import { createChatWindow } from '@/lib/api/chat-windows';
+
+const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string; defaultModel: string }> = [
+  { value: 'openai', label: 'OpenAI', defaultModel: 'gpt-4o-mini' },
+  { value: 'anthropic', label: 'Anthropic', defaultModel: 'claude-sonnet-4-6' },
+  { value: 'perplexity', label: 'Perplexity', defaultModel: 'sonar-pro' },
+];
+
+interface CreateChatWindowCTAProps {
+  workspaceId: string;
+}
+
+export function CreateChatWindowCTA({ workspaceId }: CreateChatWindowCTAProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.75rem' }}>
+        <div style={{ fontSize: '1rem', color: '#e8e8ef' }}>No windows yet</div>
+        <div style={{ fontSize: '0.85rem', color: '#8a8a95' }}>
+          Add a chat window to start a conversation.
+        </div>
+        <Button onClick={() => setOpen(true)} style={{ marginTop: '0.5rem' }}>
+          Create chat window
+        </Button>
+      </div>
+      {open && (
+        <CreateChatWindowModal workspaceId={workspaceId} onClose={() => setOpen(false)} />
+      )}
+    </>
+  );
+}
+
+function CreateChatWindowModal({
+  workspaceId,
+  onClose,
+}: {
+  workspaceId: string;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const [title, setTitle] = useState('');
+  const [provider, setProvider] = useState<AIProvider>('openai');
+  const [model, setModel] = useState('gpt-4o-mini');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onProviderChange = (value: AIProvider) => {
+    setProvider(value);
+    const def = PROVIDER_OPTIONS.find((o) => o.value === value)?.defaultModel;
+    if (def) setModel(def);
+  };
+
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmedTitle = title.trim();
+      const trimmedModel = model.trim();
+      if (!trimmedTitle || !trimmedModel || submitting) return;
+      setSubmitting(true);
+      try {
+        await createChatWindow({
+          workspaceId,
+          title: trimmedTitle,
+          provider,
+          model: trimmedModel,
+        });
+        onClose();
+        router.refresh();
+      } catch (err) {
+        toast.pushError(err, 'create chat window');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [title, model, provider, submitting, workspaceId, onClose, router, toast],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-chat-window-title"
+      style={backdropStyle}
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        <h2 id="create-chat-window-title" style={{ margin: 0, fontSize: '1.05rem' }}>
+          New chat window
+        </h2>
+        <form
+          onSubmit={onSubmit}
+          style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}
+        >
+          <label style={fieldStyle}>
+            <span style={labelTextStyle}>Title</span>
+            <input
+              autoFocus
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              maxLength={120}
+              disabled={submitting}
+              style={inputStyle}
+            />
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelTextStyle}>Provider</span>
+            <select
+              value={provider}
+              onChange={(e) => onProviderChange(e.target.value as AIProvider)}
+              disabled={submitting}
+              style={inputStyle}
+            >
+              {PROVIDER_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={fieldStyle}>
+            <span style={labelTextStyle}>Model</span>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              required
+              maxLength={80}
+              disabled={submitting}
+              style={inputStyle}
+            />
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={submitting || !title.trim() || !model.trim()}
+            >
+              {submitting ? 'Creating…' : 'Create'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  padding: '1.5rem',
+  width: '100%',
+  maxWidth: 420,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  color: '#f5f5f5',
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const labelTextStyle: React.CSSProperties = {
+  fontSize: '0.78rem',
+  color: '#8a8a95',
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.55rem 0.7rem',
+  borderRadius: 6,
+  border: '1px solid #2a2a30',
+  background: '#0f0f13',
+  color: '#f5f5f5',
+  fontSize: '0.9rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};

--- a/apps/web/src/features/workspace/CreateWorkspaceCTA.tsx
+++ b/apps/web/src/features/workspace/CreateWorkspaceCTA.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback, useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/Button';
+import { Panel } from '@/components/Panel';
+import { useToast } from '@/components/ToastHost';
+import { createWorkspace } from '@/lib/api/workspaces';
+
+interface CreateWorkspaceCTAProps {
+  projectId: string;
+}
+
+export function CreateWorkspaceCTA({ projectId }: CreateWorkspaceCTAProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div style={{ padding: '3rem 1.5rem', maxWidth: 640, margin: '0 auto', width: '100%' }}>
+        <Panel style={{ padding: '2.5rem 2rem', textAlign: 'center' }}>
+          <div style={{ color: '#e8e8ef', fontSize: '1.1rem', fontWeight: 500 }}>
+            No workspace yet
+          </div>
+          <div
+            style={{
+              color: '#8a8a95',
+              fontSize: '0.9rem',
+              marginTop: 6,
+              marginBottom: '1.25rem',
+            }}
+          >
+            A workspace groups chat windows for this project.
+          </div>
+          <Button onClick={() => setOpen(true)}>Create workspace</Button>
+        </Panel>
+      </div>
+      {open && (
+        <CreateWorkspaceModal projectId={projectId} onClose={() => setOpen(false)} />
+      )}
+    </>
+  );
+}
+
+function CreateWorkspaceModal({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const router = useRouter();
+  const toast = useToast();
+  const [name, setName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = name.trim();
+      if (!trimmed || submitting) return;
+      setSubmitting(true);
+      try {
+        await createWorkspace({ projectId, name: trimmed });
+        onClose();
+        router.refresh();
+      } catch (err) {
+        toast.pushError(err, 'create workspace');
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [name, submitting, projectId, onClose, router, toast],
+  );
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-workspace-title"
+      style={backdropStyle}
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+    >
+      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
+        <h2 id="create-workspace-title" style={{ margin: 0, fontSize: '1.05rem' }}>
+          New workspace
+        </h2>
+        <form
+          onSubmit={onSubmit}
+          style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}
+        >
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={{ fontSize: '0.78rem', color: '#8a8a95' }}>Workspace name</span>
+            <input
+              autoFocus
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={120}
+              disabled={submitting}
+              style={inputStyle}
+            />
+          </label>
+          <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+            <Button type="button" variant="ghost" onClick={onClose} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? 'Creating…' : 'Create'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  padding: '1.5rem',
+  width: '100%',
+  maxWidth: 420,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+  color: '#f5f5f5',
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: '0.55rem 0.7rem',
+  borderRadius: 6,
+  border: '1px solid #2a2a30',
+  background: '#0f0f13',
+  color: '#f5f5f5',
+  fontSize: '0.9rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -2,10 +2,13 @@
 
 import type { ChatWindow, Workspace as WorkspaceType } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
+import { useCallback } from 'react';
 import { useWorkspaceState } from '@/features/workspace/useWorkspaceState';
 import { useChatSessions } from '@/features/chat/useChatSessions';
 import { WorkspaceSidebar } from '@/features/workspace/WorkspaceSidebar';
 import { WorkspaceCanvas } from '@/features/workspace/WorkspaceCanvas';
+import { useToast } from '@/components/ToastHost';
+import type { ApiCallError } from '@/lib/api/client';
 
 interface WorkspaceProps {
   projectId: string;
@@ -25,7 +28,17 @@ export function Workspace({
   messagesByWindow,
 }: WorkspaceProps) {
   const state = useWorkspaceState({ windows });
-  const chat = useChatSessions(messagesByWindow);
+  const toast = useToast();
+  const handleSendError = useCallback(
+    (chatWindowId: string, err: ApiCallError) => {
+      const win = windows.find((w) => w.id === chatWindowId);
+      const prefix = win?.title ?? 'Send failed';
+      const code = err.code ?? 'error';
+      toast.push('error', `${prefix}: ${code} — ${err.message}`);
+    },
+    [toast, windows],
+  );
+  const chat = useChatSessions(messagesByWindow, { onError: handleSendError });
 
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -44,6 +44,8 @@ export function Workspace({
         onReset={state.reset}
       />
       <WorkspaceCanvas
+        workspaceId={activeWorkspace.id}
+        totalWindows={state.visibleWindows.length + state.closedWindows.length}
         visibleWindows={state.visibleWindows}
         getMessages={chat.getMessages}
         isPending={chat.isPending}

--- a/apps/web/src/features/workspace/WorkspaceCanvas.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCanvas.tsx
@@ -2,10 +2,13 @@
 
 import type { ChatWindow as ChatWindowType } from '@webapp/types';
 import { ChatWindow } from '@/features/chat/ChatWindow';
+import { CreateChatWindowCTA } from '@/features/workspace/CreateChatWindowCTA';
 import type { MockMessage, WindowPreset } from '@/lib/data';
 import { WINDOW_PRESETS } from '@/lib/data';
 
 interface WorkspaceCanvasProps {
+  workspaceId: string;
+  totalWindows: number;
   visibleWindows: ChatWindowType[];
   getMessages: (chatWindowId: string) => MockMessage[];
   isPending: (chatWindowId: string) => boolean;
@@ -22,6 +25,8 @@ interface WorkspaceCanvasProps {
 }
 
 export function WorkspaceCanvas({
+  workspaceId,
+  totalWindows,
   visibleWindows,
   getMessages,
   isPending,
@@ -50,7 +55,13 @@ export function WorkspaceCanvas({
       }}
     >
       {visibleWindows.length === 0 ? (
-        <EmptyWorkspace hasClosed={hasClosed} onReset={onReset} onCreate={onCreate} />
+        <EmptyWorkspace
+          workspaceId={workspaceId}
+          totalWindows={totalWindows}
+          hasClosed={hasClosed}
+          onReset={onReset}
+          onCreate={onCreate}
+        />
       ) : (
         visibleWindows.map((w) => (
           <ChatWindow
@@ -76,14 +87,35 @@ export function WorkspaceCanvas({
 }
 
 function EmptyWorkspace({
+  workspaceId,
+  totalWindows,
   hasClosed,
   onReset,
   onCreate,
 }: {
+  workspaceId: string;
+  totalWindows: number;
   hasClosed: boolean;
   onReset: () => void;
   onCreate: (preset: WindowPreset, title?: string) => string;
 }) {
+  if (totalWindows === 0) {
+    return (
+      <div
+        style={{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '4rem 1rem',
+          color: '#8a8a95',
+        }}
+      >
+        <CreateChatWindowCTA workspaceId={workspaceId} />
+      </div>
+    );
+  }
   const defaultPreset = WINDOW_PRESETS[0]!;
   return (
     <div


### PR DESCRIPTION
## Summary
- Send-message + assistant-response loop already wired across `ChatWindow`, `useChatSessions` (optimistic render + retry + cancel), `WorkspaceCanvas`, project-detail page (`POST /v1/messages` via `postMessage` client).
- Adds `onError` callback to `useChatSessions` so the consumer can react to send failures.
- `Workspace` consumes that callback and pushes a toast via existing `ToastHost`. Cancel-by-user does not toast (suppressed when `code === 'canceled'`).

## Behaviour vs scope
- Empty input: ignored.
- Double submit: prevented (`pending` disables input + `submit()` early-returns).
- API error: failed message stays visible with inline retry, **plus** toast.
- Plain text only, user right / assistant left, no streaming, no markdown.
- Enter sends (input element fires form submit). No textarea, so Shift+Enter not needed.

## Test plan
- [ ] `pnpm --filter @webapp/web typecheck`
- [ ] `pnpm --filter @webapp/web lint`
- [ ] `pnpm --filter @webapp/web build`
- [ ] Manual: with backend up + provider key, open project → workspace, send a message, verify assistant reply appears
- [ ] Manual: kill backend, send a message, verify error toast appears and message shows failed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)