### PR TITLE
feat(api): GET /v1/version endpoint

### DIFF
--- a/apps/api/src/controllers/version.controller.test.ts
+++ b/apps/api/src/controllers/version.controller.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ApiResponse } from '@webapp/types';
+import { startTestServer, type Harness } from '../test/server-harness.js';
+
+describe('GET /v1/version', () => {
+  let harness: Harness;
+  beforeEach(async () => { harness = await startTestServer(); });
+  afterEach(async () => { await harness.close(); });
+
+  it('returns service + version + node + buildTimestamp', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/version`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{
+      service: string; version: string; commit: string | null; node: string; buildTimestamp: string;
+    }>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.service).toBe('webapp-api');
+    expect(typeof body.data.version).toBe('string');
+    expect(body.data.version.length).toBeGreaterThan(0);
+    expect(typeof body.data.node).toBe('string');
+    expect(body.data.node.startsWith('v')).toBe(true);
+    expect(typeof body.data.buildTimestamp).toBe('string');
+    // commit may be null when no GIT_SHA-style env var is set
+    expect(body.data.commit === null || typeof body.data.commit === 'string').toBe(true);
+  });
+});

--- a/apps/api/src/controllers/version.controller.ts
+++ b/apps/api/src/controllers/version.controller.ts
@@ -1,0 +1,34 @@
+import { env } from '../config/env.js';
+import { respond, type InternalResult, type RequestContext } from '../lib/http.js';
+
+export interface VersionResponse {
+  service: 'webapp-api';
+  version: string;
+  /** Optional commit SHA — populated from GIT_SHA / VERCEL_GIT_COMMIT_SHA / RENDER_GIT_COMMIT, when set. */
+  commit: string | null;
+  /** Node runtime version. */
+  node: string;
+  buildTimestamp: string;
+}
+
+const BUILD_TIMESTAMP = new Date().toISOString();
+
+function readCommit(): string | null {
+  return (
+    process.env.GIT_SHA ??
+    process.env.VERCEL_GIT_COMMIT_SHA ??
+    process.env.RENDER_GIT_COMMIT ??
+    null
+  );
+}
+
+export function versionController(_ctx: RequestContext): InternalResult {
+  const data: VersionResponse = {
+    service: 'webapp-api',
+    version: env.serviceVersion,
+    commit:  readCommit(),
+    node:    process.version,
+    buildTimestamp: BUILD_TIMESTAMP,
+  };
+  return respond(data);
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,4 +1,5 @@
 import { healthController } from '../controllers/health.controller.js';
+import { versionController } from '../controllers/version.controller.js';
 import {
   createChatWindowController,
   deleteChatWindowController,
@@ -150,6 +151,7 @@ const stateHandler = (db && authDeps)
 export const businessRoutes: RouteDefinition[] = [
   { method: 'GET', path: API_HEALTH_PATH, handler: healthController },
   { method: 'GET', path: '/v1/health',    handler: healthController },
+  { method: 'GET', path: '/v1/version',   handler: versionController },
 
   ...projectRoutes,
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -129,6 +129,7 @@ export type ApiErrorResponse       = Extract<ApiResponse<never>, { ok: false }>;
 // ── Canonical API route contract ─────────────────────────────────────────────
 
 export const API_HEALTH_PATH       = '/health' as const;
+export const API_VERSION_PATH      = '/v1/version' as const;
 export const API_PROJECTS_PATH     = '/v1/projects' as const;
 export const API_WORKSPACES_PATH   = '/v1/workspaces' as const;
 export const API_CHAT_WINDOWS_PATH = '/v1/chat-windows' as const;


### PR DESCRIPTION
Adds a tiny readonly endpoint exposing service identity, semantic version, Node runtime, build timestamp, and (when configured) the git commit SHA.

Picks up `GIT_SHA` / `VERCEL_GIT_COMMIT_SHA` / `RENDER_GIT_COMMIT` — first hit wins, `null` otherwise.

Useful for ops triage ("which version is deployed?"), debugging mismatched envs, and frontend-side cache busting if needed.

## Changes
- `apps/api/src/controllers/version.controller.ts` (new)
- `apps/api/src/controllers/version.controller.test.ts` (new — 1 integration test)
- `apps/api/src/routes/index.ts` (+1 route line)
- `packages/types/src/index.ts` (+1 line: `API_VERSION_PATH`, additive)

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 281/281 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓