### PR TITLE
test(api): cover RateLimiter increment + reset behaviour

### DIFF
--- a/apps/api/src/lib/rate-limiter.test.ts
+++ b/apps/api/src/lib/rate-limiter.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RateLimiter } from './rate-limiter.js';
+
+describe('RateLimiter', () => {
+  beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-01-01T00:00:00Z')); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('allows up to max requests in the window', () => {
+    const rl = new RateLimiter(3, 60_000);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(true);
+    const blocked = rl.check('a');
+    expect(blocked.ok).toBe(false);
+    expect(blocked.retryAfterSecs).toBeGreaterThan(0);
+    expect(blocked.retryAfterSecs).toBeLessThanOrEqual(60);
+  });
+
+  it('isolates buckets by key', () => {
+    const rl = new RateLimiter(1, 60_000);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(false);
+    expect(rl.check('b').ok).toBe(true);
+  });
+
+  it('resets after the window elapses', () => {
+    const rl = new RateLimiter(2, 60_000);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(false);
+
+    vi.advanceTimersByTime(60_000);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(true);
+    expect(rl.check('a').ok).toBe(false);
+  });
+
+  it('retryAfterSecs decreases as time passes within the window', () => {
+    const rl = new RateLimiter(1, 60_000);
+    rl.check('a');
+    const first = rl.check('a');
+    expect(first.ok).toBe(false);
+    expect(first.retryAfterSecs).toBe(60);
+
+    vi.advanceTimersByTime(45_000);
+    const later = rl.check('a');
+    expect(later.ok).toBe(false);
+    expect(later.retryAfterSecs).toBeLessThanOrEqual(15);
+    expect(later.retryAfterSecs).toBeGreaterThan(0);
+  });
+
+  it('reset() clears the bucket immediately', () => {
+    const rl = new RateLimiter(1, 60_000);
+    rl.check('a');
+    expect(rl.check('a').ok).toBe(false);
+    rl.reset('a');
+    expect(rl.check('a').ok).toBe(true);
+  });
+});

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,11 +1,12 @@
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { ApiResponse, SafeUser } from '@webapp/types';
 import { Router } from '../lib/router.js';
 import { createApiServer } from '../lib/server.js';
 import { makeAuthRoutes } from './auth.js';
 import type { AuthDeps } from '../controllers/auth.controller.js';
+import { RateLimiter } from '../lib/rate-limiter.js';
 import { hashPassword } from '../lib/password.js';
 import { hashSessionToken } from '../lib/session-token.js';
 import { SESSION_COOKIE_NAME } from '../config/auth.js';
@@ -368,5 +369,36 @@ describe('rate limiting — login', () => {
     expect(body.error.code).toBe('rate_limited');
     expect(res.headers.get('retry-after')).toBe('120');
     await close();
+  });
+});
+
+// Real RateLimiter wired through deps — proves the bucket increments AND
+// resets after the configured window when used end-to-end through the route.
+describe('rate limiting — end-to-end with real limiter', () => {
+  it('blocks after max attempts then unblocks once the window elapses', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const limiter = new RateLimiter(2, 60_000);
+      const { baseUrl, close } = await startServer(makeDeps({
+        checkRateLimit: (key) => limiter.check(key),
+      }));
+
+      // Two attempts allowed, third returns 429.
+      for (let i = 0; i < 2; i++) {
+        const r = await post(baseUrl, '/v1/auth/login', { email: 'a@b.com', password: 'pw' });
+        expect([200, 401]).toContain(r.status);
+      }
+      const blocked = await post(baseUrl, '/v1/auth/login', { email: 'a@b.com', password: 'pw' });
+      expect(blocked.status).toBe(429);
+
+      vi.advanceTimersByTime(60_000);
+
+      const after = await post(baseUrl, '/v1/auth/login', { email: 'a@b.com', password: 'pw' });
+      expect(after.status).not.toBe(429);
+      await close();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Closes #15 — closes the test-coverage gap on auth rate limiting.

The implementation already shipped (auth controllers go through a 10/15min in-memory token bucket per IP); only direct unit tests on the limiter itself and an end-to-end route assertion of the window reset were missing.

## Changes
- `apps/api/src/lib/rate-limiter.test.ts` (new): 5 unit tests using fake timers — within-window cap, key isolation, window reset, decreasing `retryAfterSecs` over time, manual `reset()`.
- `apps/api/src/routes/auth.test.ts`: extended with a route-level test wiring a real `RateLimiter` through the deps; proves the third login is blocked with 429 and the next one (after 60s) is allowed again.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 286/286 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓