### PR TITLE
fix(web): include session credentials for project loading

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,7 +5,10 @@ import { Panel } from '@/components/Panel';
 import { listProjects as listMockProjects, listWorkspacesForProject } from '@/lib/data';
 import { getApiBaseUrl } from '@/lib/api/env';
 import { fetchProjects } from '@/lib/api/projects';
+import { serverApiHeaders } from '@/lib/api/server';
 import { CreateProjectEmptyState } from '@/features/projects/CreateProjectEmptyState';
+
+export const dynamic = 'force-dynamic';
 
 type ProjectsResult =
   | { source: 'api'; projects: Project[] }
@@ -17,7 +20,8 @@ async function loadProjects(): Promise<ProjectsResult> {
     return { source: 'mock', projects: listMockProjects() };
   }
   try {
-    const projects = await fetchProjects();
+    const headers = await serverApiHeaders();
+    const projects = await fetchProjects({ headers });
     return { source: 'api', projects };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';

--- a/apps/web/src/app/project/[id]/page.tsx
+++ b/apps/web/src/app/project/[id]/page.tsx
@@ -17,6 +17,7 @@ import { fetchProject } from '@/lib/api/projects';
 import { fetchProjectWorkspaces } from '@/lib/api/workspaces';
 import { fetchWorkspaceWindows } from '@/lib/api/chat-windows';
 import { fetchWindowMessages } from '@/lib/api/messages';
+import { serverApiHeaders } from '@/lib/api/server';
 import type { ApiCallError } from '@/lib/api/client';
 import type { ChatWindow } from '@webapp/types';
 
@@ -46,14 +47,14 @@ interface WindowsLoad {
   message?: string;
 }
 
-async function loadProject(id: string): Promise<ProjectLoad> {
+async function loadProject(id: string, headers: Record<string, string>): Promise<ProjectLoad> {
   if (!getApiBaseUrl()) {
     const project = getMockProject(id);
     if (!project) return { source: 'mock', project: null as unknown as Project };
     return { source: 'mock', project };
   }
   try {
-    const project = await fetchProject(id);
+    const project = await fetchProject(id, { headers });
     return { source: 'api', project };
   } catch (err) {
     const e = err as ApiCallError;
@@ -65,12 +66,16 @@ async function loadProject(id: string): Promise<ProjectLoad> {
   }
 }
 
-async function loadWorkspaces(projectId: string, projectFromApi: boolean): Promise<WorkspacesLoad> {
+async function loadWorkspaces(
+  projectId: string,
+  projectFromApi: boolean,
+  headers: Record<string, string>,
+): Promise<WorkspacesLoad> {
   if (!projectFromApi || !getApiBaseUrl()) {
     return { source: 'mock', workspaces: listWorkspacesForProject(projectId) };
   }
   try {
-    const workspaces = await fetchProjectWorkspaces(projectId);
+    const workspaces = await fetchProjectWorkspaces(projectId, { headers });
     return { source: 'api', workspaces };
   } catch (err) {
     const e = err as ApiCallError;
@@ -82,12 +87,16 @@ async function loadWorkspaces(projectId: string, projectFromApi: boolean): Promi
   }
 }
 
-async function loadWindows(workspaceId: string, workspacesFromApi: boolean): Promise<WindowsLoad> {
+async function loadWindows(
+  workspaceId: string,
+  workspacesFromApi: boolean,
+  headers: Record<string, string>,
+): Promise<WindowsLoad> {
   if (!workspacesFromApi || !getApiBaseUrl()) {
     return { source: 'mock', windows: getWindowsForWorkspace(workspaceId) };
   }
   try {
-    const windows = await fetchWorkspaceWindows(workspaceId);
+    const windows = await fetchWorkspaceWindows(workspaceId, { headers });
     return { source: 'api', windows };
   } catch (err) {
     const e = err as ApiCallError;
@@ -102,6 +111,7 @@ async function loadWindows(workspaceId: string, workspacesFromApi: boolean): Pro
 async function loadMessagesForWindows(
   windows: ChatWindow[],
   windowsFromApi: boolean,
+  headers: Record<string, string>,
 ): Promise<Record<string, MockMessage[]>> {
   const out: Record<string, MockMessage[]> = {};
   if (!windowsFromApi || !getApiBaseUrl()) {
@@ -111,7 +121,7 @@ async function loadMessagesForWindows(
   const results = await Promise.all(
     windows.map(async (w) => {
       try {
-        return [w.id, await fetchWindowMessages(w.id)] as const;
+        return [w.id, await fetchWindowMessages(w.id, { headers })] as const;
       } catch {
         return [w.id, getMessagesForWindow(w.id)] as const;
       }
@@ -125,7 +135,8 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
   const { id } = await params;
   const { workspace: workspaceParam } = await searchParams;
 
-  const load = await loadProject(id);
+  const headers = await serverApiHeaders();
+  const load = await loadProject(id, headers);
 
   if (load.source === 'error' && !load.project) {
     return (
@@ -142,7 +153,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
   }
 
   const project = load.project!;
-  const wsLoad = await loadWorkspaces(project.id, load.source === 'api');
+  const wsLoad = await loadWorkspaces(project.id, load.source === 'api', headers);
   const projectWorkspaces = wsLoad.workspaces;
 
   if (projectWorkspaces.length === 0) {
@@ -195,9 +206,9 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
     );
   }
 
-  const winLoad = await loadWindows(activeWorkspace.id, wsLoad.source === 'api');
+  const winLoad = await loadWindows(activeWorkspace.id, wsLoad.source === 'api', headers);
   const ws = winLoad.windows;
-  const messagesByWindow = await loadMessagesForWindows(ws, winLoad.source === 'api');
+  const messagesByWindow = await loadMessagesForWindows(ws, winLoad.source === 'api', headers);
 
   return (
     <Workspace

--- a/apps/web/src/lib/api/chat-windows.ts
+++ b/apps/web/src/lib/api/chat-windows.ts
@@ -3,14 +3,19 @@ import { API_CHAT_WINDOWS_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
 import { postJson } from '@/lib/api/http';
 
+export interface FetchOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
 export function fetchWorkspaceWindows(
   workspaceId: string,
-  signal?: AbortSignal,
+  options?: FetchOptions,
 ): Promise<ChatWindow[]> {
   const encoded = encodeURIComponent(workspaceId);
   return apiFetch<ChatWindow[]>(
     `${API_CHAT_WINDOWS_PATH}?workspaceId=${encoded}`,
-    signal ? { signal } : undefined,
+    options,
   );
 }
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -38,6 +38,7 @@ export interface ApiFetchOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: unknown;
   credentials?: RequestCredentials;
+  headers?: Record<string, string>;
 }
 
 export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
@@ -55,7 +56,7 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
   }
 
   const method = options.method ?? 'GET';
-  const headers: Record<string, string> = { accept: 'application/json' };
+  const headers: Record<string, string> = { accept: 'application/json', ...(options.headers ?? {}) };
   let bodyInit: BodyInit | undefined;
   if (options.body !== undefined) {
     headers['content-type'] = 'application/json';

--- a/apps/web/src/lib/api/messages.ts
+++ b/apps/web/src/lib/api/messages.ts
@@ -3,15 +3,17 @@ import { apiFetch, type ApiCallError } from '@/lib/api/client';
 import { getApiBaseUrl } from '@/lib/api/env';
 import { postJson } from '@/lib/api/http';
 
+export interface FetchMessagesOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
 export function fetchWindowMessages(
   chatWindowId: string,
-  signal?: AbortSignal,
+  options?: FetchMessagesOptions,
 ): Promise<Message[]> {
   const encoded = encodeURIComponent(chatWindowId);
-  return apiFetch<Message[]>(
-    `/v1/windows/${encoded}/messages`,
-    signal ? { signal } : undefined,
-  );
+  return apiFetch<Message[]>(`/v1/windows/${encoded}/messages`, options);
 }
 
 export interface PostMessageInput {

--- a/apps/web/src/lib/api/projects.ts
+++ b/apps/web/src/lib/api/projects.ts
@@ -2,13 +2,18 @@ import type { Project } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
 import { postJson } from '@/lib/api/http';
 
-export function fetchProjects(signal?: AbortSignal): Promise<Project[]> {
-  return apiFetch<Project[]>('/v1/projects', signal ? { signal } : undefined);
+export interface FetchOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
 }
 
-export function fetchProject(id: string, signal?: AbortSignal): Promise<Project> {
+export function fetchProjects(options?: FetchOptions): Promise<Project[]> {
+  return apiFetch<Project[]>('/v1/projects', options);
+}
+
+export function fetchProject(id: string, options?: FetchOptions): Promise<Project> {
   const encoded = encodeURIComponent(id);
-  return apiFetch<Project>(`/v1/projects/${encoded}`, signal ? { signal } : undefined);
+  return apiFetch<Project>(`/v1/projects/${encoded}`, options);
 }
 
 export interface CreateProjectInput {

--- a/apps/web/src/lib/api/server.ts
+++ b/apps/web/src/lib/api/server.ts
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers';
+
+export async function serverApiHeaders(): Promise<Record<string, string>> {
+  const store = await cookies();
+  const cookie = store
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+  return cookie ? { cookie } : {};
+}

--- a/apps/web/src/lib/api/workspaces.ts
+++ b/apps/web/src/lib/api/workspaces.ts
@@ -2,15 +2,17 @@ import type { Workspace } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
 import { postJson } from '@/lib/api/http';
 
+export interface FetchOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+}
+
 export function fetchProjectWorkspaces(
   projectId: string,
-  signal?: AbortSignal,
+  options?: FetchOptions,
 ): Promise<Workspace[]> {
   const encoded = encodeURIComponent(projectId);
-  return apiFetch<Workspace[]>(
-    `/v1/projects/${encoded}/workspaces`,
-    signal ? { signal } : undefined,
-  );
+  return apiFetch<Workspace[]>(`/v1/projects/${encoded}/workspaces`, options);
 }
 
 export interface CreateWorkspaceInput {


### PR DESCRIPTION
## Root cause
`app/page.tsx` and `app/project/[id]/page.tsx` are server components. They call `fetchProjects`, `fetchProject`, `fetchProjectWorkspaces`, `fetchWorkspaceWindows`, `fetchWindowMessages` directly. `apiFetch` sets `credentials: 'include'`, but that only matters for browser-origin requests — when these functions run inside a React Server Component, the outgoing fetch is a Node-side request to the API with no Cookie header. Backend correctly returns 401 `unauthenticated`, the page renders "Could not reach the API". `/v1/auth/me` worked because it's invoked from `SessionContext` (a client component), where the browser attached the session cookie automatically.

## Fix
Forward incoming cookies into the SSR fetch chain.

- `apiFetch` options gain `headers` passthrough (merged into outgoing request).
- New `lib/api/server.ts` exports `serverApiHeaders()` — reads cookies via `next/headers` and returns `{ cookie: "..." }`. Server-only import.
- SSR-callable wrappers (`fetchProjects`, `fetchProject`, `fetchProjectWorkspaces`, `fetchWorkspaceWindows`, `fetchWindowMessages`) now take `{ signal?, headers? }` instead of a bare `signal?`.
- `app/page.tsx` and `app/project/[id]/page.tsx` `await serverApiHeaders()` once and pass `headers` to every load helper.
- `app/page.tsx` marked `export const dynamic = 'force-dynamic'` so `cookies()` is allowed (was previously a static route by accident).

Auth is unchanged on the backend; cookies still travel exactly as before, just no longer dropped at the RSC boundary.

## Files changed
- `apps/web/src/lib/api/client.ts` — add `headers` option
- `apps/web/src/lib/api/server.ts` — new (server-only cookie forwarder)
- `apps/web/src/lib/api/projects.ts`, `workspaces.ts`, `chat-windows.ts`, `messages.ts` — wrappers accept `{ signal, headers }`
- `apps/web/src/app/page.tsx` — forward headers, force-dynamic
- `apps/web/src/app/project/[id]/page.tsx` — forward headers through every load helper

## Browser validation result
Reproduced the bug locally (web fetched mock data when SSR couldn't auth). With the fix:
- `POST /v1/auth/signup` → 201
- `POST /v1/projects` → 201
- `GET http://localhost:3000/` with session cookie → 200, homepage renders the real project ("api" badge, project name visible in HTML)
- Anonymous request to `/` still gets 200 with mock data fallback (existing behavior, unchanged).

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build` — `/` is now `ƒ Dynamic`, `/project/[id]` already was

🤖 Generated with [Claude Code](https://claude.com/claude-code)