### PR TITLE
feat(api): add streaming messages endpoint (SSE)

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -7,6 +7,7 @@ import {
   respondCreated,
   respondError,
   respondNotFound,
+  respondStreamed,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
@@ -18,7 +19,11 @@ import * as messagesRepo from '../db/messages.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
 import { getDecryptedApiKey } from '../db/provider-connections.repo.js';
 import { createOpenAIClient } from '../providers/openai.provider.js';
-import type { ChatCompletionResult, ChatMessage } from '../providers/provider.interface.js';
+import type {
+  ChatCompletionResult,
+  ChatCompletionStreamChunk,
+  ChatMessage,
+} from '../providers/provider.interface.js';
 
 // ── Provider timeout guard ────────────────────────────────────────────────────
 
@@ -77,6 +82,7 @@ export interface MessagesDeps {
   findChatWindow:    (chatWindowId: string, userId: string) => Promise<DbChatWindow | null>;
   getApiKey:         (userId: string, provider: AIProvider) => Promise<string | null>;
   generate:          (apiKey: string, messages: ChatMessage[], model: string) => Promise<ChatCompletionResult>;
+  generateStream:    (apiKey: string, messages: ChatMessage[], model: string) => AsyncIterable<ChatCompletionStreamChunk>;
   maxContextMessages: number;
   providerTimeoutMs?: number;
 }
@@ -91,6 +97,7 @@ export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps
     findChatWindow:    (chatWindowId, userId)              => chatWindowsRepo.findChatWindowById(db, chatWindowId, userId),
     getApiKey:         (userId, provider)                  => getDecryptedApiKey(db, userId, provider),
     generate:          (apiKey, msgs, model)               => createOpenAIClient(apiKey).createChatCompletion(msgs, model),
+    generateStream:    (apiKey, msgs, model)               => createOpenAIClient(apiKey).createChatCompletionStream(msgs, model),
     maxContextMessages: env.openaiMaxContextMessages,
   };
 }
@@ -236,4 +243,124 @@ export async function getMessageDbController(
   const id = ctx.params['id'] ?? '';
   const row = await deps.findMessage(id, user.id);
   return row ? respond(toMessage(row)) : respondNotFound(`Message ${id} not found`);
+}
+
+// ── Streaming controller ──────────────────────────────────────────────────────
+
+function sseWrite(res: import('node:http').ServerResponse, payload: unknown): void {
+  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+export async function streamMessageDbController(
+  ctx: RequestContext,
+  deps: MessagesDeps,
+): Promise<InternalResult> {
+  const user = await deps.resolveUser(ctx.req);
+  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+
+  const body = await parseJsonBody(ctx, CreateMessageDbBody);
+  if (!body.ok) return body.result;
+  if (body.value.role !== 'user') {
+    return respondError('validation_error', 'Streaming is only supported for role=user messages', 400);
+  }
+
+  const chatWindowId = body.value.chatWindowId;
+  const content = body.value.content;
+
+  const cw = await deps.findChatWindow(chatWindowId, user.id);
+  if (cw === null) return respondNotFound(`ChatWindow ${chatWindowId} not found`);
+  if (cw.provider !== 'openai') {
+    return respondError(
+      'provider_not_configured',
+      `Streaming is only supported for openai chat windows (got '${cw.provider}')`,
+      412,
+    );
+  }
+  const apiKey = await deps.getApiKey(user.id, 'openai');
+  if (!apiKey) {
+    return respondError(
+      'provider_not_configured',
+      'No OpenAI connection configured. Add your API key in provider settings.',
+      412,
+    );
+  }
+
+  const history = await deps.listMessages(chatWindowId, user.id);
+  const recentHistory = (history ?? []).slice(-deps.maxContextMessages);
+  const contextMessages: ChatMessage[] = [
+    ...recentHistory.map((m) => ({ role: m.role as ChatMessage['role'], content: m.content })),
+    { role: 'user', content },
+  ];
+
+  const res = ctx.res;
+  if (!res) return respondError('internal_error', 'Streaming requires a response object', 500);
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-store, no-transform',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+    'X-Request-Id': ctx.requestId,
+  });
+
+  const startedAt = Date.now();
+  let assistantContent = '';
+  let model = cw.model;
+  let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+  let aborted = false;
+
+  ctx.req.on('close', () => { aborted = true; });
+
+  try {
+    for await (const chunk of deps.generateStream(apiKey, contextMessages, cw.model)) {
+      if (aborted) break;
+      if (chunk.type === 'delta') {
+        assistantContent += chunk.content;
+        sseWrite(res, { delta: chunk.content });
+      } else {
+        model = chunk.model;
+        usage = chunk.usage;
+      }
+    }
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : 'Unknown provider error';
+    sseWrite(res, { error: detail });
+    res.write('data: [DONE]\n\n');
+    res.end();
+    return respondStreamed(502);
+  }
+
+  if (aborted || assistantContent.length === 0) {
+    // Client gave up or provider produced nothing — do NOT persist a half-baked pair.
+    if (!aborted) sseWrite(res, { error: 'empty_response' });
+    res.write('data: [DONE]\n\n');
+    res.end();
+    return respondStreamed(aborted ? 499 : 502);
+  }
+
+  const latencyMs = Date.now() - startedAt;
+  const assistantMetadata: AssistantMessageMetadata = {
+    provider:         'openai',
+    model,
+    promptTokens:     usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    latencyMs,
+  };
+
+  const pair = await deps.persistMessagePair(chatWindowId, user.id, content, assistantContent, assistantMetadata);
+  if (pair === null) {
+    sseWrite(res, { error: 'chat_window_not_found' });
+    res.write('data: [DONE]\n\n');
+    res.end();
+    return respondStreamed(404);
+  }
+
+  sseWrite(res, {
+    done: true,
+    userMessage:      toMessage(pair.userRow),
+    assistantMessage: toMessage(pair.assistantRow),
+  });
+  res.write('data: [DONE]\n\n');
+  res.end();
+  return respondStreamed(200);
 }

--- a/apps/api/src/lib/http.ts
+++ b/apps/api/src/lib/http.ts
@@ -11,6 +11,7 @@ export interface RequestContext {
   url: URL;
   requestId: string;
   req: IncomingMessage;
+  res?: ServerResponse;
   params: Record<string, string>;
 }
 
@@ -19,6 +20,13 @@ export interface InternalResult {
   httpStatus: number;
   body: ApiResponse<unknown>;
   headers?: Record<string, string>;
+  /** When true, the handler already wrote the response (used by streaming). Pipeline must not write again. */
+  streamed?: boolean;
+}
+
+/** Sentinel value for handlers that took over the response (e.g. SSE). */
+export function respondStreamed(httpStatus = 200): InternalResult {
+  return { httpStatus, body: { ok: true, data: null }, streamed: true };
 }
 
 export type RouteHandler = (ctx: RequestContext) => Promise<InternalResult> | InternalResult;

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -78,16 +78,18 @@ export async function handleRequest(
   }
 
   const { handler, params } = match;
-  const ctx: RequestContext = { method: rawMethod, path, url, requestId, req, params };
+  const ctx: RequestContext = { method: rawMethod, path, url, requestId, req, res, params };
 
   try {
-    const { httpStatus, body, headers } = await handler(ctx);
-    writeJson(res, httpStatus, body, requestId, headers);
+    const result = await handler(ctx);
+    if (!result.streamed) {
+      writeJson(res, result.httpStatus, result.body, requestId, result.headers);
+    }
     logger.info('request handled', {
       requestId,
       method: rawMethod,
       path,
-      status: httpStatus,
+      status: result.httpStatus,
       durationMs: Date.now() - startedAt,
     });
   } catch (err) {

--- a/apps/api/src/providers/openai.provider.test.ts
+++ b/apps/api/src/providers/openai.provider.test.ts
@@ -141,4 +141,45 @@ describe('createOpenAIClient', () => {
       });
     });
   });
+
+  describe('createChatCompletionStream', () => {
+    function sseStream(payloads: string[]): Response {
+      const body = payloads.map((p) => `data: ${p}\n\n`).join('') + 'data: [DONE]\n\n';
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(body));
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+    }
+
+    it('yields delta + done chunks parsed from SSE', async () => {
+      vi.mocked(fetch).mockResolvedValue(sseStream([
+        JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'Hi ' } }] }),
+        JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'there' } }] }),
+        JSON.stringify({ model: MODEL, choices: [{ delta: {} }], usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 } }),
+      ]));
+
+      const chunks = [];
+      for await (const c of createOpenAIClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+        chunks.push(c);
+      }
+      const deltas = chunks.filter((c) => c.type === 'delta').map((c) => c.type === 'delta' ? c.content : '');
+      const done   = chunks.find((c) => c.type === 'done');
+      expect(deltas.join('')).toBe('Hi there');
+      expect(done).toBeTruthy();
+      if (done?.type !== 'done') throw new Error('expected done');
+      expect(done.usage.promptTokens).toBe(4);
+      expect(done.usage.completionTokens).toBe(2);
+      expect(done.model).toBe(MODEL);
+    });
+
+    it('throws ProviderError when upstream returns non-2xx', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeErrorResponse(401, 'Invalid key'));
+
+      const it = createOpenAIClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
+      await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
+    });
+  });
 });

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -1,4 +1,9 @@
-import type { ChatCompletionResult, ChatMessage, ProviderClient } from './provider.interface.js';
+import type {
+  ChatCompletionResult,
+  ChatCompletionStreamChunk,
+  ChatMessage,
+  ProviderClient,
+} from './provider.interface.js';
 import { ProviderError } from './provider.interface.js';
 
 // ── Key verification ──────────────────────────────────────────────────────────
@@ -113,6 +118,95 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
           totalTokens:      data.usage?.total_tokens      ?? 0,
         },
       };
+    },
+
+    async *createChatCompletionStream(
+      messages: ChatMessage[],
+      model: string,
+    ): AsyncIterable<ChatCompletionStreamChunk> {
+      let res: Response;
+      try {
+        res = await fetch(OPENAI_CHAT_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+            'Accept': 'text/event-stream',
+          },
+          body: JSON.stringify({
+            model,
+            messages,
+            stream: true,
+            stream_options: { include_usage: true },
+          }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `OpenAI request failed: ${(err as Error).message}`,
+          'api_error',
+          'openai',
+        );
+      }
+
+      if (!res.ok || !res.body) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`OpenAI API error: ${detail}`, 'api_error', 'openai');
+      }
+
+      const decoder = new TextDecoder();
+      let buf = '';
+      let finalModel = model;
+      let usage: ChatCompletionResult['usage'] = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+
+          let idx;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            if (line === '' || !line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '[DONE]') continue;
+
+            let event: {
+              model?: string;
+              choices?: Array<{ delta?: { content?: string } }>;
+              usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+            };
+            try {
+              event = JSON.parse(payload);
+            } catch {
+              throw new ProviderError('Failed to parse OpenAI stream chunk', 'invalid_response', 'openai');
+            }
+
+            if (event.model) finalModel = event.model;
+            if (event.usage) {
+              usage = {
+                promptTokens:     event.usage.prompt_tokens     ?? 0,
+                completionTokens: event.usage.completion_tokens ?? 0,
+                totalTokens:      event.usage.total_tokens      ?? 0,
+              };
+            }
+            const delta = event.choices?.[0]?.delta?.content;
+            if (typeof delta === 'string' && delta.length > 0) {
+              yield { type: 'delta', content: delta };
+            }
+          }
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* ignore */ }
+      }
+
+      yield { type: 'done', model: finalModel, usage };
     },
   };
 }

--- a/apps/api/src/providers/provider.interface.ts
+++ b/apps/api/src/providers/provider.interface.ts
@@ -17,6 +17,12 @@ export interface ChatCompletionResult {
   };
 }
 
+// ── Streaming chunk ───────────────────────────────────────────────────────────
+
+export type ChatCompletionStreamChunk =
+  | { type: 'delta'; content: string }
+  | { type: 'done'; model: string; usage: ChatCompletionResult['usage'] };
+
 // ── Provider client contract ──────────────────────────────────────────────────
 
 export interface ProviderClient {
@@ -24,6 +30,11 @@ export interface ProviderClient {
     messages: ChatMessage[],
     model: string,
   ): Promise<ChatCompletionResult>;
+
+  createChatCompletionStream(
+    messages: ChatMessage[],
+    model: string,
+  ): AsyncIterable<ChatCompletionStreamChunk>;
 }
 
 // ── Typed error ───────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -63,6 +63,7 @@ function makeDeps(overrides: Partial<MessagesDeps> = {}): MessagesDeps {
     findChatWindow:     async () => mockChatWindow('anthropic'),
     getApiKey:          async () => null,
     generate:           async () => { throw new Error('should not be called in this test'); },
+    generateStream:     async function* () { throw new Error('should not be called in this test'); },
     maxContextMessages: 20,
     ...overrides,
   };
@@ -571,6 +572,140 @@ describe('GET /v1/messages/:id — user isolation', () => {
   it('returns 404 for non-existent message', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await get(baseUrl, '/v1/messages/does-not-exist');
+    expect(res.status).toBe(404);
+    await close();
+  });
+});
+
+// ── Streaming ────────────────────────────────────────────────────────────────
+
+async function readSseEvents(res: Response): Promise<string[]> {
+  if (!res.body) throw new Error('no body');
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  const events: string[] = [];
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    let idx;
+    while ((idx = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (line.startsWith('data:')) events.push(line.slice(5).trim());
+    }
+  }
+  return events;
+}
+
+describe('POST /v1/messages/stream — authenticated', () => {
+  it('streams deltas and persists the assistant message at the end', async () => {
+    let persistedAssistant: string | null = null;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:        async () => USER_1,
+      findChatWindow:     async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:          async () => 'sk-test',
+      listMessages:       async () => [],
+      generateStream:     async function* () {
+        yield { type: 'delta',  content: 'Hi ' };
+        yield { type: 'delta',  content: 'there!' };
+        yield { type: 'done',   model: 'gpt-4o-mini', usage: { promptTokens: 4, completionTokens: 3, totalTokens: 7 } };
+      },
+      persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) => {
+        persistedAssistant = assistantContent;
+        return mockPair(chatWindowId, userContent, assistantContent);
+      },
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hello' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type') ?? '').toMatch(/text\/event-stream/);
+
+    const events = await readSseEvents(res);
+    // Two deltas + final done payload + literal [DONE].
+    expect(events).toContain('[DONE]');
+    const deltas = events
+      .filter((e) => e !== '[DONE]')
+      .map((e) => JSON.parse(e) as { delta?: string; done?: boolean });
+    expect(deltas.filter((d) => typeof d.delta === 'string').map((d) => d.delta).join('')).toBe('Hi there!');
+    const final = deltas.find((d) => d.done === true);
+    expect(final).toBeTruthy();
+    expect(persistedAssistant).toBe('Hi there!');
+    await close();
+  });
+
+  it('emits an error event and does not persist when provider throws', async () => {
+    let persisted = false;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      generateStream: async function* () {
+        yield { type: 'delta', content: 'partial' };
+        throw new Error('upstream boom');
+      },
+      persistMessagePair: async () => { persisted = true; return null; },
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hello' });
+    expect(res.status).toBe(200);
+    const events = await readSseEvents(res);
+    const errEvent = events
+      .filter((e) => e !== '[DONE]')
+      .map((e) => JSON.parse(e) as { error?: string })
+      .find((e) => typeof e.error === 'string');
+    expect(errEvent?.error).toContain('upstream boom');
+    expect(persisted).toBe(false);
+    await close();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { baseUrl, close } = await startServer(makeDeps());
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
+    expect(res.status).toBe(401);
+    await close();
+  });
+
+  it('returns 412 provider_not_configured when chat-window provider is not openai', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('anthropic'),
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('provider_not_configured');
+    await close();
+  });
+
+  it('returns 412 when no openai connection is configured', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => null,
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
+    expect(res.status).toBe(412);
+    await close();
+  });
+
+  it('returns 400 when role is not user', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'assistant', content: 'hi' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('validation_error');
+    await close();
+  });
+
+  it('returns 404 when chat-window does not exist or is not owned', async () => {
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => null,
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'nope', role: 'user', content: 'hi' });
     expect(res.status).toBe(404);
     await close();
   });

--- a/apps/api/src/routes/messages-db.ts
+++ b/apps/api/src/routes/messages-db.ts
@@ -4,13 +4,15 @@ import {
   listMessagesDbController,
   createMessageDbController,
   getMessageDbController,
+  streamMessageDbController,
 } from '../controllers/messages-db.controller.js';
-import { API_MESSAGES_PATH } from '@webapp/types';
+import { API_MESSAGES_PATH, API_MESSAGES_STREAM_PATH } from '@webapp/types';
 
 export function makeMessageDbRoutes(deps: MessagesDeps): RouteDefinition[] {
   return [
     { method: 'GET',  path: API_MESSAGES_PATH,            handler: (ctx) => listMessagesDbController(ctx, deps) },
     { method: 'POST', path: API_MESSAGES_PATH,            handler: (ctx) => createMessageDbController(ctx, deps) },
+    { method: 'POST', path: API_MESSAGES_STREAM_PATH,     handler: (ctx) => streamMessageDbController(ctx, deps) },
     { method: 'GET',  path: `${API_MESSAGES_PATH}/:id`,   handler: (ctx) => getMessageDbController(ctx, deps) },
   ];
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -133,6 +133,7 @@ export const API_PROJECTS_PATH     = '/v1/projects' as const;
 export const API_WORKSPACES_PATH   = '/v1/workspaces' as const;
 export const API_CHAT_WINDOWS_PATH = '/v1/chat-windows' as const;
 export const API_MESSAGES_PATH     = '/v1/messages' as const;
+export const API_MESSAGES_STREAM_PATH = '/v1/messages/stream' as const;
 export const API_STATE_PATH        = '/v1/state' as const;
 export const API_AUTH_SIGNUP_PATH  = '/v1/auth/signup' as const;
 export const API_AUTH_LOGIN_PATH   = '/v1/auth/login' as const;


### PR DESCRIPTION
## Summary
Adds `POST /v1/messages/stream` — token-by-token streaming of assistant replies over Server-Sent Events. The existing `POST /v1/messages` keeps its non-streaming behaviour unchanged.

## Endpoint behavior
- **Auth + gating identical** to `POST /v1/messages`: requires session cookie, ownership-checked chat window, OpenAI provider configured.
- **Wire format (SSE):**

```
data: {"delta":"Hi "}
data: {"delta":"there!"}
data: {"done":true,"userMessage":{...},"assistantMessage":{...}}
data: [DONE]
```

- **On provider error mid-stream:** an error event then `[DONE]`:

```
data: {"error":"OpenAI API error: ..."}
data: [DONE]
```

## Example curl

```bash
curl -N -X POST http://localhost:4000/v1/messages/stream \
  -H 'Content-Type: application/json' \
  -b cookies.txt \
  -d '{"chatWindowId":"<id>","role":"user","content":"hello"}'
```

`-N` disables curl's output buffering so deltas print as they arrive.

## Persistence
- Full assistant content is **accumulated** during streaming, then persisted via the existing `persistMessagePair` atomic insert — so on-disk state is identical to the non-streaming endpoint.
- **Aborted clients** (TCP close mid-stream) and **empty provider responses** do NOT persist — avoids half-baked pairs.
- **Provider error mid-stream** emits the error event and skips persistence; the partial bytes already on the wire are deliberately not stored.

## Implementation notes
- `ProviderClient` gains `createChatCompletionStream` returning `AsyncIterable<{type:'delta',content} | {type:'done',model,usage}>`. Easy to extend for Anthropic / Perplexity adapters later.
- The OpenAI implementation posts `stream:true` with `stream_options.include_usage` and parses SSE chunks via a `ReadableStream` reader.
- `RequestContext` now exposes `res?` and `InternalResult` gains a `streamed?` flag. The middleware skips the JSON envelope writer when `streamed === true`. Pre-existing controllers untouched.
- `streamMessageDbController` reuses the existing user-resolve / chat-window-find / api-key-fetch / context-build flow; persistence goes through the same `persistMessagePair` already exercised by the non-streaming path.

## Limitations
- **Streaming is OpenAI-only.** Non-openai chat windows return `412 provider_not_configured` with a clear message — same gating as #20's chat-window create.
- **No keep-alive pings** yet. If the provider holds the connection open for tens of seconds before the first delta, intermediaries (some proxies, browser tabs) may close. Trivial to add a periodic `:ping` comment if it becomes a problem.
- **No reconnect / resume.** SSE clients that drop will need to POST again. We don't store partial bytes.
- **Aborted clients are detected via `req.on('close')`.** Status code returned to the pipeline log is 499 in that case (informational only — the response was already sent).

## Test plan
- 5 new route tests (`messages-db.test.ts`): success path with persistence, provider error mid-stream + no persistence, 401 unauth, 412 non-openai window, 412 no key, 400 non-user role, 404 unknown window.
- 2 new provider tests (`openai.provider.test.ts`): SSE parsing yields delta+done chunks; non-2xx upstream throws `ProviderError`.
- `pnpm --filter @webapp/api test` → **280/280 passing**.
- `pnpm typecheck` and `pnpm build` green.

## Out of scope
- Anthropic / Perplexity streaming adapters (issues #14 / #33).
- Frontend wiring of the new endpoint.
- Reconnect / resume protocol.