### PR TITLE
feat(web): provider_not_configured toast → settings link

### DIFF
--- a/apps/web/src/components/ToastHost.tsx
+++ b/apps/web/src/components/ToastHost.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import {
   createContext,
   useCallback,
@@ -13,15 +14,25 @@ import type { ApiCallError } from '@/lib/api/client';
 
 type ToastTone = 'success' | 'error' | 'info';
 
+export interface ToastAction {
+  label: string;
+  href: string;
+}
+
 export interface Toast {
   id: string;
   tone: ToastTone;
   message: string;
+  action?: ToastAction;
+}
+
+interface PushOptions {
+  action?: ToastAction;
 }
 
 interface ToastContextValue {
-  push: (tone: ToastTone, message: string) => void;
-  pushError: (error: unknown, prefix?: string) => void;
+  push: (tone: ToastTone, message: string, options?: PushOptions) => void;
+  pushError: (error: unknown, prefix?: string, options?: PushOptions) => void;
   dismiss: (id: string) => void;
 }
 
@@ -50,18 +61,18 @@ export function ToastHost({ children }: { children: ReactNode }) {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  const push = useCallback((tone: ToastTone, message: string) => {
+  const push = useCallback((tone: ToastTone, message: string, options?: PushOptions) => {
     const id = nextId();
-    setToasts((prev) => [...prev, { id, tone, message }]);
+    setToasts((prev) => [...prev, { id, tone, message, action: options?.action }]);
   }, []);
 
   const pushError = useCallback(
-    (error: unknown, prefix?: string) => {
+    (error: unknown, prefix?: string, options?: PushOptions) => {
       const e = error as ApiCallError | undefined;
       const code = e?.code ?? 'error';
       const msg = e?.message ?? 'Unknown error';
       const full = prefix ? `${prefix}: ${code} — ${msg}` : `${code} — ${msg}`;
-      push('error', full);
+      push('error', full, options);
     },
     [push],
   );
@@ -92,7 +103,19 @@ export function ToastHost({ children }: { children: ReactNode }) {
             style={{ ...toastStyle, ...toneStyles[t.tone] }}
             onClick={() => dismiss(t.id)}
           >
-            {t.message}
+            <div>{t.message}</div>
+            {t.action ? (
+              <Link
+                href={t.action.href}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dismiss(t.id);
+                }}
+                style={toastActionStyle}
+              >
+                {t.action.label}
+              </Link>
+            ) : null}
           </div>
         ))}
       </div>
@@ -118,6 +141,17 @@ const toastStyle: React.CSSProperties = {
   boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
   cursor: 'pointer',
   color: '#f5f5f5',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const toastActionStyle: React.CSSProperties = {
+  alignSelf: 'flex-start',
+  fontSize: '0.78rem',
+  fontWeight: 600,
+  textDecoration: 'underline',
+  color: 'inherit',
 };
 
 const toneStyles: Record<ToastTone, React.CSSProperties> = {

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -34,6 +34,12 @@ export function Workspace({
       const win = windows.find((w) => w.id === chatWindowId);
       const prefix = win?.title ?? 'Send failed';
       const code = err.code ?? 'error';
+      if (code === 'provider_not_configured') {
+        toast.push('error', `${prefix}: ${err.message}`, {
+          action: { label: 'Add provider key →', href: '/settings/providers' },
+        });
+        return;
+      }
       toast.push('error', `${prefix}: ${code} — ${err.message}`);
     },
     [toast, windows],


### PR DESCRIPTION
## Summary
First-run users hit `provider_not_configured` (412) when they send a message before adding an OpenAI key. The error toast surfaces the message but offers no path forward — they have to remember to navigate to /settings/providers themselves.

This PR adds an inline CTA inside the toast so the recovery is one click.

## Changes
- `ToastHost.push` / `pushError` accept an optional `{ action: { label, href } }`. When present, the toast renders a Next `<Link>` underneath the message (auto-dismisses on click).
- `Workspace.tsx#handleSendError` detects `code === 'provider_not_configured'` and pushes the toast with `action: { label: 'Add provider key →', href: '/settings/providers' }`. All other error codes keep the existing format.

## UX
**Before:** `QA Win: provider_not_configured — No OpenAI connection configured. Add your API key in provider settings.` — plain text, user navigates manually.

**After:** Same message, plus a tappable `Add provider key →` link that takes them straight to `/settings/providers`.

## Risk
`safe`. Pure additive change to ToastHost (optional field) — no callers break. Single new code path in Workspace gated on the exact backend error code.

## Test plan
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`
- [ ] Manual: send a message in a chat window with no OpenAI key configured → verify toast shows action link → click → land on /settings/providers
- [ ] Manual: trigger any other error (e.g. backend down) → verify plain toast still renders without action

🤖 Generated with [Claude Code](https://claude.com/claude-code)