### PR TITLE
polish(web): message UX (copy, metadata, retry, regenerate)

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { useLayoutEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react';
 import type { AIProvider } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
 
@@ -18,6 +18,7 @@ interface ChatWindowProps {
   onRename?: (id: string, title: string) => void;
   onDelete?: (id: string) => void;
   onRetry?: (id: string, clientTempId: string) => void;
+  onRegenerate?: (id: string, assistantMessageId: string) => void;
   onCancel?: (id: string) => void;
 }
 
@@ -47,6 +48,7 @@ export function ChatWindow({
   onRename,
   onDelete,
   onRetry,
+  onRegenerate,
   onCancel,
 }: ChatWindowProps) {
   const [draft, setDraft] = useState('');
@@ -273,6 +275,11 @@ export function ChatWindow({
               onRetry={
                 onRetry && m.clientTempId ? () => onRetry(id, m.clientTempId!) : undefined
               }
+              onRegenerate={
+                onRegenerate && m.role === 'assistant' && (m.status ?? 'ok') === 'ok'
+                  ? () => onRegenerate(id, m.id)
+                  : undefined
+              }
             />
           ))
         )}
@@ -444,17 +451,27 @@ function StreamingCursor() {
 function MessageBubble({
   message,
   onRetry,
+  onRegenerate,
 }: {
   message: MockMessage;
   onRetry?: () => void;
+  onRegenerate?: () => void;
 }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
-  const timestamp = formatMessageTimestamp(message.createdAt);
+  const absoluteStamp = formatMessageTimestamp(message.createdAt);
+  const relativeStamp = formatRelativeStamp(message.createdAt);
   const metaParts: string[] = [];
   if (message.provider) metaParts.push(providerLabel[message.provider]);
   if (message.model) metaParts.push(message.model);
-  if (timestamp) metaParts.push(timestamp);
+  if (typeof message.promptTokens === 'number' || typeof message.completionTokens === 'number') {
+    const p = typeof message.promptTokens === 'number' ? message.promptTokens : '?';
+    const c = typeof message.completionTokens === 'number' ? message.completionTokens : '?';
+    metaParts.push(`${p}+${c} tok`);
+  }
+  if (typeof message.latencyMs === 'number') {
+    metaParts.push(formatLatency(message.latencyMs));
+  }
   const showMeta = isAssistant && metaParts.length > 0;
   const status = message.status ?? 'ok';
   const isPending = status === 'pending';
@@ -463,6 +480,7 @@ function MessageBubble({
   const isCanceled = isFailed && message.errorCode === 'canceled';
   const borderColor = isFailed ? (isCanceled ? '#3a3a45' : '#6b2a2a') : '#24242c';
   const opacity = isPending ? 0.7 : 1;
+  const canCopy = !isStreaming && !isPending && message.content.length > 0;
 
   return (
     <div
@@ -560,6 +578,139 @@ function MessageBubble({
           {metaParts.join(' · ')}
         </div>
       )}
+      <MessageActions
+        content={message.content}
+        absoluteStamp={absoluteStamp}
+        relativeStamp={relativeStamp}
+        canCopy={canCopy}
+        onRegenerate={isAssistant && !isStreaming && !isPending ? onRegenerate : undefined}
+        align={isUser ? 'end' : 'start'}
+      />
     </div>
   );
+}
+
+function MessageActions({
+  content,
+  absoluteStamp,
+  relativeStamp,
+  canCopy,
+  onRegenerate,
+  align,
+}: {
+  content: string;
+  absoluteStamp: string | null;
+  relativeStamp: string | null;
+  canCopy: boolean;
+  onRegenerate?: () => void;
+  align: 'start' | 'end';
+}) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (!canCopy) return;
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content);
+      } else if (typeof document !== 'undefined') {
+        const ta = document.createElement('textarea');
+        ta.value = content;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore — feedback simply won't show
+    }
+  };
+  return (
+    <div
+      style={{
+        marginTop: 6,
+        display: 'flex',
+        justifyContent: align === 'end' ? 'flex-end' : 'flex-start',
+        gap: 8,
+        fontSize: '0.65rem',
+        color: '#6a6a75',
+        alignItems: 'center',
+      }}
+    >
+      {relativeStamp ? (
+        <span title={absoluteStamp ?? undefined}>{relativeStamp}</span>
+      ) : null}
+      {canCopy ? (
+        <button
+          type="button"
+          onClick={onCopy}
+          aria-label="Copy message"
+          title="Copy message"
+          style={messageActionButton}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      ) : null}
+      {onRegenerate ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRegenerate();
+          }}
+          aria-label="Regenerate response"
+          title="Regenerate (re-sends last user message)"
+          style={messageActionButton}
+        >
+          Regenerate
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+const messageActionButton: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #2a2a30',
+  color: '#a0a0aa',
+  borderRadius: 4,
+  padding: '1px 6px',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.65rem',
+  letterSpacing: '0.02em',
+};
+
+function formatRelativeStamp(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  const diff = Date.now() - t;
+  if (diff < 0) return 'just now';
+  const sec = Math.floor(diff / 1000);
+  if (sec < 5) return 'just now';
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  const wk = Math.floor(day / 7);
+  if (wk < 5) return `${wk}w ago`;
+  const mo = Math.floor(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  const yr = Math.floor(day / 365);
+  return `${yr}y ago`;
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(s >= 10 ? 0 : 1)}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${Math.round(s - m * 60)}s`;
 }

--- a/apps/web/src/features/chat/useChatSessions.ts
+++ b/apps/web/src/features/chat/useChatSessions.ts
@@ -17,6 +17,7 @@ export interface ChatSessionsApi {
   isPending: (chatWindowId: string) => boolean;
   sendUserMessage: (chatWindowId: string, content: string) => void;
   retry: (chatWindowId: string, clientTempId: string) => void;
+  regenerate: (chatWindowId: string, assistantMessageId: string) => void;
   cancel: (chatWindowId: string) => void;
 }
 
@@ -120,6 +121,9 @@ export function useChatSessions(
                 createdAt: assistantRow.createdAt,
                 provider: assistantRow.provider ?? undefined,
                 model: assistantRow.model ?? undefined,
+                promptTokens: assistantRow.promptTokens ?? undefined,
+                completionTokens: assistantRow.completionTokens ?? undefined,
+                latencyMs: assistantRow.latencyMs ?? undefined,
                 status: 'ok',
               },
             ]
@@ -245,6 +249,9 @@ export function useChatSessions(
                   createdAt: assistantRow.createdAt,
                   provider: assistantRow.provider ?? undefined,
                   model: assistantRow.model ?? undefined,
+                  promptTokens: assistantRow.promptTokens ?? undefined,
+                  completionTokens: assistantRow.completionTokens ?? undefined,
+                  latencyMs: assistantRow.latencyMs ?? undefined,
                   status: 'ok' as const,
                 };
               }
@@ -443,5 +450,36 @@ export function useChatSessions(
     controllers.current.get(chatWindowId)?.abort();
   }, []);
 
-  return { getMessages, isPending, sendUserMessage, retry, cancel };
+  const regenerate = useCallback(
+    (chatWindowId: string, assistantMessageId: string) => {
+      const session = sessionsRef.current[chatWindowId];
+      if (!session) return;
+      if (session.pendingTempId != null) return;
+      const idx = session.messages.findIndex((m) => m.id === assistantMessageId);
+      if (idx < 0) return;
+      const target = session.messages[idx];
+      if (!target || target.role !== 'assistant') return;
+      let userIdx = idx - 1;
+      while (userIdx >= 0 && session.messages[userIdx]!.role !== 'user') userIdx -= 1;
+      if (userIdx < 0) return;
+      const userMsg = session.messages[userIdx]!;
+      const content = userMsg.content;
+      if (!content.trim()) return;
+      setSessions((prev) => {
+        const cur = prev[chatWindowId];
+        if (!cur) return prev;
+        return {
+          ...prev,
+          [chatWindowId]: {
+            ...cur,
+            messages: cur.messages.filter((m) => m.id !== assistantMessageId),
+          },
+        };
+      });
+      sendUserMessage(chatWindowId, content);
+    },
+    [sendUserMessage],
+  );
+
+  return { getMessages, isPending, sendUserMessage, retry, regenerate, cancel };
 }

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -105,6 +105,7 @@ export function Workspace({
         isPending={chat.isPending}
         onSend={chat.sendUserMessage}
         onRetry={chat.retry}
+        onRegenerate={chat.regenerate}
         onCancel={chat.cancel}
         activeId={state.activeId}
         hasClosed={state.closedWindows.length > 0}

--- a/apps/web/src/features/workspace/WorkspaceCanvas.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCanvas.tsx
@@ -14,6 +14,7 @@ interface WorkspaceCanvasProps {
   isPending: (chatWindowId: string) => boolean;
   onSend: (chatWindowId: string, content: string) => void;
   onRetry: (chatWindowId: string, clientTempId: string) => void;
+  onRegenerate: (chatWindowId: string, assistantMessageId: string) => void;
   onCancel: (chatWindowId: string) => void;
   activeId: string | null;
   hasClosed: boolean;
@@ -33,6 +34,7 @@ export function WorkspaceCanvas({
   isPending,
   onSend,
   onRetry,
+  onRegenerate,
   onCancel,
   activeId,
   hasClosed,
@@ -81,6 +83,7 @@ export function WorkspaceCanvas({
             onRename={onRename}
             onDelete={onDelete}
             onRetry={onRetry}
+            onRegenerate={onRegenerate}
             onCancel={onCancel}
           />
         ))

--- a/apps/web/src/lib/mocks/fixtures.ts
+++ b/apps/web/src/lib/mocks/fixtures.ts
@@ -10,6 +10,9 @@ export interface MockMessage {
   createdAt: string;
   provider?: AIProvider | null;
   model?: string | null;
+  promptTokens?: number | null;
+  completionTokens?: number | null;
+  latencyMs?: number | null;
   status?: MockMessageStatus;
   clientTempId?: string;
   errorCode?: string;


### PR DESCRIPTION
## Summary
Per-message UX inside `ChatWindow`: copy, richer assistant metadata, regenerate, plus a relative timestamp on every bubble. Retry was already wired and is preserved.

## UX before / after
| Feature | Before | After |
|---|---|---|
| Copy | not possible | "Copy" pill at the bottom of every settled (non-streaming) message → flips to "Copied" for 1.5s. Uses `navigator.clipboard.writeText` with a hidden-textarea fallback for older browsers. |
| Assistant metadata | provider · model | provider · model · `prompt+completion tok` · latency (e.g. `OpenAI · gpt-4o-mini · 13+7 tok · 974ms`). Hidden if none of those fields are present. |
| Retry | already on failed messages | unchanged. |
| Regenerate | not possible | "Regenerate" pill on completed assistant messages → drops the assistant row locally and re-runs `sendUserMessage` with the previous user message's content. Disabled while a request is in flight or while streaming. |
| Timestamp | only assistant meta showed an absolute ISO | every message has a small relative stamp ("just now" / "5m ago" / "3h ago" / ...) at the bubble footer; absolute ISO appears in the `title` attribute on hover. |

## Files changed
- `apps/web/src/lib/mocks/fixtures.ts` — `MockMessage` widened with `promptTokens`, `completionTokens`, `latencyMs`.
- `apps/web/src/features/chat/useChatSessions.ts` — copy those fields through on success + stream finalize; new `regenerate(chatWindowId, assistantMessageId)`.
- `apps/web/src/features/chat/ChatWindow.tsx` — `onRegenerate` prop; new `MessageActions` footer with Copy + Regenerate; relative timestamp helper; latency formatter.
- `apps/web/src/features/workspace/Workspace.tsx` — passes `chat.regenerate` to canvas.
- `apps/web/src/features/workspace/WorkspaceCanvas.tsx` — `onRegenerate` prop forwarding.

## Edge cases handled
- Streaming / pending message → Copy hidden (content is incomplete) and Regenerate hidden (`status` gate).
- Failed assistant message → Retry path still owns the recovery; Regenerate hidden.
- User message → Copy shown, Regenerate hidden (only assistant rows can regenerate).
- No `clipboard` API → fallback selection-based `execCommand('copy')` on a hidden textarea.
- Token / latency metadata missing → the meta line drops the missing parts cleanly; if all assistant meta is empty, the line is not rendered.
- Regenerate while a request is already in flight → no-op (`session.pendingTempId != null`).
- Regenerate on a window with no preceding user message → no-op.
- Negative clock-skew on the timestamp → "just now".
- Streaming behavior intact: dispatchStream unchanged, only its finalize step now also copies the new assistant meta fields.

## Known limitation (deliberate)
Backend has no "regenerate against existing user message" endpoint. Per the spec ("re-send last user message"), Regenerate POSTs the same user content again, which means the user row will be persisted twice on the backend. After a refresh you'll see the duplicated user message. Solving that cleanly needs a new backend route — out of scope here. Disabled by default for streaming/pending messages, available only on completed assistant rows so it can't compound mid-flight.

## Constraints respected
- Frontend only.
- No new dependencies.
- No layout redesign — the actions live as a small footer row inside the existing bubble.
- Streaming behavior intact (Copy + Regenerate hidden during stream).

## Checks
- [x] `pnpm --filter @webapp/web typecheck`
- [x] `pnpm --filter @webapp/web lint`
- [x] `pnpm --filter @webapp/web build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)