### PR TITLE
feat(web): project and workspace rename/delete controls

### DIFF
--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useState, type KeyboardEvent } from 'react';
 import type { AIProvider, ChatWindow, Workspace } from '@webapp/types';
 import type { WindowPreset } from '@/lib/data';
 import { Button } from '@/components/Button';
 import { NewWindowComposer } from '@/features/workspace/NewWindowComposer';
+import { useToast } from '@/components/ToastHost';
+import type { ApiCallError } from '@/lib/api/client';
+import { deleteProject, patchProject } from '@/lib/api/projects';
+import { deleteWorkspace, patchWorkspace } from '@/lib/api/workspaces';
 
 interface WorkspaceSidebarProps {
   projectId: string;
@@ -69,7 +74,7 @@ export function WorkspaceSidebar({
         >
           ← Projects
         </Link>
-        <div style={{ fontSize: '0.95rem', fontWeight: 600, color: '#f5f5f5' }}>{projectName}</div>
+        <ProjectHeader projectId={projectId} projectName={projectName} />
         <WorkspaceSwitcher
           projectId={projectId}
           workspaces={workspaces}
@@ -136,6 +141,155 @@ export function WorkspaceSidebar({
   );
 }
 
+function ProjectHeader({ projectId, projectName }: { projectId: string; projectName: string }) {
+  const router = useRouter();
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(projectName);
+  const [name, setName] = useState(projectName);
+  const [busy, setBusy] = useState(false);
+  const isLocal = projectId.startsWith('local-') || projectId.startsWith('proj-');
+
+  const commit = useCallback(() => {
+    const trimmed = draft.trim();
+    setEditing(false);
+    if (!trimmed || trimmed === name) {
+      setDraft(name);
+      return;
+    }
+    if (isLocal) {
+      setName(trimmed);
+      return;
+    }
+    const previous = name;
+    setName(trimmed);
+    setBusy(true);
+    void patchProject(projectId, { name: trimmed })
+      .then((p) => {
+        setName(p.name);
+        setDraft(p.name);
+        router.refresh();
+      })
+      .catch((err: unknown) => {
+        const e = err as ApiCallError;
+        setName(previous);
+        setDraft(previous);
+        toast.push('error', `Rename project failed: ${e.code ?? 'error'} — ${e.message}`);
+      })
+      .finally(() => setBusy(false));
+  }, [draft, name, projectId, isLocal, router, toast]);
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setDraft(name);
+      setEditing(false);
+    }
+  };
+
+  const onDelete = () => {
+    if (busy) return;
+    if (typeof window === 'undefined') return;
+    const ok = window.confirm(
+      `Delete project "${name}"? This removes all its workspaces, chat windows, and messages. This cannot be undone.`,
+    );
+    if (!ok) return;
+    if (isLocal) {
+      router.replace('/');
+      return;
+    }
+    setBusy(true);
+    void deleteProject(projectId)
+      .then(() => {
+        router.replace('/');
+        router.refresh();
+      })
+      .catch((err: unknown) => {
+        const e = err as ApiCallError;
+        toast.push('error', `Delete project failed: ${e.code ?? 'error'} — ${e.message}`);
+        setBusy(false);
+      });
+  };
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      {editing ? (
+        <input
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={onKeyDown}
+          aria-label="Rename project"
+          style={{
+            flex: 1,
+            background: '#0f0f13',
+            border: '1px solid #2a2a30',
+            borderRadius: 4,
+            padding: '2px 6px',
+            color: '#f5f5f5',
+            fontSize: '0.95rem',
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            outline: 'none',
+          }}
+        />
+      ) : (
+        <button
+          onDoubleClick={() => {
+            setDraft(name);
+            setEditing(true);
+          }}
+          title="Double-click to rename"
+          style={{
+            flex: 1,
+            background: 'transparent',
+            border: 'none',
+            color: '#f5f5f5',
+            fontSize: '0.95rem',
+            fontWeight: 600,
+            fontFamily: 'inherit',
+            textAlign: 'left',
+            padding: 0,
+            cursor: 'text',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {name}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onDelete}
+        disabled={busy}
+        aria-label="Delete project"
+        title="Delete project"
+        style={{
+          background: 'transparent',
+          border: 'none',
+          color: '#8a8a95',
+          cursor: busy ? 'not-allowed' : 'pointer',
+          fontSize: '0.65rem',
+          fontWeight: 500,
+          padding: '2px 6px',
+          borderRadius: 4,
+          fontFamily: 'inherit',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          opacity: busy ? 0.5 : 1,
+        }}
+      >
+        Delete
+      </button>
+    </div>
+  );
+}
+
 function WorkspaceSwitcher({
   projectId,
   workspaces,
@@ -147,44 +301,171 @@ function WorkspaceSwitcher({
   activeWorkspaceId: string;
   activeWorkspaceName: string;
 }) {
+  const router = useRouter();
+  const toast = useToast();
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(activeWorkspaceName);
+  const [name, setName] = useState(activeWorkspaceName);
+  const [busy, setBusy] = useState(false);
+  const isLocal =
+    activeWorkspaceId.startsWith('local-') || activeWorkspaceId.startsWith('ws-');
   const single = workspaces.length <= 1;
+
+  const commit = () => {
+    const trimmed = draft.trim();
+    setEditing(false);
+    if (!trimmed || trimmed === name) {
+      setDraft(name);
+      return;
+    }
+    if (isLocal) {
+      setName(trimmed);
+      return;
+    }
+    const previous = name;
+    setName(trimmed);
+    setBusy(true);
+    void patchWorkspace(activeWorkspaceId, { name: trimmed })
+      .then((w) => {
+        setName(w.name);
+        setDraft(w.name);
+        router.refresh();
+      })
+      .catch((err: unknown) => {
+        const e = err as ApiCallError;
+        setName(previous);
+        setDraft(previous);
+        toast.push('error', `Rename workspace failed: ${e.code ?? 'error'} — ${e.message}`);
+      })
+      .finally(() => setBusy(false));
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      setDraft(name);
+      setEditing(false);
+    }
+  };
+
+  const onDelete = () => {
+    if (busy) return;
+    if (typeof window === 'undefined') return;
+    const ok = window.confirm(
+      `Delete workspace "${name}"? This removes all its chat windows and messages. This cannot be undone.`,
+    );
+    if (!ok) return;
+    if (isLocal) {
+      const next = workspaces.find((w) => w.id !== activeWorkspaceId);
+      router.replace(next ? `/project/${projectId}?workspace=${next.id}` : `/project/${projectId}`);
+      return;
+    }
+    setBusy(true);
+    void deleteWorkspace(activeWorkspaceId)
+      .then(() => {
+        const next = workspaces.find((w) => w.id !== activeWorkspaceId);
+        router.replace(next ? `/project/${projectId}?workspace=${next.id}` : `/project/${projectId}`);
+        router.refresh();
+      })
+      .catch((err: unknown) => {
+        const e = err as ApiCallError;
+        toast.push('error', `Delete workspace failed: ${e.code ?? 'error'} — ${e.message}`);
+        setBusy(false);
+      });
+  };
 
   return (
     <div style={{ position: 'relative', marginTop: 6 }}>
-      <button
-        onClick={() => !single && setOpen((v) => !v)}
-        disabled={single}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          width: '100%',
-          gap: 6,
-          background: '#181820',
-          border: '1px solid #24242c',
-          borderRadius: 6,
-          padding: '0.35rem 0.55rem',
-          color: '#e8e8ef',
-          fontSize: '0.78rem',
-          fontFamily: 'inherit',
-          cursor: single ? 'default' : 'pointer',
-          opacity: single ? 0.85 : 1,
-        }}
-      >
-        <span
+      <div style={{ display: 'flex', alignItems: 'stretch', gap: 4 }}>
+        {editing ? (
+          <input
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={onKeyDown}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Rename workspace"
+            style={{
+              flex: 1,
+              background: '#0f0f13',
+              border: '1px solid #2a2a30',
+              borderRadius: 6,
+              padding: '0.35rem 0.55rem',
+              color: '#f5f5f5',
+              fontSize: '0.78rem',
+              fontFamily: 'inherit',
+              outline: 'none',
+              minWidth: 0,
+            }}
+          />
+        ) : (
+          <button
+            onClick={() => !single && setOpen((v) => !v)}
+            onDoubleClick={() => {
+              setDraft(name);
+              setEditing(true);
+            }}
+            title={single ? 'Double-click to rename' : 'Switch · double-click to rename'}
+            style={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 6,
+              background: '#181820',
+              border: '1px solid #24242c',
+              borderRadius: 6,
+              padding: '0.35rem 0.55rem',
+              color: '#e8e8ef',
+              fontSize: '0.78rem',
+              fontFamily: 'inherit',
+              cursor: single ? 'text' : 'pointer',
+              minWidth: 0,
+            }}
+          >
+            <span
+              style={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {name}
+            </span>
+            {single ? null : (
+              <span style={{ color: '#8a8a95', fontSize: '0.7rem' }}>{open ? '▴' : '▾'}</span>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={busy}
+          aria-label="Delete workspace"
+          title="Delete workspace"
           style={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
+            background: 'transparent',
+            border: '1px solid #24242c',
+            color: '#8a8a95',
+            cursor: busy ? 'not-allowed' : 'pointer',
+            fontSize: '0.65rem',
+            fontWeight: 500,
+            padding: '0 0.5rem',
+            borderRadius: 6,
+            fontFamily: 'inherit',
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+            opacity: busy ? 0.5 : 1,
           }}
         >
-          {activeWorkspaceName}
-        </span>
-        {single ? null : (
-          <span style={{ color: '#8a8a95', fontSize: '0.7rem' }}>{open ? '▴' : '▾'}</span>
-        )}
-      </button>
+          Delete
+        </button>
+      </div>
       {open && !single ? (
         <div
           style={{

--- a/apps/web/src/lib/api/projects.ts
+++ b/apps/web/src/lib/api/projects.ts
@@ -1,6 +1,6 @@
 import type { Project } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
-import { postJson } from '@/lib/api/http';
+import { deleteJson, patchJson, postJson } from '@/lib/api/http';
 
 export interface FetchOptions {
   signal?: AbortSignal;
@@ -23,4 +23,23 @@ export interface CreateProjectInput {
 
 export function createProject(input: CreateProjectInput, signal?: AbortSignal): Promise<Project> {
   return postJson<Project>('/v1/projects', input, signal);
+}
+
+export interface PatchProjectInput {
+  name?: string;
+  description?: string;
+}
+
+export function patchProject(
+  id: string,
+  input: PatchProjectInput,
+  signal?: AbortSignal,
+): Promise<Project> {
+  const encoded = encodeURIComponent(id);
+  return patchJson<Project>(`/v1/projects/${encoded}`, input, signal);
+}
+
+export function deleteProject(id: string, signal?: AbortSignal): Promise<null> {
+  const encoded = encodeURIComponent(id);
+  return deleteJson<null>(`/v1/projects/${encoded}`, signal);
 }

--- a/apps/web/src/lib/api/workspaces.ts
+++ b/apps/web/src/lib/api/workspaces.ts
@@ -1,7 +1,7 @@
 import type { Workspace } from '@webapp/types';
 import { API_WORKSPACES_PATH } from '@webapp/types';
 import { apiFetch } from '@/lib/api/client';
-import { postJson } from '@/lib/api/http';
+import { deleteJson, patchJson, postJson } from '@/lib/api/http';
 
 export interface FetchOptions {
   signal?: AbortSignal;
@@ -26,4 +26,22 @@ export function createWorkspace(
   signal?: AbortSignal,
 ): Promise<Workspace> {
   return postJson<Workspace>('/v1/workspaces', input, signal);
+}
+
+export interface PatchWorkspaceInput {
+  name?: string;
+}
+
+export function patchWorkspace(
+  id: string,
+  input: PatchWorkspaceInput,
+  signal?: AbortSignal,
+): Promise<Workspace> {
+  const encoded = encodeURIComponent(id);
+  return patchJson<Workspace>(`${API_WORKSPACES_PATH}/${encoded}`, input, signal);
+}
+
+export function deleteWorkspace(id: string, signal?: AbortSignal): Promise<null> {
+  const encoded = encodeURIComponent(id);
+  return deleteJson<null>(`${API_WORKSPACES_PATH}/${encoded}`, signal);
 }


### PR DESCRIPTION
## Summary
Mirrors the chat-window rename/delete UX (#100) at the project + workspace levels. Frontend only, consistent shape, no layout redesign.

## UX before / after
| Action | Before | After |
|---|---|---|
| Rename project | not possible | double-click the project name in the sidebar header → inline input → Enter commits, Escape cancels. `PATCH /v1/projects/:id` on commit, `router.refresh()` on success; toast + rollback on failure. |
| Delete project | not possible | small "Delete" button next to the project name. `window.confirm` guard, `DELETE /v1/projects/:id`, `router.replace('/')` on success; toast on failure. |
| Rename workspace | not possible | double-click the active-workspace pill in the sidebar → inline input → Enter commits. `PATCH /v1/workspaces/:id`. Single-click on the pill still opens the dropdown when there are multiple workspaces. |
| Delete workspace | not possible | "Delete" button next to the workspace pill. `window.confirm`, `DELETE /v1/workspaces/:id`. On success: redirect to another workspace if any, otherwise `/project/:id` (which falls into the existing `CreateWorkspaceCTA` empty state). |
| Chat-window rename/delete | from #100 | unchanged. |

## API client
- `lib/api/projects.ts`: `patchProject`, `deleteProject`
- `lib/api/workspaces.ts`: `patchWorkspace`, `deleteWorkspace`

Reuses the `patchJson` / `deleteJson` helpers introduced in #100; no new HTTP plumbing.

## Files changed
- `apps/web/src/lib/api/projects.ts`
- `apps/web/src/lib/api/workspaces.ts`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`

## Edge cases handled
- Empty / unchanged rename → no API call (`!trimmed || trimmed === name` short-circuit).
- API failure → previous name restored, error toast naming the entity.
- Delete failure → toast + busy released, no navigation.
- Active workspace deleted → falls back to first remaining workspace; if none, lands on `/project/:id` empty state.
- Active project deleted → `router.replace('/')` so the user never sees a 404 page on a stale id.
- Mock / fixture ids (`proj-*`, `ws-*`, `local-*`) stay client-side, never hit the API, matching the existing chat-window pattern.
- SSR-safe `window.confirm` (`typeof window !== 'undefined'`).
- Busy guard on Delete button prevents double-click during the round trip.
- Editing input on `Enter` commits, on `Escape` cancels and restores draft.

## Constraints respected
- Frontend only.
- No new dependencies.
- No bulk actions, no project-list-level controls, no layout redesign.
- Consistent with chat-window rename/delete UX (double-click rename, inline Delete tag, `window.confirm`, toast on failure).

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)