### PR TITLE
test(api): add local AI smoke script

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -54,6 +54,22 @@ Vitest spins up the real server on an ephemeral port per suite and asserts on th
 
 The suite runs green without `DATABASE_URL` (DB repos are mocked per test). To also exercise the DB-backed path locally — applying drizzle migrations against a real Postgres before running tests — export `DATABASE_URL` (see `## Local Postgres (DB mode)` below) and run `pnpm --filter @webapp/api db:migrate` once, then `pnpm --filter @webapp/api test`. CI runs this variant in the `api-db-tests` job.
 
+### AI smoke (manual)
+
+End-to-end check of the full chat flow against a running API and a real OpenAI account:
+
+```bash
+# 1. API up + Postgres up + migrations applied (see "Local Postgres" below).
+# 2. apps/api/.env contains OPENAI_API_KEY (loaded automatically).
+pnpm api:smoke:ai
+# or equivalently:
+pnpm --filter @webapp/api smoke:ai
+```
+
+The script signs up a fresh user, creates a project / workspace / chat-window, upserts the OpenAI key, posts a message "hello", and asserts an assistant reply was persisted. It **never logs the key value**. Missing `OPENAI_API_KEY` fails fast with a clear message.
+
+This script is **not** wired into CI: it spends real OpenAI tokens and assumes a live API on `http://localhost:4000`. Override the target with `SMOKE_API_BASE_URL=…` or the model with `SMOKE_MODEL=…`.
+
 ## Env vars
 
 Canonical template: [`apps/api/.env.example`](./.env.example). Copy it to `apps/api/.env` (or export the vars in your shell) and tweak values as needed. `pnpm --filter @webapp/api dev` auto-loads `apps/api/.env` when it exists (via `--env-file-if-exists`); shell-exported vars still win because Node's `--env-file*` flags don't override existing process env. The table below documents each variable.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "smoke:ai": "node --env-file-if-exists=.env scripts/smoke-ai.mjs",
     "clean": "rm -rf dist .turbo",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/apps/api/scripts/smoke-ai.mjs
+++ b/apps/api/scripts/smoke-ai.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+// Local AI smoke test for @webapp/api.
+// Walks the full chat flow: signup → project → workspace → openai key →
+// chat-window → POST message → expect assistant reply.
+// Spends real OpenAI tokens. Not wired into CI on purpose.
+
+const BASE_URL = process.env.SMOKE_API_BASE_URL ?? 'http://localhost:4000';
+const MODEL    = process.env.SMOKE_MODEL ?? 'gpt-4o-mini';
+
+function fail(msg, extra) {
+  console.error(`✗ ${msg}`);
+  if (extra !== undefined) console.error(extra);
+  process.exit(1);
+}
+
+function pass(msg) {
+  console.log(`✓ ${msg}`);
+}
+
+if (!process.env.OPENAI_API_KEY) {
+  fail('OPENAI_API_KEY required (set it in apps/api/.env or in your shell)');
+}
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+// ── Cookie jar ────────────────────────────────────────────────────────────────
+
+const cookies = new Map();
+
+function captureCookies(setCookie) {
+  if (!setCookie) return;
+  const list = Array.isArray(setCookie) ? setCookie : [setCookie];
+  for (const raw of list) {
+    const [pair] = raw.split(';');
+    const eq = pair.indexOf('=');
+    if (eq < 0) continue;
+    cookies.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+  }
+}
+
+function cookieHeader() {
+  if (cookies.size === 0) return undefined;
+  return [...cookies.entries()].map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+async function req(method, path, body) {
+  const headers = { 'Content-Type': 'application/json' };
+  const c = cookieHeader();
+  if (c) headers['Cookie'] = c;
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  // Capture every Set-Cookie header (Node fetch returns a single string).
+  captureCookies(res.headers.getSetCookie?.() ?? res.headers.get('set-cookie'));
+  let json = null;
+  if (res.status !== 204) {
+    try { json = await res.json(); } catch { /* not json */ }
+  }
+  return { status: res.status, body: json };
+}
+
+async function expectOk(label, p) {
+  const { status, body } = await p;
+  if (status >= 400 || !body || body.ok !== true) {
+    const errCode = body?.error?.code ?? '<no-envelope>';
+    fail(`${label}: HTTP ${status} (${errCode})`, body);
+  }
+  pass(`${label} (HTTP ${status})`);
+  return body.data;
+}
+
+// ── Steps ─────────────────────────────────────────────────────────────────────
+
+const ts    = Date.now();
+const EMAIL = `smoke-${ts}@example.test`;
+const PASS  = `smoke-pass-${ts}-${Math.random().toString(36).slice(2)}`;
+
+console.log(`▶ smoke-ai against ${BASE_URL} as ${EMAIL}`);
+
+// 1. Health
+{
+  const { status, body } = await req('GET', '/v1/health');
+  if (status !== 200 || !body?.ok) {
+    fail(`health: API not reachable at ${BASE_URL} (HTTP ${status})`, body);
+  }
+  pass('health');
+}
+
+// 2. Signup
+const user = await expectOk('signup', req('POST', '/v1/auth/signup', { email: EMAIL, password: PASS }));
+if (!user?.id) fail('signup returned no user.id');
+
+// 3. Project
+const project = await expectOk('create project', req('POST', '/v1/projects', { name: `Smoke ${ts}` }));
+if (!project?.id) fail('project missing id');
+
+// 4. Workspace
+const workspace = await expectOk(
+  'create workspace',
+  req('POST', '/v1/workspaces', { projectId: project.id, name: 'Smoke WS' }),
+);
+if (!workspace?.id) fail('workspace missing id');
+
+// 5. OpenAI connection (apiKey from env, never printed)
+await expectOk(
+  'upsert openai connection',
+  req('PUT', '/v1/provider-connections/openai', { apiKey: OPENAI_API_KEY }),
+);
+
+// 6. Chat window
+const cw = await expectOk(
+  'create chat-window',
+  req('POST', '/v1/chat-windows', {
+    workspaceId: workspace.id,
+    title:       'Smoke Chat',
+    provider:    'openai',
+    model:       MODEL,
+  }),
+);
+if (!cw?.id) fail('chat-window missing id');
+
+// 7. Send message + verify assistant reply
+const pair = await expectOk(
+  'POST message "hello"',
+  req('POST', '/v1/messages', {
+    chatWindowId: cw.id,
+    role:         'user',
+    content:      'hello',
+  }),
+);
+
+if (!pair?.assistantMessage) fail('no assistantMessage in response');
+const am = pair.assistantMessage;
+if (am.role !== 'assistant')   fail(`assistant role wrong: ${am.role}`);
+if (typeof am.content !== 'string' || am.content.length === 0) {
+  fail('assistant content empty');
+}
+if (am.provider !== 'openai')  fail(`assistant provider wrong: ${am.provider}`);
+
+pass(`assistant reply (${am.content.length} chars, ${am.promptTokens ?? '?'} prompt + ${am.completionTokens ?? '?'} completion tokens, ${am.latencyMs ?? '?'}ms)`);
+
+console.log('\n✓ smoke-ai PASSED');

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "api:smoke:ai": "pnpm --filter @webapp/api smoke:ai",
     "format": "prettier --write \"**/*.{ts,tsx,js,json,md,css,yml,yaml}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md,css,yml,yaml}\"",
     "clean": "turbo run clean && rm -rf node_modules",


### PR DESCRIPTION
## Summary
Adds a local-only smoke script that walks the full backend chat flow against a running API + a real OpenAI account. Captures the manually validated golden path so it can be re-run on demand.

## What it validates
1. `GET /v1/health` reachable
2. `POST /v1/auth/signup` (fresh user per run)
3. `POST /v1/projects`
4. `POST /v1/workspaces`
5. `PUT /v1/provider-connections/openai` (upsert key — never logged)
6. `POST /v1/chat-windows` (provider=openai)
7. `POST /v1/messages` `"hello"` → assistant reply persisted
8. Asserts: `role=assistant`, non-empty `content`, `provider=openai`, surfaces token + latency counters

## Run
```bash
# Prereqs: API up on http://localhost:4000, Postgres up + migrated, apps/api/.env contains OPENAI_API_KEY
pnpm api:smoke:ai
# or
pnpm --filter @webapp/api smoke:ai
```

Override target / model:
```bash
SMOKE_API_BASE_URL=http://localhost:4000 SMOKE_MODEL=gpt-4o-mini pnpm api:smoke:ai
```

## Safety
- **Key never printed.** `OPENAI_API_KEY` is read from `process.env` and forwarded only inside the JSON body of the upsert request.
- **Missing key fails fast.** Without `OPENAI_API_KEY`, the script exits 1 with `OPENAI_API_KEY required` — no cryptic stack trace.
- **Pure Node ESM, no new deps.** Cookie jar built from `Set-Cookie` headers; nothing else.
- **Not in CI.** It spends real OpenAI tokens and assumes a live API. Wired locally only.

## Files changed
- `apps/api/scripts/smoke-ai.mjs` (new)
- `apps/api/package.json` — adds `smoke:ai` script
- `package.json` — adds root convenience alias `api:smoke:ai`
- `apps/api/README.md` — new "AI smoke (manual)" subsection

## Local verification
- Full smoke run: ✓ all steps green; assistant replied (34 chars, 8 prompt + 9 completion tokens, ~1.8s).
- Missing-key path: ✓ exits 1 with clear message.
- `pnpm typecheck`, `pnpm --filter @webapp/api test` (271/271), `pnpm build` — all green.