### PR TITLE
feat(web): chat window rename and delete controls

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -16,6 +16,7 @@ interface ChatWindowProps {
   onFocus?: (id: string) => void;
   onSend?: (id: string, content: string) => void;
   onRename?: (id: string, title: string) => void;
+  onDelete?: (id: string) => void;
   onRetry?: (id: string, clientTempId: string) => void;
   onCancel?: (id: string) => void;
 }
@@ -44,6 +45,7 @@ export function ChatWindow({
   onFocus,
   onSend,
   onRename,
+  onDelete,
   onRetry,
   onCancel,
 }: ChatWindowProps) {
@@ -176,27 +178,63 @@ export function ChatWindow({
           )}
           <ProviderBadge provider={provider} model={model} />
         </div>
-        {onClose ? (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose(id);
-            }}
-            aria-label="Close window"
-            style={{
-              background: 'transparent',
-              border: 'none',
-              color: '#8a8a95',
-              cursor: 'pointer',
-              fontSize: '1.1rem',
-              padding: '0.25rem 0.5rem',
-              borderRadius: 6,
-              lineHeight: 1,
-            }}
-          >
-            ×
-          </button>
-        ) : null}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          {onDelete ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                if (typeof window === 'undefined') {
+                  onDelete(id);
+                  return;
+                }
+                const ok = window.confirm(
+                  `Delete chat window "${title}"? This removes its messages and cannot be undone.`,
+                );
+                if (ok) onDelete(id);
+              }}
+              aria-label="Delete chat window"
+              title="Delete chat window"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#8a8a95',
+                cursor: 'pointer',
+                fontSize: '0.7rem',
+                fontWeight: 500,
+                padding: '0.25rem 0.5rem',
+                borderRadius: 6,
+                lineHeight: 1,
+                fontFamily: 'inherit',
+                textTransform: 'uppercase',
+                letterSpacing: '0.04em',
+              }}
+            >
+              Delete
+            </button>
+          ) : null}
+          {onClose ? (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onClose(id);
+              }}
+              aria-label="Close window"
+              title="Close window"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#8a8a95',
+                cursor: 'pointer',
+                fontSize: '1.1rem',
+                padding: '0.25rem 0.5rem',
+                borderRadius: 6,
+                lineHeight: 1,
+              }}
+            >
+              ×
+            </button>
+          ) : null}
+        </div>
       </div>
 
       <div

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -27,8 +27,17 @@ export function Workspace({
   windows,
   messagesByWindow,
 }: WorkspaceProps) {
-  const state = useWorkspaceState({ windows });
   const toast = useToast();
+  const handleWindowError = useCallback(
+    (action: 'rename' | 'delete', err: ApiCallError, win?: ChatWindow) => {
+      const verb = action === 'rename' ? 'Rename failed' : 'Delete failed';
+      const target = win?.title ? `“${win.title}”` : 'window';
+      const code = err.code ?? 'error';
+      toast.push('error', `${verb} for ${target}: ${code} — ${err.message}`);
+    },
+    [toast],
+  );
+  const state = useWorkspaceState({ windows, onError: handleWindowError });
   const handleSendError = useCallback(
     (chatWindowId: string, err: ApiCallError) => {
       const win = windows.find((w) => w.id === chatWindowId);
@@ -79,6 +88,7 @@ export function Workspace({
         onClose={state.close}
         onFocus={state.focus}
         onRename={state.renameWindow}
+        onDelete={state.deleteWindow}
         onReset={state.reset}
         onCreate={state.createWindow}
       />

--- a/apps/web/src/features/workspace/WorkspaceCanvas.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCanvas.tsx
@@ -20,6 +20,7 @@ interface WorkspaceCanvasProps {
   onClose: (id: string) => void;
   onFocus: (id: string) => void;
   onRename: (id: string, title: string) => void;
+  onDelete: (id: string) => void;
   onReset: () => void;
   onCreate: (preset: WindowPreset, title?: string) => string;
 }
@@ -38,6 +39,7 @@ export function WorkspaceCanvas({
   onClose,
   onFocus,
   onRename,
+  onDelete,
   onReset,
   onCreate,
 }: WorkspaceCanvasProps) {
@@ -77,6 +79,7 @@ export function WorkspaceCanvas({
             onFocus={onFocus}
             onSend={onSend}
             onRename={onRename}
+            onDelete={onDelete}
             onRetry={onRetry}
             onCancel={onCancel}
           />

--- a/apps/web/src/features/workspace/useWorkspaceState.ts
+++ b/apps/web/src/features/workspace/useWorkspaceState.ts
@@ -1,13 +1,19 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { ChatWindow } from '@webapp/types';
 import type { WindowPreset } from '@/lib/data';
-import { createChatWindow } from '@/lib/api/chat-windows';
+import {
+  createChatWindow,
+  deleteChatWindow,
+  patchChatWindow,
+} from '@/lib/api/chat-windows';
+import type { ApiCallError } from '@/lib/api/client';
 import { getApiBaseUrl } from '@/lib/api/env';
 
 interface WorkspaceStateInit {
   windows: ChatWindow[];
+  onError?: (action: 'rename' | 'delete', error: ApiCallError, window?: ChatWindow) => void;
 }
 
 interface WorkspaceState {
@@ -22,15 +28,18 @@ interface WorkspaceState {
   reset: () => void;
   createWindow: (preset: WindowPreset, customTitle?: string) => string;
   renameWindow: (id: string, title: string) => void;
+  deleteWindow: (id: string) => void;
 }
 
 let creationCounter = 0;
 
-export function useWorkspaceState({ windows }: WorkspaceStateInit): WorkspaceState {
+export function useWorkspaceState({ windows, onError }: WorkspaceStateInit): WorkspaceState {
   const initialIds = useMemo(() => windows.map((w) => w.id), [windows]);
   const [pool, setPool] = useState<ChatWindow[]>(windows);
   const [openIds, setOpenIds] = useState<string[]>(initialIds);
   const [activeId, setActiveId] = useState<string | null>(initialIds[0] ?? null);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   const close = useCallback((id: string) => {
     setOpenIds((prev) => {
@@ -102,7 +111,62 @@ export function useWorkspaceState({ windows }: WorkspaceStateInit): WorkspaceSta
   const renameWindow = useCallback((id: string, title: string) => {
     const trimmed = title.trim();
     if (!trimmed) return;
-    setPool((prev) => prev.map((w) => (w.id === id ? { ...w, title: trimmed } : w)));
+    let previous: ChatWindow | undefined;
+    setPool((prev) => {
+      previous = prev.find((w) => w.id === id);
+      if (!previous || previous.title === trimmed) return prev;
+      return prev.map((w) => (w.id === id ? { ...w, title: trimmed } : w));
+    });
+    if (!previous || previous.title === trimmed) return;
+    if (!getApiBaseUrl() || id.startsWith('local-')) return;
+
+    void patchChatWindow(id, { title: trimmed })
+      .then((persisted) => {
+        setPool((prev) => prev.map((w) => (w.id === id ? persisted : w)));
+      })
+      .catch((err: unknown) => {
+        const e = err as ApiCallError;
+        const restored = previous!;
+        setPool((prev) => prev.map((w) => (w.id === id ? restored : w)));
+        onErrorRef.current?.('rename', e, restored);
+      });
+  }, []);
+
+  const deleteWindow = useCallback((id: string) => {
+    let removed: ChatWindow | undefined;
+    let removedOpenIndex = -1;
+    let removedOpen = false;
+    setPool((prev) => {
+      removed = prev.find((w) => w.id === id);
+      if (!removed) return prev;
+      return prev.filter((w) => w.id !== id);
+    });
+    setOpenIds((prev) => {
+      removedOpenIndex = prev.indexOf(id);
+      if (removedOpenIndex < 0) return prev;
+      removedOpen = true;
+      const next = prev.filter((x) => x !== id);
+      setActiveId((current) => (current === id ? (next[0] ?? null) : current));
+      return next;
+    });
+    if (!removed) return;
+    if (!getApiBaseUrl() || id.startsWith('local-')) return;
+
+    void deleteChatWindow(id).catch((err: unknown) => {
+      const e = err as ApiCallError;
+      const restored = removed!;
+      setPool((prev) => (prev.some((w) => w.id === id) ? prev : [...prev, restored]));
+      if (removedOpen) {
+        setOpenIds((prev) => {
+          if (prev.includes(id)) return prev;
+          const next = [...prev];
+          const insertAt = Math.min(Math.max(removedOpenIndex, 0), next.length);
+          next.splice(insertAt, 0, id);
+          return next;
+        });
+      }
+      onErrorRef.current?.('delete', e, restored);
+    });
   }, []);
 
   const visibleWindows = useMemo(
@@ -127,5 +191,6 @@ export function useWorkspaceState({ windows }: WorkspaceStateInit): WorkspaceSta
     reset,
     createWindow,
     renameWindow,
+    deleteWindow,
   };
 }

--- a/apps/web/src/lib/api/chat-windows.ts
+++ b/apps/web/src/lib/api/chat-windows.ts
@@ -1,7 +1,7 @@
 import type { AIProvider, ChatWindow } from '@webapp/types';
 import { API_CHAT_WINDOWS_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
-import { postJson } from '@/lib/api/http';
+import { deleteJson, patchJson, postJson } from '@/lib/api/http';
 
 export interface FetchOptions {
   signal?: AbortSignal;
@@ -31,4 +31,22 @@ export function createChatWindow(
   signal?: AbortSignal,
 ): Promise<ChatWindow> {
   return postJson<ChatWindow>(API_CHAT_WINDOWS_PATH, input, signal);
+}
+
+export interface PatchChatWindowInput {
+  title?: string;
+}
+
+export function patchChatWindow(
+  id: string,
+  input: PatchChatWindowInput,
+  signal?: AbortSignal,
+): Promise<ChatWindow> {
+  const encoded = encodeURIComponent(id);
+  return patchJson<ChatWindow>(`${API_CHAT_WINDOWS_PATH}/${encoded}`, input, signal);
+}
+
+export function deleteChatWindow(id: string, signal?: AbortSignal): Promise<null> {
+  const encoded = encodeURIComponent(id);
+  return deleteJson<null>(`${API_CHAT_WINDOWS_PATH}/${encoded}`, signal);
 }

--- a/apps/web/src/lib/api/http.ts
+++ b/apps/web/src/lib/api/http.ts
@@ -78,3 +78,11 @@ export function postJson<T>(path: string, body: unknown, signal?: AbortSignal): 
 export function putJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
   return requestJson<T>('PUT', path, body, signal);
 }
+
+export function patchJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
+  return requestJson<T>('PATCH', path, body, signal);
+}
+
+export function deleteJson<T = null>(path: string, signal?: AbortSignal): Promise<T> {
+  return requestJson<T>('DELETE', path, undefined, signal);
+}


### PR DESCRIPTION
## Summary
Adds API-backed rename + delete for chat windows, surfaced from the existing chat window header. Sidebar already lists open + closed windows so chat windows are already exposed clearly; this PR wires the actions to the backend.

## UX before / after
| Action | Before | After |
|---|---|---|
| Rename | double-click title → local-only rename, lost on refresh | double-click title → optimistic update, `PATCH /v1/chat-windows/:id`, persisted; toast + rollback on failure |
| Delete | none — only "Close window" (×) which hid locally | new "Delete" button next to ×; `window.confirm` guard, `DELETE /v1/chat-windows/:id`, optimistic remove from pool + sidebar lists; toast + restore on failure (re-inserts at original sidebar position) |
| Close (×) | unchanged | unchanged — still hides locally only |
| Sidebar window list | already showed open + closed | unchanged |

## Files changed
- `apps/web/src/lib/api/http.ts` — `patchJson`, `deleteJson` helpers
- `apps/web/src/lib/api/chat-windows.ts` — `patchChatWindow`, `deleteChatWindow`
- `apps/web/src/features/workspace/useWorkspaceState.ts` — rename now hits the API; new `deleteWindow`; new `onError` callback
- `apps/web/src/features/workspace/Workspace.tsx` — `handleWindowError` → toast; passes `onDelete` down
- `apps/web/src/features/workspace/WorkspaceCanvas.tsx` — props/forwarding
- `apps/web/src/features/chat/ChatWindow.tsx` — optional `onDelete`, confirm + button in header

## Edge cases handled
- Empty / unchanged rename: no API call (no-op `setPool` short-circuit).
- Local-only window (`local-*` id, mock mode): rename + delete stay client-side — no API call attempted.
- Rename failure: previous title restored from the captured snapshot, error toast names the window.
- Delete failure: window restored to the pool, sidebar position recovered using the captured `openIds` index, error toast names the window.
- Active window deleted: `activeId` advances to the first remaining open id (or `null` if none).
- `window.confirm` only runs in the browser (`typeof window !== 'undefined'`); SSR safe.
- `requestJson` already parses the 204 envelope `{ok:true,data:null}` returned by `respondNoContent`, no special path needed.

## Constraints respected
- No backend changes.
- No new dependencies.
- No bulk actions.
- No project / workspace rename / delete touched.
- Server / client split intact (pure client-side state hook + `'use client'` chat window).

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)