### PR TITLE
fix(web): hide unsupported providers in chat-window + provider settings

### DIFF
--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -15,8 +15,6 @@ import type { ApiCallError } from '@/lib/api/client';
 
 const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string }> = [
   { value: 'openai', label: 'OpenAI' },
-
-
 ];
 
 type LoadState =

--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -15,8 +15,8 @@ import type { ApiCallError } from '@/lib/api/client';
 
 const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string }> = [
   { value: 'openai', label: 'OpenAI' },
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'perplexity', label: 'Perplexity' },
+
+
 ];
 
 type LoadState =

--- a/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
+++ b/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
@@ -9,8 +9,8 @@ import { createChatWindow } from '@/lib/api/chat-windows';
 
 const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string; defaultModel: string }> = [
   { value: 'openai', label: 'OpenAI', defaultModel: 'gpt-4o-mini' },
-  { value: 'anthropic', label: 'Anthropic', defaultModel: 'claude-sonnet-4-6' },
-  { value: 'perplexity', label: 'Perplexity', defaultModel: 'sonar-pro' },
+
+
 ];
 
 interface CreateChatWindowCTAProps {

--- a/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
+++ b/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
@@ -9,8 +9,6 @@ import { createChatWindow } from '@/lib/api/chat-windows';
 
 const PROVIDER_OPTIONS: Array<{ value: AIProvider; label: string; defaultModel: string }> = [
   { value: 'openai', label: 'OpenAI', defaultModel: 'gpt-4o-mini' },
-
-
 ];
 
 interface CreateChatWindowCTAProps {


### PR DESCRIPTION
## Summary
End-to-end validation surfaced two product dead-ends caused by the UI offering Anthropic/Perplexity ahead of backend support:
- `POST /v1/provider-connections/anthropic` (or `perplexity`) → backend rejects with `400 validation_error: Provider 'anthropic' is not yet supported`. Form was failing in user's face.
- `POST /v1/chat-windows` with `provider: 'anthropic' | 'perplexity'` → backend accepts and persists; subsequent `POST /v1/messages` on that window persists the user row only and returns it as a single Message (not a `GeneratedMessagePair`). UI shows the user message, no assistant reply, no toast — silent dead-end.

This PR restricts the two API-connected entry points to OpenAI until the backend implements the other providers.

## Scope (deliberately tiny)
- `apps/web/src/features/workspace/CreateChatWindowCTA.tsx` — `PROVIDER_OPTIONS` reduced to OpenAI.
- `apps/web/src/app/settings/providers/page.tsx` — same.

Untouched on purpose:
- `lib/data/presets.ts`, `NewWindowComposer.tsx`, `ChatWindow.tsx` provider color/label maps — local mock-mode UI, no API write.

## Test plan
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`
- [ ] Manual: `/settings/providers` shows only OpenAI in the form select
- [ ] Manual: workspace empty state → "New chat window" modal shows only OpenAI

## Revert plan
When backend ships Anthropic + Perplexity providers, restore the two `PROVIDER_OPTIONS` arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)