### PR TITLE
feat(api): /v1/me alias for /v1/auth/me

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -238,6 +238,37 @@ describe('GET /v1/auth/me', () => {
   });
 });
 
+// ── Alias: /v1/me → /v1/auth/me ───────────────────────────────────────────────
+
+describe('GET /v1/me (alias of /v1/auth/me)', () => {
+  const KNOWN_TOKEN = 'c'.repeat(64);
+  const KNOWN_HASH  = hashSessionToken(KNOWN_TOKEN);
+  const USER        = mockUser();
+
+  it('returns 200 with safe user when session is valid', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async (h) => h === KNOWN_HASH ? mockSession(h) : null,
+      findUserById:           async (id) => id === USER.id ? USER : null,
+    }));
+    const res = await fetch(`${baseUrl}/v1/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${KNOWN_TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<SafeUser>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.id).toBe(USER.id);
+    expect('passwordHash' in body.data).toBe(false);
+    await close();
+  });
+
+  it('returns 401 with no cookie', async () => {
+    const { baseUrl, close } = await startServer(makeDeps());
+    const res = await fetch(`${baseUrl}/v1/me`);
+    expect(res.status).toBe(401);
+    await close();
+  });
+});
+
 // ── Logout ────────────────────────────────────────────────────────────────────
 
 describe('POST /v1/auth/logout', () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -11,6 +11,7 @@ import {
   API_AUTH_LOGIN_PATH,
   API_AUTH_LOGOUT_PATH,
   API_AUTH_ME_PATH,
+  API_ME_PATH,
 } from '@webapp/types';
 
 export function makeAuthRoutes(deps: AuthDeps): RouteDefinition[] {
@@ -19,5 +20,6 @@ export function makeAuthRoutes(deps: AuthDeps): RouteDefinition[] {
     { method: 'POST', path: API_AUTH_LOGIN_PATH,  handler: (ctx) => loginController(ctx, deps) },
     { method: 'POST', path: API_AUTH_LOGOUT_PATH, handler: (ctx) => logoutController(ctx, deps) },
     { method: 'GET',  path: API_AUTH_ME_PATH,     handler: (ctx) => meController(ctx, deps) },
+    { method: 'GET',  path: API_ME_PATH,          handler: (ctx) => meController(ctx, deps) },
   ];
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -138,6 +138,7 @@ export const API_AUTH_SIGNUP_PATH  = '/v1/auth/signup' as const;
 export const API_AUTH_LOGIN_PATH   = '/v1/auth/login' as const;
 export const API_AUTH_LOGOUT_PATH  = '/v1/auth/logout' as const;
 export const API_AUTH_ME_PATH      = '/v1/auth/me' as const;
+export const API_ME_PATH           = '/v1/me' as const;
 
 export interface SafeUser {
   id: string;


### PR DESCRIPTION
## Root cause
E2E run reported `GET /v1/me` returning `not_found`. Investigation: the frontend client uses `API_AUTH_ME_PATH` from `@webapp/types`, which resolves to **`/v1/auth/me`** — and the backend already serves it (`apps/api/src/routes/auth.ts`). The 404 came from the E2E script using the bare `/v1/me` convention, not the canonical path. So strictly there's no missing endpoint; the canonical contract is correct on both sides.

## What this PR does
Adds `GET /v1/me` as a thin alias of `GET /v1/auth/me` so:
- The canonical `/v1/auth/me` keeps working unchanged for the frontend.
- Manual curls / tooling / any future client that follows the common `/v1/me` convention resolves cleanly.
- Both paths share the same `meController` — no auth-state divergence possible.

A new `API_ME_PATH = '/v1/me'` constant in `@webapp/types` pins the alias so future renames stay in sync.

## Endpoints now supported
| Method | Path | Behaviour |
|---|---|---|
| GET | `/v1/auth/me` | Canonical (unchanged) |
| GET | `/v1/me` | Alias — same controller, same envelope |

## Tests
- 271/271 api tests passing (269 pre-existing + 2 new on the alias).
- Alias happy path: 200 + safe user when cookie is valid.
- Alias 401 with no cookie.
- The existing `/v1/auth/me` describe block is untouched.
- `pnpm typecheck` and `pnpm build` green.

## Out of scope
- Issue #29 (full session middleware refactor) is unrelated and stays in the backlog.