### PR TITLE
fix(api): load dev env and reject unsupported chat providers

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -56,7 +56,7 @@ The suite runs green without `DATABASE_URL` (DB repos are mocked per test). To a
 
 ## Env vars
 
-Canonical template: [`apps/api/.env.example`](./.env.example). Copy it to `apps/api/.env` (or export the vars in your shell) and tweak values as needed. The table below documents each variable.
+Canonical template: [`apps/api/.env.example`](./.env.example). Copy it to `apps/api/.env` (or export the vars in your shell) and tweak values as needed. `pnpm --filter @webapp/api dev` auto-loads `apps/api/.env` when it exists (via `--env-file-if-exists`); shell-exported vars still win because Node's `--env-file*` flags don't override existing process env. The table below documents each variable.
 
 | Name                          | Default        | Notes                                                                                  |
 | ----------------------------- | -------------- | -------------------------------------------------------------------------------------- |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "lint": "echo \"(api) lint placeholder — no eslint config in repo yet\"",

--- a/apps/api/src/controllers/chat-windows-db.controller.ts
+++ b/apps/api/src/controllers/chat-windows-db.controller.ts
@@ -58,6 +58,7 @@ export function makeChatWindowsDeps(db: Db, sessionDeps: SessionDeps): ChatWindo
 // ── Body schemas ──────────────────────────────────────────────────────────────
 
 const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
+const SUPPORTED_PROVIDERS = new Set<AIProvider>(['openai']);
 
 const CreateChatWindowDbBody = s.object({
   workspaceId: s.string({ min: 1 }),
@@ -111,6 +112,14 @@ export async function createChatWindowDbController(
 
   const body = await parseJsonBody(ctx, CreateChatWindowDbBody);
   if (!body.ok) return body.result;
+
+  if (!SUPPORTED_PROVIDERS.has(body.value.provider)) {
+    return respondError(
+      'validation_error',
+      `Provider '${body.value.provider}' is not yet supported. Pick a supported provider (openai) — others land when their adapter ships.`,
+      400,
+    );
+  }
 
   const row = await deps.createChatWindow(
     body.value.workspaceId,

--- a/apps/api/src/controllers/chat-windows.controller.ts
+++ b/apps/api/src/controllers/chat-windows.controller.ts
@@ -21,6 +21,7 @@ import {
 import { workspaceExists } from '../services/workspaces.service.js';
 
 const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
+const SUPPORTED_PROVIDERS = new Set<AIProvider>(['openai']);
 
 const CreateChatWindowBody = s.object({
   workspaceId: s.string({ min: 1 }),
@@ -45,6 +46,14 @@ export function listChatWindowsController(ctx: RequestContext): InternalResult {
 export async function createChatWindowController(ctx: RequestContext): Promise<InternalResult> {
   const body = await parseJsonBody(ctx, CreateChatWindowBody);
   if (!body.ok) return body.result;
+
+  if (!SUPPORTED_PROVIDERS.has(body.value.provider)) {
+    return respondError(
+      'validation_error',
+      `Provider '${body.value.provider}' is not yet supported. Pick a supported provider (openai) — others land when their adapter ships.`,
+      400,
+    );
+  }
 
   if (!workspaceExists(body.value.workspaceId)) {
     return respondNotFound(`Workspace ${body.value.workspaceId} not found`);

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -161,14 +161,14 @@ describe('POST /v1/chat-windows — authenticated', () => {
         mockChatWindow(workspaceId, { id: 'new-cw', title, provider, model }),
     }));
     const res = await post(baseUrl, '/v1/chat-windows', {
-      workspaceId: 'ws-1', title: 'New Chat', provider: 'anthropic', model: 'claude-3-5-sonnet',
+      workspaceId: 'ws-1', title: 'New Chat', provider: 'openai', model: 'gpt-4o',
     });
     expect(res.status).toBe(201);
     const body = (await res.json()) as ApiResponse<ChatWindow>;
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.title).toBe('New Chat');
-    expect(body.data.provider).toBe('anthropic');
-    expect(body.data.model).toBe('claude-3-5-sonnet');
+    expect(body.data.provider).toBe('openai');
+    expect(body.data.model).toBe('gpt-4o');
     expect(res.headers.get('location')).toMatch(/\/v1\/chat-windows\//);
     await close();
   });
@@ -202,6 +202,29 @@ describe('POST /v1/chat-windows — authenticated', () => {
     expect(res.status).toBe(400);
     await close();
   });
+
+  for (const provider of ['anthropic', 'perplexity'] as const) {
+    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error (no silent dead-end)`, async () => {
+      let createCalled = false;
+      const { baseUrl, close } = await startServer(makeDeps({
+        resolveUser:      async () => USER_1,
+        createChatWindow: async (workspaceId, _userId, title, p, model) => {
+          createCalled = true;
+          return mockChatWindow(workspaceId, { title, provider: p, model });
+        },
+      }));
+      const res = await post(baseUrl, '/v1/chat-windows', {
+        workspaceId: 'ws-1', title: 'X', provider, model: 'm',
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ApiResponse<never>;
+      if (body.ok) throw new Error('expected error');
+      expect(body.error.code).toBe('validation_error');
+      expect(body.error.message).toContain('not yet supported');
+      expect(createCalled).toBe(false);
+      await close();
+    });
+  }
 });
 
 // ── Get chat window by id ─────────────────────────────────────────────────────

--- a/apps/api/src/routes/chat-windows.test.ts
+++ b/apps/api/src/routes/chat-windows.test.ts
@@ -77,7 +77,7 @@ describe('POST /v1/chat-windows', () => {
     const cwRes = await fetch(`${harness.baseUrl}/v1/chat-windows`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ workspaceId: ws.id, title: 'CW', provider: 'anthropic', model: 'claude-3-5-sonnet' }),
+      body: JSON.stringify({ workspaceId: ws.id, title: 'CW', provider: 'openai', model: 'gpt-4o' }),
     });
     const cwBody = (await cwRes.json()) as ApiResponse<ChatWindow>;
     if (!cwBody.ok) throw new Error('expected ok');
@@ -116,4 +116,20 @@ describe('POST /v1/chat-windows', () => {
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('invalid_body');
   });
+
+  for (const provider of ['anthropic', 'perplexity'] as const) {
+    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error`, async () => {
+      const ws = await createWorkspace(harness.baseUrl);
+      const res = await fetch(`${harness.baseUrl}/v1/chat-windows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workspaceId: ws.id, title: 'CW', provider, model: 'm' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as ApiResponse<unknown>;
+      if (body.ok) throw new Error('expected error envelope');
+      expect(body.error.code).toBe('validation_error');
+      expect(body.error.message).toContain('not yet supported');
+    });
+  }
 });

--- a/apps/api/src/routes/get-by-id.test.ts
+++ b/apps/api/src/routes/get-by-id.test.ts
@@ -88,7 +88,7 @@ describe('GET /v1/chat-windows/:id', () => {
   it('returns a chat window by id', async () => {
     const ws = await post<Workspace>('/v1/workspaces', { projectId: 'proj-1', name: 'WS' });
     const cw = await post<ChatWindow>('/v1/chat-windows', {
-      workspaceId: ws.id, title: 'CW GetById', provider: 'anthropic', model: 'claude-3-5-sonnet',
+      workspaceId: ws.id, title: 'CW GetById', provider: 'openai', model: 'gpt-4o',
     });
 
     const res = await fetch(`${harness.baseUrl}/v1/chat-windows/${cw.id}`);
@@ -97,7 +97,7 @@ describe('GET /v1/chat-windows/:id', () => {
     expect(body.ok).toBe(true);
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe(cw.id);
-    expect(body.data.provider).toBe('anthropic');
+    expect(body.data.provider).toBe('openai');
   });
 
   it('returns 404 for unknown chat window id', async () => {

--- a/apps/api/src/routes/ordering.test.ts
+++ b/apps/api/src/routes/ordering.test.ts
@@ -67,7 +67,7 @@ describe('list ordering — createdAt ASC, id ASC tie-breaker', () => {
   it('GET /v1/chat-windows — list is sorted by createdAt/id', async () => {
     const ws = await post<Workspace>('/v1/workspaces', { projectId: 'proj-1', name: 'WS' });
     await post<ChatWindow>('/v1/chat-windows', { workspaceId: ws.id, title: 'CW-A', provider: 'openai', model: 'gpt-4o' });
-    await post<ChatWindow>('/v1/chat-windows', { workspaceId: ws.id, title: 'CW-B', provider: 'anthropic', model: 'claude-3-5-sonnet' });
+    await post<ChatWindow>('/v1/chat-windows', { workspaceId: ws.id, title: 'CW-B', provider: 'openai', model: 'gpt-4o' });
     const list = await get<ChatWindow[]>(`/v1/chat-windows?workspaceId=${ws.id}`);
     expect(list.length).toBeGreaterThanOrEqual(2);
     assertSorted(list);


### PR DESCRIPTION
Two fixes raised by the E2E report.

## 1. Dev env auto-load

`pnpm --filter @webapp/api dev` ignored `apps/api/.env`, so `DATABASE_URL` was empty in fresh shells and the API silently fell back to in-memory mode (no auth, no DB write paths).

**Change:** dev script now uses `tsx watch --env-file-if-exists=.env`. Node's flag is gentle: missing file = no-op, no crash. Shell-exported vars still win because `--env-file*` flags don't override existing process env, so CI and ad-hoc `DATABASE_URL=… pnpm dev` keep working unchanged.

`.env` is already in root `.gitignore` — no risk of committing secrets. README updated to describe the auto-load.

## 2. Reject unsupported chat providers

`POST /v1/chat-windows` previously accepted `provider: 'anthropic' | 'perplexity'`. The chat window persisted, but `POST /v1/messages` only generates for `openai`, so non-openai windows turned into silent UX dead-ends — user message persisted, no assistant reply, no error.

**Change:** both DB and in-memory chat-window controllers reject valid-but-unsupported providers at creation time with `400 validation_error` and a clear message:

```
Provider 'anthropic' is not yet supported. Pick a supported provider (openai) — others land when their adapter ships.
```

This mirrors the existing `provider-connections` controller, which already gates non-openai key uploads. The OpenAI path is unchanged. `SUPPORTED_PROVIDERS` is a single-source `Set<AIProvider>(['openai'])` per controller — flip the set when an adapter ships.

Tests assert the repo's `createChatWindow` is **not** called when a non-openai provider is sent — no orphan rows.

## Test plan
- 4 new rejection tests across both routing modes (`anthropic` + `perplexity` × in-mem + db).
- Existing happy-path tests that used `'anthropic'` switched to `'openai'`.
- `pnpm --filter @webapp/api test` → **269/269 passing**.
- `pnpm typecheck` and `pnpm build` green.
- Verified the `--env-file-if-exists` flag is recognized by `tsx 4.19.2` and no-ops cleanly when `.env` is absent.

## Out of scope
- Implementing the Anthropic / Perplexity adapters themselves (issues #14 / #33).
- Switching the API to a real `dotenv` import (Node's built-in `--env-file*` does the job without a runtime dep).