### PR TITLE
fix(web): use canonical workspaces list endpoint

### DIFF
--- a/apps/web/src/lib/api/workspaces.ts
+++ b/apps/web/src/lib/api/workspaces.ts
@@ -1,4 +1,5 @@
 import type { Workspace } from '@webapp/types';
+import { API_WORKSPACES_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
 import { postJson } from '@/lib/api/http';
 
@@ -12,7 +13,7 @@ export function fetchProjectWorkspaces(
   options?: FetchOptions,
 ): Promise<Workspace[]> {
   const encoded = encodeURIComponent(projectId);
-  return apiFetch<Workspace[]>(`/v1/projects/${encoded}/workspaces`, options);
+  return apiFetch<Workspace[]>(`${API_WORKSPACES_PATH}?projectId=${encoded}`, options);
 }
 
 export interface CreateWorkspaceInput {


### PR DESCRIPTION
## Bug
After PR #96 wired SSR cookie forwarding, the project page server-side fetch reached the API correctly but hit a non-existent route:

\`\`\`
GET /v1/projects/<id>/workspaces  → 404
\`\`\`

So the project detail page silently fell back to its mock workspaces / windows / messages branch — chat windows did not render and message history was empty after refresh.

## Fix
Backend canonical endpoint (already used by `fetchWorkspaceWindows` for chat windows):

\`\`\`
GET /v1/workspaces?projectId=<id>
\`\`\`

`fetchProjectWorkspaces` now hits that URL via `API_WORKSPACES_PATH`. Single line change.

## End-to-end browser validation
With API + DB + OpenAI key + this fix, simulating a real browser session via curl + Next dev server:

| Step | Result |
|------|--------|
| `POST /v1/auth/signup` | 201 |
| `GET /` (RSC w/ cookie) | 200, "api" badge, real projects |
| `POST /v1/projects` / `/v1/workspaces` / `/v1/chat-windows` | 201 |
| `PUT /v1/provider-connections/openai` | 200 |
| `POST /v1/messages/stream` | 200, SSE frames `{"delta":"…"}` × N → `{"done":true,userMessage,assistantMessage}` → `[DONE]` |
| `GET /v1/windows/<cw>/messages` | 200, both rows persisted |
| `GET /project/<pid>` (RSC w/ cookie) | 200, page contains both message contents |

Frontend stream parser (`lib/api/messages.streamMessage`) already handles the exact frame shape the backend ships — no parser change needed.

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build` (no route size delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)