### PR TITLE
feat(api): csrf protection on mutating routes

### DIFF
--- a/apps/api/src/lib/csrf.test.ts
+++ b/apps/api/src/lib/csrf.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { IncomingMessage } from 'node:http';
+import { checkCsrf } from './csrf.js';
+
+function reqWith(headers: Record<string, string | undefined>): IncomingMessage {
+  // Only the .headers field is touched by checkCsrf — minimal mock is fine.
+  return { headers } as unknown as IncomingMessage;
+}
+
+describe('checkCsrf', () => {
+  it('passes safe methods (GET/HEAD/OPTIONS) regardless of headers', () => {
+    for (const method of ['GET', 'HEAD', 'OPTIONS']) {
+      expect(checkCsrf(reqWith({}), method, 'http://localhost:3000').ok).toBe(true);
+    }
+  });
+
+  it('passes any method when allowedOrigin is "*"', () => {
+    expect(checkCsrf(reqWith({}), 'POST', '*').ok).toBe(true);
+    expect(checkCsrf(reqWith({ origin: 'http://anywhere' }), 'DELETE', '*').ok).toBe(true);
+  });
+
+  it('passes when Origin matches the allowlist', () => {
+    const r = checkCsrf(reqWith({ origin: 'http://localhost:3000' }), 'POST', 'http://localhost:3000');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects when Origin mismatches', () => {
+    const r = checkCsrf(reqWith({ origin: 'http://attacker.example.com' }), 'POST', 'http://localhost:3000');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('Origin');
+  });
+
+  it('falls back to Referer when Origin is missing', () => {
+    const r = checkCsrf(
+      reqWith({ referer: 'http://localhost:3000/some/page' }),
+      'POST',
+      'http://localhost:3000',
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('Referer-based pass works for the bare origin', () => {
+    const r = checkCsrf(reqWith({ referer: 'http://localhost:3000' }), 'POST', 'http://localhost:3000');
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects when both Origin and Referer are missing on a mutating request', () => {
+    const r = checkCsrf(reqWith({}), 'POST', 'http://localhost:3000');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects when Referer points to a different origin', () => {
+    const r = checkCsrf(
+      reqWith({ referer: 'http://attacker.example.com/any' }),
+      'PATCH',
+      'http://localhost:3000',
+    );
+    expect(r.ok).toBe(false);
+  });
+});

--- a/apps/api/src/lib/csrf.ts
+++ b/apps/api/src/lib/csrf.ts
@@ -1,0 +1,52 @@
+import type { IncomingMessage } from 'node:http';
+
+/** HTTP methods considered safe — never CSRF-checked. */
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+export interface CsrfDecision {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Same-origin CSRF check. Strategy:
+ * 1. Skip safe methods.
+ * 2. If allowedOrigin is "*", permissive — no check (dev / open API).
+ * 3. Otherwise the request must carry an Origin header equal to allowedOrigin.
+ *    If Origin is absent (some non-browser clients omit it), fall back to
+ *    Referer with a same-origin prefix match.
+ *
+ * Cookies use SameSite=Lax already; this is the second layer that closes the
+ * gap on browsers that leak the cookie despite SameSite (older Safari, opted-in
+ * cross-site requests, etc.) and on form-submission CSRF.
+ */
+export function checkCsrf(
+  req: IncomingMessage,
+  method: string,
+  allowedOrigin: string,
+): CsrfDecision {
+  if (SAFE_METHODS.has(method)) return { ok: true };
+  if (allowedOrigin === '*')    return { ok: true };
+
+  const origin = headerStr(req.headers.origin);
+  if (origin) {
+    return origin === allowedOrigin
+      ? { ok: true }
+      : { ok: false, reason: `Origin '${origin}' is not allowed` };
+  }
+
+  const referer = headerStr(req.headers.referer);
+  if (referer && referer.startsWith(`${allowedOrigin}/`)) return { ok: true };
+  if (referer === allowedOrigin)                          return { ok: true };
+
+  return {
+    ok: false,
+    reason: 'Missing or mismatched Origin / Referer header on a state-changing request',
+  };
+}
+
+function headerStr(v: string | string[] | undefined): string | null {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v) && v.length > 0) return v[0] ?? null;
+  return null;
+}

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -1,6 +1,11 @@
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ApiResponse } from '@webapp/types';
 import { startTestServer, type Harness } from '../test/server-harness.js';
+import { createApiServer } from '../lib/server.js';
+import { Router } from '../lib/router.js';
+import { routes } from '../routes/index.js';
 
 describe('dispatch — error envelopes', () => {
   let harness: Harness;
@@ -32,5 +37,82 @@ describe('dispatch — error envelopes', () => {
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('method_not_allowed');
+  });
+});
+
+// ── CSRF protection ───────────────────────────────────────────────────────────
+
+async function startWithOrigin(corsOrigin: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const router = new Router();
+  router.registerAll(routes);
+  const server: Server = createApiServer(router, corsOrigin);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    ),
+  };
+}
+
+describe('CSRF protection — explicit origin', () => {
+  const ORIGIN = 'http://localhost:3000';
+
+  it('blocks POST with no Origin/Referer header (403 csrf_error)', async () => {
+    const { baseUrl, close } = await startWithOrigin(ORIGIN);
+    const res = await fetch(`${baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('csrf_error');
+    await close();
+  });
+
+  it('blocks POST with mismatched Origin (403)', async () => {
+    const { baseUrl, close } = await startWithOrigin(ORIGIN);
+    const res = await fetch(`${baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Origin': 'http://attacker.example.com' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+    expect(res.status).toBe(403);
+    await close();
+  });
+
+  it('allows POST with matching Origin (passes CSRF; auth/validation may then 4xx)', async () => {
+    const { baseUrl, close } = await startWithOrigin(ORIGIN);
+    const res = await fetch(`${baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Origin': ORIGIN },
+      body: JSON.stringify({ name: 'X' }),
+    });
+    // Not 403 — CSRF passed. The downstream layer can still answer 200/201/401/etc.
+    expect(res.status).not.toBe(403);
+    await close();
+  });
+
+  it('allows GET regardless of Origin/Referer (safe method)', async () => {
+    const { baseUrl, close } = await startWithOrigin(ORIGIN);
+    const res = await fetch(`${baseUrl}/v1/health`);
+    expect(res.status).toBe(200);
+    await close();
+  });
+});
+
+describe('CSRF protection — wildcard origin (dev)', () => {
+  it('does not enforce CSRF when CORS_ORIGIN is "*"', async () => {
+    const { baseUrl, close } = await startWithOrigin('*');
+    const res = await fetch(`${baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'X' }),
+    });
+    expect(res.status).not.toBe(403);
+    await close();
   });
 });

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -10,6 +10,7 @@ import { logger } from '../lib/logger.js';
 import { generateRequestId } from '../lib/request-id.js';
 import type { Router } from '../lib/router.js';
 import { captureException } from '../lib/sentry.js';
+import { checkCsrf } from '../lib/csrf.js';
 
 function buildCorsHeaders(origin: string): Record<string, string> {
   if (origin === '*') {
@@ -54,6 +55,13 @@ export async function handleRequest(
   if (!isHttpMethod(rawMethod)) {
     writeJson(res, 405, fail('method_not_allowed', `Method ${rawMethod} not allowed`), requestId);
     logger.warn('request rejected', { requestId, method: rawMethod, path, status: 405 });
+    return;
+  }
+
+  const csrf = checkCsrf(req, rawMethod, corsOrigin);
+  if (!csrf.ok) {
+    writeJson(res, 403, fail('csrf_error', csrf.reason ?? 'CSRF check failed'), requestId);
+    logger.warn('request rejected (csrf)', { requestId, method: rawMethod, path, status: 403 });
     return;
   }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -54,6 +54,7 @@ export type ApiErrorCode =
   | 'not_found'
   | 'conflict'
   | 'unauthenticated'
+  | 'csrf_error'
   | 'method_not_allowed'
   | 'internal_error'
   | 'provider_auth_error'


### PR DESCRIPTION
Closes #12.

Adds an Origin/Referer-based same-origin check that runs in `handle-request.ts` before route dispatch, rejecting cross-origin POST/PATCH/PUT/DELETE with `403 csrf_error`.

## Strategy
- Skip safe methods (GET/HEAD/OPTIONS).
- When `CORS_ORIGIN === "*"` (default in dev/test), the check is **permissive** — no behavioural change.
- When `CORS_ORIGIN` is an explicit URL, the request must carry an `Origin` header equal to it. Falls back to `Referer` (origin or origin/path prefix) for non-browser clients that omit `Origin`.

This stacks with the existing `SameSite=Lax` session cookies and the explicit allow-origin CORS layer; it closes the gap on form-submission CSRF and on browsers that leak the cookie despite `SameSite`.

## Changes
- `apps/api/src/lib/csrf.ts` (new) + `csrf.test.ts` (8 unit tests)
- `apps/api/src/middleware/handle-request.ts` (+9 LOC: import + check)
- `apps/api/src/middleware/handle-request.test.ts` (+5 integration tests over the real router with explicit-origin and `*` wildcard)
- `packages/types/src/index.ts` (+1 line: `'csrf_error'` in `ApiErrorCode`, additive)

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 293/293 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓