### PR TITLE
feat(web): streaming assistant responses

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -344,6 +344,23 @@ function Spinner() {
   );
 }
 
+function StreamingCursor() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 7,
+        height: '0.95em',
+        marginLeft: 2,
+        background: '#f5f5f5',
+        verticalAlign: '-2px',
+        animation: 'chat-blink 1s steps(2, end) infinite',
+      }}
+    />
+  );
+}
+
 function MessageBubble({
   message,
   onRetry,
@@ -361,6 +378,7 @@ function MessageBubble({
   const showMeta = isAssistant && metaParts.length > 0;
   const status = message.status ?? 'ok';
   const isPending = status === 'pending';
+  const isStreaming = status === 'streaming';
   const isFailed = status === 'failed';
   const borderColor = isFailed ? '#6b2a2a' : '#24242c';
   const opacity = isPending ? 0.7 : 1;
@@ -408,6 +426,7 @@ function MessageBubble({
         )}
       </div>
       {message.content}
+      {isStreaming && <StreamingCursor />}
       {isFailed && (
         <div
           style={{

--- a/apps/web/src/features/chat/useChatSessions.ts
+++ b/apps/web/src/features/chat/useChatSessions.ts
@@ -3,7 +3,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MockMessage } from '@/lib/data';
 import { getApiBaseUrl } from '@/lib/api/env';
-import { isGeneratedPair, postMessage, type PostMessageResult } from '@/lib/api/messages';
+import {
+  isGeneratedPair,
+  postMessage,
+  streamMessage,
+  type PostMessageResult,
+} from '@/lib/api/messages';
+import type { Message } from '@webapp/types';
 import type { ApiCallError } from '@/lib/api/client';
 
 export interface ChatSessionsApi {
@@ -16,6 +22,13 @@ export interface ChatSessionsApi {
 
 export interface UseChatSessionsOptions {
   onError?: (chatWindowId: string, error: ApiCallError) => void;
+  stream?: boolean;
+}
+
+let streamTempCounter = 0;
+function nextStreamAssistantId(chatWindowId: string): string {
+  streamTempCounter += 1;
+  return `tmp-asst-${chatWindowId}-${Date.now()}-${streamTempCounter}`;
 }
 
 interface SessionState {
@@ -57,6 +70,8 @@ export function useChatSessions(
   sessionsRef.current = sessions;
   const onErrorRef = useRef(options?.onError);
   onErrorRef.current = options?.onError;
+  const streamRef = useRef(options?.stream === true);
+  streamRef.current = options?.stream === true;
 
   useEffect(() => {
     const map = controllers.current;
@@ -149,6 +164,184 @@ export function useChatSessions(
     [],
   );
 
+  const seedStreamingAssistant = useCallback(
+    (chatWindowId: string, assistantTempId: string) => {
+      const now = new Date().toISOString();
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        const placeholder: MockMessage = {
+          id: assistantTempId,
+          chatWindowId,
+          role: 'assistant',
+          content: '',
+          createdAt: now,
+          status: 'streaming',
+          clientTempId: assistantTempId,
+        };
+        return {
+          ...prev,
+          [chatWindowId]: { ...current, messages: [...current.messages, placeholder] },
+        };
+      });
+    },
+    [],
+  );
+
+  const appendStreamDelta = useCallback(
+    (chatWindowId: string, assistantTempId: string, delta: string) => {
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            ...current,
+            messages: current.messages.map((m) =>
+              m.clientTempId === assistantTempId
+                ? { ...m, content: m.content + delta }
+                : m,
+            ),
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const finalizeStream = useCallback(
+    (
+      chatWindowId: string,
+      userTempId: string,
+      assistantTempId: string,
+      userRow: Message | null,
+      assistantRow: Message | null,
+    ) => {
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        const messages = current.messages
+          .map((m) => {
+            if (m.clientTempId === userTempId) {
+              if (userRow) {
+                return {
+                  id: userRow.id,
+                  chatWindowId: userRow.chatWindowId,
+                  role: userRow.role,
+                  content: userRow.content,
+                  createdAt: userRow.createdAt,
+                  status: 'ok' as const,
+                };
+              }
+              return { ...m, status: 'ok' as const };
+            }
+            if (m.clientTempId === assistantTempId) {
+              if (assistantRow) {
+                return {
+                  id: assistantRow.id,
+                  chatWindowId: assistantRow.chatWindowId,
+                  role: assistantRow.role,
+                  content: assistantRow.content,
+                  createdAt: assistantRow.createdAt,
+                  provider: assistantRow.provider ?? undefined,
+                  model: assistantRow.model ?? undefined,
+                  status: 'ok' as const,
+                };
+              }
+              return { ...m, status: 'ok' as const };
+            }
+            return m;
+          });
+        return {
+          ...prev,
+          [chatWindowId]: {
+            messages,
+            pendingTempId: current.pendingTempId === userTempId ? null : current.pendingTempId,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const dropStreamingPlaceholder = useCallback(
+    (chatWindowId: string, assistantTempId: string) => {
+      setSessions((prev) => {
+        const current = prev[chatWindowId];
+        if (!current) return prev;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            ...current,
+            messages: current.messages.filter((m) => m.clientTempId !== assistantTempId),
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const dispatchStream = useCallback(
+    (chatWindowId: string, tempId: string, content: string) => {
+      const ctrl = new AbortController();
+      controllers.current.get(chatWindowId)?.abort();
+      controllers.current.set(chatWindowId, ctrl);
+
+      const assistantTempId = nextStreamAssistantId(chatWindowId);
+      seedStreamingAssistant(chatWindowId, assistantTempId);
+
+      let userRow: Message | null = null;
+      let assistantRow: Message | null = null;
+
+      streamMessage(
+        { chatWindowId, role: 'user', content },
+        {
+          onUserMessage: (m) => {
+            userRow = m;
+          },
+          onDelta: (d) => appendStreamDelta(chatWindowId, assistantTempId, d),
+          onDone: (m) => {
+            assistantRow = m;
+          },
+        },
+        ctrl.signal,
+      )
+        .then(() => {
+          if (controllers.current.get(chatWindowId) === ctrl) {
+            controllers.current.delete(chatWindowId);
+          }
+          if (ctrl.signal.aborted) return;
+          finalizeStream(chatWindowId, tempId, assistantTempId, userRow, assistantRow);
+        })
+        .catch((err: unknown) => {
+          if (controllers.current.get(chatWindowId) === ctrl) {
+            controllers.current.delete(chatWindowId);
+          }
+          dropStreamingPlaceholder(chatWindowId, assistantTempId);
+          if (ctrl.signal.aborted) {
+            const code = (err as ApiCallError | null)?.code;
+            if (code === 'timeout') {
+              fulfillError(chatWindowId, tempId, err);
+            } else {
+              fulfillError(chatWindowId, tempId, {
+                code: 'canceled',
+                message: 'Request canceled',
+              });
+            }
+            return;
+          }
+          fulfillError(chatWindowId, tempId, err);
+        });
+    },
+    [
+      seedStreamingAssistant,
+      appendStreamDelta,
+      finalizeStream,
+      dropStreamingPlaceholder,
+      fulfillError,
+    ],
+  );
+
   const dispatchPost = useCallback(
     (chatWindowId: string, tempId: string, content: string) => {
       const ctrl = new AbortController();
@@ -211,9 +404,12 @@ export function useChatSessions(
           },
         };
       });
-      if (useApi) dispatchPost(chatWindowId, tempId, trimmed);
+      if (useApi) {
+        if (streamRef.current) dispatchStream(chatWindowId, tempId, trimmed);
+        else dispatchPost(chatWindowId, tempId, trimmed);
+      }
     },
-    [dispatchPost],
+    [dispatchPost, dispatchStream],
   );
 
   const retry = useCallback(
@@ -237,9 +433,10 @@ export function useChatSessions(
           },
         };
       });
-      dispatchPost(chatWindowId, clientTempId, target.content);
+      if (streamRef.current) dispatchStream(chatWindowId, clientTempId, target.content);
+      else dispatchPost(chatWindowId, clientTempId, target.content);
     },
-    [dispatchPost],
+    [dispatchPost, dispatchStream],
   );
 
   const cancel = useCallback((chatWindowId: string) => {

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -44,7 +44,10 @@ export function Workspace({
     },
     [toast, windows],
   );
-  const chat = useChatSessions(messagesByWindow, { onError: handleSendError });
+  const chat = useChatSessions(messagesByWindow, {
+    onError: handleSendError,
+    stream: true,
+  });
 
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>

--- a/apps/web/src/lib/api/messages.ts
+++ b/apps/web/src/lib/api/messages.ts
@@ -1,5 +1,6 @@
 import type { GeneratedMessagePair, Message, MessageRole } from '@webapp/types';
-import { apiFetch } from '@/lib/api/client';
+import { apiFetch, type ApiCallError } from '@/lib/api/client';
+import { getApiBaseUrl } from '@/lib/api/env';
 import { postJson } from '@/lib/api/http';
 
 export function fetchWindowMessages(
@@ -35,4 +36,117 @@ export function postMessage(
   signal?: AbortSignal,
 ): Promise<PostMessageResult> {
   return postJson<PostMessageResult>('/v1/messages', input, signal);
+}
+
+export interface StreamMessageHandlers {
+  onUserMessage?: (message: Message) => void;
+  onDelta?: (delta: string) => void;
+  onDone?: (assistant: Message | null) => void;
+}
+
+function toApiCallError(message: string, init: Partial<ApiCallError> = {}): ApiCallError {
+  const err = new Error(message) as ApiCallError;
+  if (init.code !== undefined) err.code = init.code;
+  if (init.status !== undefined) err.status = init.status;
+  if (init.cause !== undefined) err.cause = init.cause;
+  return err;
+}
+
+export async function streamMessage(
+  input: PostMessageInput,
+  handlers: StreamMessageHandlers,
+  signal?: AbortSignal,
+): Promise<void> {
+  const baseUrl = getApiBaseUrl();
+  if (!baseUrl) throw toApiCallError('NEXT_PUBLIC_API_URL is not configured', { code: 'no_api_url' });
+
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/v1/messages/stream`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'text/event-stream' },
+      body: JSON.stringify(input),
+      credentials: 'include',
+      cache: 'no-store',
+      signal,
+    });
+  } catch (err) {
+    const aborted = (err as { name?: string } | null)?.name === 'AbortError';
+    throw toApiCallError(
+      aborted ? 'Stream request aborted' : 'Network error opening stream',
+      { code: aborted ? 'canceled' : 'network_error', cause: err },
+    );
+  }
+
+  if (!res.ok || !res.body) {
+    let code = 'stream_error';
+    let message = `Stream failed with status ${res.status}`;
+    try {
+      const text = await res.text();
+      const parsed = text ? JSON.parse(text) : null;
+      if (parsed && parsed.ok === false && parsed.error) {
+        code = String(parsed.error.code ?? code);
+        message = String(parsed.error.message ?? message);
+      }
+    } catch {
+      // body wasn't JSON; keep defaults
+    }
+    throw toApiCallError(message, { code, status: res.status });
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep: number;
+      while ((sep = buffer.indexOf('\n\n')) >= 0) {
+        const rawEvent = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        const data = rawEvent
+          .split('\n')
+          .filter((l) => l.startsWith('data:'))
+          .map((l) => l.slice(5).trimStart())
+          .join('\n');
+        if (!data) continue;
+        if (data === '[DONE]') {
+          handlers.onDone?.(null);
+          return;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          continue;
+        }
+        const obj = parsed as Record<string, unknown> | null;
+        if (!obj || typeof obj !== 'object') continue;
+        if (typeof obj.delta === 'string') {
+          handlers.onDelta?.(obj.delta);
+          continue;
+        }
+        if (obj.error && typeof obj.error === 'object') {
+          const e = obj.error as Record<string, unknown>;
+          throw toApiCallError(String(e.message ?? 'Stream error'), {
+            code: String(e.code ?? 'stream_error'),
+          });
+        }
+        if (obj.userMessage && typeof obj.userMessage === 'object') {
+          handlers.onUserMessage?.(obj.userMessage as Message);
+        }
+        if (obj.assistantMessage && typeof obj.assistantMessage === 'object') {
+          handlers.onDone?.(obj.assistantMessage as Message);
+          return;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  handlers.onDone?.(null);
 }

--- a/apps/web/src/lib/mocks/fixtures.ts
+++ b/apps/web/src/lib/mocks/fixtures.ts
@@ -1,6 +1,6 @@
 import type { AIProvider, ChatWindow, MessageRole, Project, Workspace } from '@webapp/types';
 
-export type MockMessageStatus = 'pending' | 'ok' | 'failed';
+export type MockMessageStatus = 'pending' | 'streaming' | 'ok' | 'failed';
 
 export interface MockMessage {
   id: string;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -17,3 +17,8 @@ body {
     transform: rotate(360deg);
   }
 }
+
+@keyframes chat-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}


### PR DESCRIPTION
## Summary
Renders assistant replies token-by-token using SSE. Existing non-stream path is preserved as a fallback (gated by a hook option), so this PR is additive.

## Backend contract assumed
`POST /v1/messages/stream` returns `text/event-stream` with the following frame shapes:

| Frame                                            | Effect                                  |
|--------------------------------------------------|-----------------------------------------|
| `data: {"userMessage":{...}}`                    | Persisted user row                      |
| `data: {"delta":"text"}`                         | Append token to assistant bubble        |
| `data: {"assistantMessage":{...}}`               | Persisted assistant row, ends stream    |
| `data: {"error":{"code":"...","message":"..."}}` | Throws ApiCallError                     |
| `data: [DONE]`                                   | Closes the stream                       |

Non-2xx HTTP responses are parsed as the standard `{ok:false,error}` JSON envelope when present.

## Internal flow
1. User submits → optimistic user message rendered (existing).
2. `dispatchStream` seeds an empty assistant message with `status: 'streaming'`.
3. `streamMessage` opens `fetch` w/ `accept: text/event-stream`, reads `ReadableStream`, splits on `\n\n`, joins `data:` lines per frame.
4. Each delta calls `appendStreamDelta` → React state setter appends to that assistant bubble.
5. Final `assistantMessage` (or `[DONE]`) → `finalizeStream` swaps temp ids for real rows, marks `status: 'ok'`.
6. Errors → drop the streaming placeholder, mark user message `failed`, push toast.
7. Cancel → `AbortController` aborts the fetch; same code paths as non-stream.

## UX before / after
- Before: 5–30s blank wait, full reply appears at once.
- After: tokens stream in real-time with a blinking cursor; same toast/retry semantics on error.

## Risk / safety
- Pure additive in `lib/api/messages.ts` (new export `streamMessage`, plus `streamingCursor`-related CSS).
- Hook keeps the existing `postMessage` path; only callers that pass `stream: true` get the new behavior.
- `MockMessageStatus` widened with `'streaming'` — no exhaustive switches in the codebase rely on the union.

## Test plan
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`
- [ ] Manual (post backend ship): send a message → tokens appear progressively, cursor blinks, finalizes cleanly.
- [ ] Manual: error mid-stream → toast pushed, user message marked failed, retry button works.
- [ ] Manual: cancel mid-stream → placeholder removed, user message keeps `canceled`/`ok` semantics as before.

## Human action needed
Backend `POST /v1/messages/stream` must ship for streaming to activate. Until then, the route returns 404 → user sees a `network_error`/`stream_error` toast. Toggle `stream: false` in `Workspace.tsx` if you need to disable it before the backend lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)