### PR TITLE
polish(web): chat history navigation states

### DIFF
--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -2,7 +2,8 @@
 
 import type { ChatWindow, Workspace as WorkspaceType } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useWorkspaceState } from '@/features/workspace/useWorkspaceState';
 import { useChatSessions } from '@/features/chat/useChatSessions';
 import { WorkspaceSidebar } from '@/features/workspace/WorkspaceSidebar';
@@ -28,6 +29,10 @@ export function Workspace({
   messagesByWindow,
 }: WorkspaceProps) {
   const toast = useToast();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const initialWindowParam = searchParams?.get('window') ?? null;
   const handleWindowError = useCallback(
     (action: 'rename' | 'delete', err: ApiCallError, win?: ChatWindow) => {
       const verb = action === 'rename' ? 'Rename failed' : 'Delete failed';
@@ -37,7 +42,25 @@ export function Workspace({
     },
     [toast],
   );
-  const state = useWorkspaceState({ windows, onError: handleWindowError });
+  const state = useWorkspaceState({
+    windows,
+    initialActiveId: initialWindowParam,
+    onError: handleWindowError,
+  });
+  const lastSyncedWindowRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pathname) return;
+    const current = state.activeId;
+    if (lastSyncedWindowRef.current === current) return;
+    lastSyncedWindowRef.current = current;
+    if (current && current.startsWith('local-')) return;
+    const next = new URLSearchParams(searchParams?.toString() ?? '');
+    next.set('workspace', activeWorkspace.id);
+    if (current) next.set('window', current);
+    else next.delete('window');
+    const target = `${pathname}?${next.toString()}`;
+    router.replace(target, { scroll: false });
+  }, [pathname, router, searchParams, state.activeId, activeWorkspace.id]);
   const handleSendError = useCallback(
     (chatWindowId: string, err: ApiCallError) => {
       const win = windows.find((w) => w.id === chatWindowId);

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -554,9 +554,11 @@ interface WindowRowProps {
 }
 
 function WindowRow({ window, active, muted, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+  const stamp = formatRelative(window.updatedAt ?? window.createdAt);
   return (
     <div
       onClick={onClick}
+      aria-current={active ? 'true' : undefined}
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -565,9 +567,11 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
         borderRadius: 8,
         cursor: 'pointer',
         background: active ? '#1c1c28' : 'transparent',
-        border: `1px solid ${active ? '#3a3f6b' : 'transparent'}`,
-        opacity: muted ? 0.6 : 1,
+        border: `1px solid ${active ? '#4f6bff' : 'transparent'}`,
+        boxShadow: active ? '0 0 0 1px rgba(79,107,255,0.25)' : 'none',
+        opacity: muted ? 0.55 : 1,
         marginBottom: 2,
+        transition: 'background 120ms ease, border-color 120ms ease',
       }}
     >
       <span
@@ -577,30 +581,79 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
           borderRadius: '50%',
           background: providerColor[window.provider],
           flexShrink: 0,
+          boxShadow: active ? '0 0 0 2px rgba(79,107,255,0.18)' : 'none',
         }}
       />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
             fontSize: '0.82rem',
-            color: '#e8e8ef',
+            color: active ? '#f5f5f5' : '#e8e8ef',
+            fontWeight: active ? 600 : 500,
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
           }}
         >
-          {window.title}
+          <span
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            {window.title}
+          </span>
+          {active ? (
+            <span
+              style={{
+                marginLeft: 'auto',
+                fontSize: '0.62rem',
+                fontWeight: 600,
+                color: '#9aa6ff',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                flexShrink: 0,
+              }}
+            >
+              Active
+            </span>
+          ) : null}
         </div>
         <div
           style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
             fontSize: '0.68rem',
             color: '#8a8a95',
             overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
           }}
         >
-          {window.provider} · {window.model}
+          <span
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              minWidth: 0,
+            }}
+          >
+            {window.provider} · {window.model}
+          </span>
+          {stamp ? (
+            <span
+              style={{
+                marginLeft: 'auto',
+                color: '#6a6a75',
+                flexShrink: 0,
+              }}
+              title={window.updatedAt ?? window.createdAt}
+            >
+              {stamp}
+            </span>
+          ) : null}
         </div>
       </div>
       <button
@@ -624,4 +677,26 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
       </button>
     </div>
   );
+}
+
+function formatRelative(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  const diff = Date.now() - t;
+  if (diff < 0) return 'just now';
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d`;
+  const wk = Math.floor(day / 7);
+  if (wk < 5) return `${wk}w`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo`;
+  const yr = Math.floor(day / 365);
+  return `${yr}y`;
 }

--- a/apps/web/src/features/workspace/useWorkspaceState.ts
+++ b/apps/web/src/features/workspace/useWorkspaceState.ts
@@ -13,7 +13,22 @@ import { getApiBaseUrl } from '@/lib/api/env';
 
 interface WorkspaceStateInit {
   windows: ChatWindow[];
+  initialActiveId?: string | null;
   onError?: (action: 'rename' | 'delete', error: ApiCallError, window?: ChatWindow) => void;
+}
+
+function pickInitialActive(windows: ChatWindow[], hint: string | null | undefined): string | null {
+  if (hint && windows.some((w) => w.id === hint)) return hint;
+  if (windows.length === 0) return null;
+  const sorted = [...windows].sort((a, b) => {
+    const ta = Date.parse(a.updatedAt ?? a.createdAt);
+    const tb = Date.parse(b.updatedAt ?? b.createdAt);
+    if (Number.isNaN(ta) && Number.isNaN(tb)) return 0;
+    if (Number.isNaN(ta)) return 1;
+    if (Number.isNaN(tb)) return -1;
+    return tb - ta;
+  });
+  return sorted[0]?.id ?? null;
 }
 
 interface WorkspaceState {
@@ -33,11 +48,17 @@ interface WorkspaceState {
 
 let creationCounter = 0;
 
-export function useWorkspaceState({ windows, onError }: WorkspaceStateInit): WorkspaceState {
+export function useWorkspaceState({
+  windows,
+  initialActiveId,
+  onError,
+}: WorkspaceStateInit): WorkspaceState {
   const initialIds = useMemo(() => windows.map((w) => w.id), [windows]);
   const [pool, setPool] = useState<ChatWindow[]>(windows);
   const [openIds, setOpenIds] = useState<string[]>(initialIds);
-  const [activeId, setActiveId] = useState<string | null>(initialIds[0] ?? null);
+  const [activeId, setActiveId] = useState<string | null>(() =>
+    pickInitialActive(windows, initialActiveId),
+  );
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
 
@@ -61,8 +82,8 @@ export function useWorkspaceState({ windows, onError }: WorkspaceStateInit): Wor
   const reset = useCallback(() => {
     setPool(windows);
     setOpenIds(initialIds);
-    setActiveId(initialIds[0] ?? null);
-  }, [windows, initialIds]);
+    setActiveId(pickInitialActive(windows, initialActiveId));
+  }, [windows, initialIds, initialActiveId]);
 
   const createWindow = useCallback(
     (preset: WindowPreset, customTitle?: string) => {


### PR DESCRIPTION
## Summary
Tightens selection + sidebar visual states so the user can always tell which window they are in, and refresh keeps them on it.

## Selection rules (priority order)
1. URL `?window=<id>` if that id exists in the current workspace's window pool.
2. Most recently updated (or created) window in the pool.
3. `null` (empty state) if there are no windows.

`useWorkspaceState({ windows, initialActiveId })` applies these on mount and on `reset()`. `Workspace.tsx` extracts `?window` from `searchParams` and feeds it as `initialActiveId`.

## URL stability
- `Workspace.tsx` watches `state.activeId`. When it changes, `router.replace` rewrites the URL with both `?workspace=<id>` and `?window=<id>` (no scroll, no history entry).
- `local-*` temp ids (optimistic create before the API persists) are not written to the URL, since they don't survive a refresh.
- After rename: id stays the same → URL unchanged.
- After delete: state hook picks next open id → URL re-syncs.
- After create on a real workspace: optimistic temp id activates briefly, real id replaces it, URL syncs to the real id.

## Sidebar polish
| State | Before | After |
|---|---|---|
| Active row | dim border (#3a3f6b) | accent border (#4f6bff) + soft outer shadow, bolder title, right-aligned "Active" tag, halo on the provider dot |
| Open inactive | normal | unchanged |
| Closed | 0.6 opacity, ↺ action | 0.55 opacity for clearer separation, same ↺ action |
| Metadata row | provider · model | provider · model · relative timestamp (s/m/h/d/w/mo/y) with absolute ISO in `title` |

`formatRelative()` is a small inline helper, no dep.

## Empty states
- No workspace → existing `CreateWorkspaceCTA` preserved.
- Workspace with no windows → existing `CreateChatWindowCTA` preserved.
- Chat window with no messages → existing two-line "Start the conversation" placeholder from #99 preserved.

## Files changed
- `apps/web/src/features/workspace/useWorkspaceState.ts` — `initialActiveId`, `pickInitialActive`, `reset()` reuses picker.
- `apps/web/src/features/workspace/Workspace.tsx` — reads `?window`, syncs URL on selection change.
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx` — `WindowRow` polish, `formatRelative` helper.

## Edge cases handled
- URL has `?window=<bogus-id>` → falls through to most-recently-updated rule.
- Pool is empty → activeId stays `null`, no URL write.
- Active window is a `local-*` optimistic id → URL is not polluted with it; once the real id arrives, `lastSyncedWindowRef` notices the change and syncs.
- Refresh on a project with the active window closed → page reloads windows; selection rule picks the most-recently-updated one even if it's not in the open list (sidebar will move it to Open via reopen on focus, since `focus` already promotes to active).
- `updatedAt` missing → falls back to `createdAt`; both missing → no timestamp rendered.
- Sub-minute updates show "0s"/"1s"/... no jumpy "in the future" if clock skew yields a slightly negative diff (returns "just now").

## Constraints respected
- Frontend only. No backend, no API contract change.
- No new dependencies.
- No search, no folders/tags.
- AppShell + layout untouched.
- Consistent with chat-window/project/workspace controls already shipped.

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)