### PR TITLE
feat(api): anthropic adapter + provider registry

### DIFF
--- a/apps/api/src/controllers/chat-windows-db.controller.ts
+++ b/apps/api/src/controllers/chat-windows-db.controller.ts
@@ -15,6 +15,7 @@ import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ChatWindowPatch } from '../db/chat-windows.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
+import { SUPPORTED_PROVIDERS } from '../providers/registry.js';
 
 // ── Internal DB row shape ──────────────────────────────────────────────────────
 
@@ -58,7 +59,6 @@ export function makeChatWindowsDeps(db: Db, sessionDeps: SessionDeps): ChatWindo
 // ── Body schemas ──────────────────────────────────────────────────────────────
 
 const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
-const SUPPORTED_PROVIDERS = new Set<AIProvider>(['openai']);
 
 const CreateChatWindowDbBody = s.object({
   workspaceId: s.string({ min: 1 }),

--- a/apps/api/src/controllers/chat-windows.controller.ts
+++ b/apps/api/src/controllers/chat-windows.controller.ts
@@ -19,9 +19,9 @@ import {
   updateChatWindow,
 } from '../services/chat-windows.service.js';
 import { workspaceExists } from '../services/workspaces.service.js';
+import { SUPPORTED_PROVIDERS } from '../providers/registry.js';
 
 const AI_PROVIDERS = ['openai', 'anthropic', 'perplexity'] as const;
-const SUPPORTED_PROVIDERS = new Set<AIProvider>(['openai']);
 
 const CreateChatWindowBody = s.object({
   workspaceId: s.string({ min: 1 }),

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -18,7 +18,7 @@ import type { Db, AssistantMessageMetadata } from '../db/messages.repo.js';
 import * as messagesRepo from '../db/messages.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
 import { getDecryptedApiKey } from '../db/provider-connections.repo.js';
-import { createOpenAIClient } from '../providers/openai.provider.js';
+import { getProviderClient, isSupportedProvider } from '../providers/registry.js';
 import type {
   ChatCompletionResult,
   ChatCompletionStreamChunk,
@@ -78,11 +78,12 @@ export interface MessagesDeps {
   createMessage:  (chatWindowId: string, userId: string, role: MessageRole, content: string) => Promise<DbMessage | null>;
   persistMessagePair: (chatWindowId: string, userId: string, userContent: string, assistantContent: string, assistantMetadata?: AssistantMessageMetadata) => Promise<{ userRow: DbMessage; assistantRow: DbMessage } | null>;
   findMessage:    (id: string, userId: string) => Promise<DbMessage | null>;
-  // Provider generation deps — used only when posting a user message to an openai chat window.
+  // Provider generation deps — used when posting a user message to a chat window
+  // whose provider has a working adapter (see SUPPORTED_PROVIDERS in providers/registry.ts).
   findChatWindow:    (chatWindowId: string, userId: string) => Promise<DbChatWindow | null>;
   getApiKey:         (userId: string, provider: AIProvider) => Promise<string | null>;
-  generate:          (apiKey: string, messages: ChatMessage[], model: string) => Promise<ChatCompletionResult>;
-  generateStream:    (apiKey: string, messages: ChatMessage[], model: string) => AsyncIterable<ChatCompletionStreamChunk>;
+  generate:          (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string) => Promise<ChatCompletionResult>;
+  generateStream:    (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string) => AsyncIterable<ChatCompletionStreamChunk>;
   maxContextMessages: number;
   providerTimeoutMs?: number;
 }
@@ -96,8 +97,8 @@ export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps
     findMessage:    (id, userId)                          => messagesRepo.findMessageById(db, id, userId),
     findChatWindow:    (chatWindowId, userId)              => chatWindowsRepo.findChatWindowById(db, chatWindowId, userId),
     getApiKey:         (userId, provider)                  => getDecryptedApiKey(db, userId, provider),
-    generate:          (apiKey, msgs, model)               => createOpenAIClient(apiKey).createChatCompletion(msgs, model),
-    generateStream:    (apiKey, msgs, model)               => createOpenAIClient(apiKey).createChatCompletionStream(msgs, model),
+    generate:          (provider, apiKey, msgs, model)     => getProviderClient(provider, apiKey).createChatCompletion(msgs, model),
+    generateStream:    (provider, apiKey, msgs, model)     => getProviderClient(provider, apiKey).createChatCompletionStream(msgs, model),
     maxContextMessages: env.openaiMaxContextMessages,
   };
 }
@@ -165,12 +166,12 @@ export async function createMessageDbController(
     const cw = await deps.findChatWindow(chatWindowId, user.id);
     if (cw === null) return respondNotFound(`ChatWindow ${chatWindowId} not found`);
 
-    if (cw.provider === 'openai') {
-      const apiKey = await deps.getApiKey(user.id, 'openai');
+    if (isSupportedProvider(cw.provider)) {
+      const apiKey = await deps.getApiKey(user.id, cw.provider);
       if (!apiKey) {
         return respondError(
           'provider_not_configured',
-          'No OpenAI connection configured. Add your API key in provider settings.',
+          `No ${cw.provider} connection configured. Add your API key in provider settings.`,
           412,
         );
       }
@@ -190,7 +191,7 @@ export async function createMessageDbController(
       const startedAt = Date.now();
       try {
         completion = await withTimeout(
-          deps.generate(apiKey, contextMessages, cw.model),
+          deps.generate(cw.provider, apiKey, contextMessages, cw.model),
           deps.providerTimeoutMs ?? PROVIDER_TIMEOUT_MS,
         );
       } catch (err) {
@@ -269,18 +270,18 @@ export async function streamMessageDbController(
 
   const cw = await deps.findChatWindow(chatWindowId, user.id);
   if (cw === null) return respondNotFound(`ChatWindow ${chatWindowId} not found`);
-  if (cw.provider !== 'openai') {
+  if (!isSupportedProvider(cw.provider)) {
     return respondError(
       'provider_not_configured',
-      `Streaming is only supported for openai chat windows (got '${cw.provider}')`,
+      `Streaming is not supported for provider '${cw.provider}' yet`,
       412,
     );
   }
-  const apiKey = await deps.getApiKey(user.id, 'openai');
+  const apiKey = await deps.getApiKey(user.id, cw.provider);
   if (!apiKey) {
     return respondError(
       'provider_not_configured',
-      'No OpenAI connection configured. Add your API key in provider settings.',
+      `No ${cw.provider} connection configured. Add your API key in provider settings.`,
       412,
     );
   }
@@ -312,7 +313,7 @@ export async function streamMessageDbController(
   ctx.req.on('close', () => { aborted = true; });
 
   try {
-    for await (const chunk of deps.generateStream(apiKey, contextMessages, cw.model)) {
+    for await (const chunk of deps.generateStream(cw.provider, apiKey, contextMessages, cw.model)) {
       if (aborted) break;
       if (chunk.type === 'delta') {
         assistantContent += chunk.content;
@@ -340,7 +341,7 @@ export async function streamMessageDbController(
 
   const latencyMs = Date.now() - startedAt;
   const assistantMetadata: AssistantMessageMetadata = {
-    provider:         'openai',
+    provider:         cw.provider,
     model,
     promptTokens:     usage.promptTokens,
     completionTokens: usage.completionTokens,

--- a/apps/api/src/controllers/provider-connections.controller.ts
+++ b/apps/api/src/controllers/provider-connections.controller.ts
@@ -13,11 +13,11 @@ import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ProviderConnectionMeta } from '../db/provider-connections.repo.js';
 import * as providerRepo from '../db/provider-connections.repo.js';
-import { verifyOpenAIKey } from '../providers/openai.provider.js';
+import { verifyProviderKey, SUPPORTED_PROVIDERS } from '../providers/registry.js';
 import { RateLimiter, type RateLimitResult } from '../lib/rate-limiter.js';
 
 const VALID_PROVIDERS = new Set<AIProvider>(['openai', 'anthropic', 'perplexity']);
-const ENABLED_PROVIDERS = new Set<AIProvider>(['openai']);
+const ENABLED_PROVIDERS = SUPPORTED_PROVIDERS;
 
 const UpsertConnectionBody = s.object({
   apiKey: s.string({ min: 1, max: 500, trim: true }),
@@ -45,14 +45,14 @@ export interface ProviderConnectionsDeps {
 const providerTestLimiter = new RateLimiter(1, 60 * 1000);
 
 async function pingProvider(provider: AIProvider, apiKey: string): Promise<PingResult> {
-  if (provider === 'openai') return verifyOpenAIKey(apiKey);
-  return 'provider_error';
+  if (!SUPPORTED_PROVIDERS.has(provider)) return 'provider_error';
+  return verifyProviderKey(provider, apiKey);
 }
 
 export function makeProviderConnectionsDeps(db: Db, sessionDeps: SessionDeps): ProviderConnectionsDeps {
   return {
     resolveUser:         (req)                   => resolveCurrentUser(req, sessionDeps),
-    verifyKey:           (_provider, apiKey)     => verifyOpenAIKey(apiKey),
+    verifyKey:           (provider, apiKey)      => verifyProviderKey(provider, apiKey),
     upsertConnection:    (userId, provider, key) => providerRepo.upsertProviderConnection(db, userId, provider, key),
     findConnection:      (userId, provider)      => providerRepo.findProviderConnection(db, userId, provider),
     listConnections:     (userId)                => providerRepo.listProviderConnections(db, userId),

--- a/apps/api/src/providers/anthropic.provider.test.ts
+++ b/apps/api/src/providers/anthropic.provider.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAnthropicClient, verifyAnthropicKey } from './anthropic.provider.js';
+import { ProviderError } from './provider.interface.js';
+
+const MESSAGES = [{ role: 'user' as const, content: 'Hello' }];
+const MODEL    = 'claude-3-5-sonnet';
+const API_KEY  = 'sk-ant-test';
+
+function ok(body: object): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+function bad(status: number, errorMessage: string): Response {
+  return new Response(JSON.stringify({ error: { message: errorMessage } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('verifyAnthropicKey', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns ok on 200', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    expect(await verifyAnthropicKey(API_KEY)).toBe('ok');
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    const init = call[1] as RequestInit;
+    expect(init.headers).toMatchObject({ 'x-api-key': API_KEY, 'anthropic-version': '2023-06-01' });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 401 }));
+    expect(await verifyAnthropicKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns provider_error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('boom'));
+    expect(await verifyAnthropicKey(API_KEY)).toBe('provider_error');
+  });
+});
+
+describe('createAnthropicClient.createChatCompletion', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns normalized result with content + model + usage', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      content: [{ type: 'text', text: 'Hello human!' }],
+      usage:   { input_tokens: 10, output_tokens: 4 },
+    }));
+    const r = await createAnthropicClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+    expect(r.content).toBe('Hello human!');
+    expect(r.model).toBe(MODEL);
+    expect(r.usage).toEqual({ promptTokens: 10, completionTokens: 4, totalTokens: 14 });
+  });
+
+  it('extracts a system prompt from system-role messages and posts it separately', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      content: [{ type: 'text', text: 'ok' }],
+      usage:   { input_tokens: 1, output_tokens: 1 },
+    }));
+    await createAnthropicClient(API_KEY).createChatCompletion([
+      { role: 'system', content: 'You are X.' },
+      { role: 'system', content: 'Style: terse.' },
+      { role: 'user',   content: 'Hi' },
+    ], MODEL);
+
+    const call = vi.mocked(fetch).mock.calls[0]!;
+    const init = call[1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { system?: string; messages: Array<{ role: string }> };
+    expect(body.system).toBe('You are X.\n\nStyle: terse.');
+    expect(body.messages).toEqual([{ role: 'user', content: 'Hi' }]);
+  });
+
+  it('throws ProviderError on non-2xx with the upstream message', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'invalid x-api-key'));
+    await expect(createAnthropicClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toMatchObject({ code: 'api_error' });
+  });
+
+  it('throws invalid_response when content is empty', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      content: [],
+      usage:   { input_tokens: 1, output_tokens: 0 },
+    }));
+    await expect(createAnthropicClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toBeInstanceOf(ProviderError);
+  });
+});
+
+describe('createAnthropicClient.createChatCompletionStream', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  function sse(events: string[]): Response {
+    const body = events.join('') + '\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode(body)); c.close(); },
+    });
+    return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  it('parses content_block_delta + message_delta + message_start', async () => {
+    vi.mocked(fetch).mockResolvedValue(sse([
+      `event: message_start\ndata: ${JSON.stringify({ type: 'message_start', message: { model: MODEL, usage: { input_tokens: 5, output_tokens: 0 } } })}\n\n`,
+      `event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hi ' } })}\n\n`,
+      `event: content_block_delta\ndata: ${JSON.stringify({ type: 'content_block_delta', delta: { type: 'text_delta', text: 'there' } })}\n\n`,
+      `event: message_delta\ndata: ${JSON.stringify({ type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 2 } })}\n\n`,
+      `event: message_stop\ndata: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
+    ]));
+
+    const chunks = [];
+    for await (const c of createAnthropicClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+      chunks.push(c);
+    }
+    const text = chunks.filter((c) => c.type === 'delta').map((c) => c.type === 'delta' ? c.content : '').join('');
+    const done = chunks.find((c) => c.type === 'done');
+    expect(text).toBe('Hi there');
+    if (done?.type !== 'done') throw new Error('expected done');
+    expect(done.model).toBe(MODEL);
+    expect(done.usage.promptTokens).toBe(5);
+    expect(done.usage.completionTokens).toBe(2);
+    expect(done.usage.totalTokens).toBe(7);
+  });
+
+  it('throws ProviderError on non-2xx upstream', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'invalid x-api-key'));
+    const it = createAnthropicClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
+    await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -1,0 +1,259 @@
+import type {
+  ChatCompletionResult,
+  ChatCompletionStreamChunk,
+  ChatMessage,
+  ProviderClient,
+} from './provider.interface.js';
+import { ProviderError } from './provider.interface.js';
+
+// ── Endpoints ─────────────────────────────────────────────────────────────────
+
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_MODELS_URL   = 'https://api.anthropic.com/v1/models';
+const ANTHROPIC_VERSION      = '2023-06-01';
+
+/** Default cap when no per-call value is supplied. Anthropic requires max_tokens. */
+const DEFAULT_MAX_TOKENS = 1024;
+
+// ── Key verification ──────────────────────────────────────────────────────────
+
+export type AnthropicVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
+
+export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerifyResult> {
+  let res: Response;
+  try {
+    res = await fetch(ANTHROPIC_MODELS_URL, {
+      method: 'GET',
+      headers: {
+        'x-api-key':         apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+    });
+  } catch {
+    return 'provider_error';
+  }
+  if (res.status === 200) return 'ok';
+  if (res.status === 401) return 'unauthorized';
+  return 'provider_error';
+}
+
+// ── Helpers: split a generic ChatMessage[] into Anthropic's shape ─────────────
+
+interface AnthropicShape {
+  system: string | undefined;
+  messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+function toAnthropicShape(messages: ChatMessage[]): AnthropicShape {
+  const systemParts: string[] = [];
+  const out: AnthropicShape['messages'] = [];
+  for (const m of messages) {
+    if (m.role === 'system') systemParts.push(m.content);
+    else                     out.push({ role: m.role, content: m.content });
+  }
+  return {
+    system:   systemParts.length === 0 ? undefined : systemParts.join('\n\n'),
+    messages: out,
+  };
+}
+
+// ── Wire types (subset) ───────────────────────────────────────────────────────
+
+interface AnthropicTextBlock { type: 'text'; text: string }
+interface AnthropicResponse {
+  model: string;
+  content: AnthropicTextBlock[];
+  usage:   { input_tokens: number; output_tokens: number };
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export function createAnthropicClient(apiKey: string): ProviderClient {
+  return {
+    async createChatCompletion(
+      messages: ChatMessage[],
+      model: string,
+    ): Promise<ChatCompletionResult> {
+      const shape = toAnthropicShape(messages);
+
+      let res: Response;
+      try {
+        res = await fetch(ANTHROPIC_MESSAGES_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':      'application/json',
+            'x-api-key':         apiKey,
+            'anthropic-version': ANTHROPIC_VERSION,
+          },
+          body: JSON.stringify({
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            ...(shape.system ? { system: shape.system } : {}),
+            messages: shape.messages,
+            stream: false,
+          }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Anthropic request failed: ${(err as Error).message}`,
+          'api_error',
+          'anthropic',
+        );
+      }
+
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Anthropic API error: ${detail}`, 'api_error', 'anthropic');
+      }
+
+      let data: AnthropicResponse;
+      try {
+        data = (await res.json()) as AnthropicResponse;
+      } catch {
+        throw new ProviderError('Failed to parse Anthropic response', 'invalid_response', 'anthropic');
+      }
+
+      const text = data.content
+        ?.filter((b) => b.type === 'text')
+        .map((b) => b.text)
+        .join('');
+      if (!text || text.length === 0) {
+        throw new ProviderError('Anthropic response missing text content', 'invalid_response', 'anthropic');
+      }
+
+      return {
+        content: text,
+        model:   data.model ?? model,
+        usage:   {
+          promptTokens:     data.usage?.input_tokens  ?? 0,
+          completionTokens: data.usage?.output_tokens ?? 0,
+          totalTokens:      (data.usage?.input_tokens ?? 0) + (data.usage?.output_tokens ?? 0),
+        },
+      };
+    },
+
+    async *createChatCompletionStream(
+      messages: ChatMessage[],
+      model: string,
+    ): AsyncIterable<ChatCompletionStreamChunk> {
+      const shape = toAnthropicShape(messages);
+
+      let res: Response;
+      try {
+        res = await fetch(ANTHROPIC_MESSAGES_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':      'application/json',
+            'Accept':            'text/event-stream',
+            'x-api-key':         apiKey,
+            'anthropic-version': ANTHROPIC_VERSION,
+          },
+          body: JSON.stringify({
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            ...(shape.system ? { system: shape.system } : {}),
+            messages: shape.messages,
+            stream: true,
+          }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Anthropic request failed: ${(err as Error).message}`,
+          'api_error',
+          'anthropic',
+        );
+      }
+
+      if (!res.ok || !res.body) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Anthropic API error: ${detail}`, 'api_error', 'anthropic');
+      }
+
+      const decoder = new TextDecoder();
+      let buf = '';
+      let finalModel = model;
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+
+          let idx;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            // Anthropic SSE has both "event: <name>" and "data: <json>" lines.
+            // Only "data:" carries the payload we care about — every event has
+            // a discriminating "type" inside the JSON, so we can ignore the
+            // event: line entirely.
+            if (!line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '' || payload === '[DONE]') continue;
+
+            let event: {
+              type?: string;
+              message?: { model?: string; usage?: { input_tokens?: number; output_tokens?: number } };
+              delta?: { text?: string; type?: string; stop_reason?: string };
+              usage?: { input_tokens?: number; output_tokens?: number };
+            };
+            try {
+              event = JSON.parse(payload);
+            } catch {
+              throw new ProviderError('Failed to parse Anthropic stream chunk', 'invalid_response', 'anthropic');
+            }
+
+            switch (event.type) {
+              case 'message_start': {
+                if (event.message?.model) finalModel = event.message.model;
+                if (event.message?.usage?.input_tokens !== undefined) {
+                  promptTokens = event.message.usage.input_tokens;
+                }
+                break;
+              }
+              case 'content_block_delta': {
+                const text = event.delta?.text;
+                if (typeof text === 'string' && text.length > 0) {
+                  yield { type: 'delta', content: text };
+                }
+                break;
+              }
+              case 'message_delta': {
+                if (event.usage?.output_tokens !== undefined) {
+                  completionTokens = event.usage.output_tokens;
+                }
+                break;
+              }
+              default:
+                // message_stop, ping, content_block_start/stop — no-op
+                break;
+            }
+          }
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* ignore */ }
+      }
+
+      yield {
+        type: 'done',
+        model: finalModel,
+        usage: {
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+        },
+      };
+    },
+  };
+}

--- a/apps/api/src/providers/registry.test.ts
+++ b/apps/api/src/providers/registry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_PROVIDERS, getProviderClient, isSupportedProvider } from './registry.js';
+
+describe('providers/registry', () => {
+  it('lists openai and anthropic as supported', () => {
+    expect(SUPPORTED_PROVIDERS.has('openai')).toBe(true);
+    expect(SUPPORTED_PROVIDERS.has('anthropic')).toBe(true);
+    expect(SUPPORTED_PROVIDERS.has('perplexity')).toBe(false);
+  });
+
+  it('isSupportedProvider mirrors the set', () => {
+    expect(isSupportedProvider('openai')).toBe(true);
+    expect(isSupportedProvider('anthropic')).toBe(true);
+    expect(isSupportedProvider('perplexity')).toBe(false);
+  });
+
+  it('returns a client for each supported provider', () => {
+    expect(getProviderClient('openai',    'k')).toBeDefined();
+    expect(getProviderClient('anthropic', 'k')).toBeDefined();
+  });
+
+  it('throws for an unsupported provider', () => {
+    expect(() => getProviderClient('perplexity', 'k')).toThrow();
+  });
+});

--- a/apps/api/src/providers/registry.ts
+++ b/apps/api/src/providers/registry.ts
@@ -1,0 +1,31 @@
+import type { AIProvider } from '@webapp/types';
+import type { ProviderClient } from './provider.interface.js';
+import { createOpenAIClient,    verifyOpenAIKey,    type OpenAIVerifyResult }    from './openai.provider.js';
+import { createAnthropicClient, verifyAnthropicKey, type AnthropicVerifyResult } from './anthropic.provider.js';
+
+export type VerifyResult = OpenAIVerifyResult | AnthropicVerifyResult; // identical union shape today
+
+/** Providers that have a working adapter. Single source of truth for upserts and chat-window creation. */
+export const SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set(['openai', 'anthropic']);
+
+export function isSupportedProvider(p: AIProvider): boolean {
+  return SUPPORTED_PROVIDERS.has(p);
+}
+
+export function getProviderClient(provider: AIProvider, apiKey: string): ProviderClient {
+  switch (provider) {
+    case 'openai':    return createOpenAIClient(apiKey);
+    case 'anthropic': return createAnthropicClient(apiKey);
+    default:
+      throw new Error(`No provider client for '${provider}'`);
+  }
+}
+
+export function verifyProviderKey(provider: AIProvider, apiKey: string): Promise<VerifyResult> {
+  switch (provider) {
+    case 'openai':    return verifyOpenAIKey(apiKey);
+    case 'anthropic': return verifyAnthropicKey(apiKey);
+    default:
+      return Promise.resolve('provider_error');
+  }
+}

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -203,7 +203,7 @@ describe('POST /v1/chat-windows — authenticated', () => {
     await close();
   });
 
-  for (const provider of ['anthropic', 'perplexity'] as const) {
+  for (const provider of ['perplexity'] as const) {
     it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error (no silent dead-end)`, async () => {
       let createCalled = false;
       const { baseUrl, close } = await startServer(makeDeps({

--- a/apps/api/src/routes/chat-windows.test.ts
+++ b/apps/api/src/routes/chat-windows.test.ts
@@ -117,7 +117,7 @@ describe('POST /v1/chat-windows', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
-  for (const provider of ['anthropic', 'perplexity'] as const) {
+  for (const provider of ['perplexity'] as const) {
     it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error`, async () => {
       const ws = await createWorkspace(harness.baseUrl);
       const res = await fetch(`${harness.baseUrl}/v1/chat-windows`, {

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -32,7 +32,7 @@ function mockMessage(chatWindowId: string, overrides: Partial<{
   };
 }
 
-function mockChatWindow(provider: AIProvider = 'anthropic', model = 'claude-3') {
+function mockChatWindow(provider: AIProvider = 'perplexity', model = 'sonar') {
   return {
     id:          'cw-1',
     workspaceId: 'ws-1',
@@ -59,8 +59,8 @@ function makeDeps(overrides: Partial<MessagesDeps> = {}): MessagesDeps {
     persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) =>
       mockPair(chatWindowId, userContent, assistantContent),
     findMessage:        async () => null,
-    // Default: non-openai window so existing tests bypass generation path.
-    findChatWindow:     async () => mockChatWindow('anthropic'),
+    // Default: unsupported-provider window so existing tests bypass generation path.
+    findChatWindow:     async () => mockChatWindow('perplexity'),
     getApiKey:          async () => null,
     generate:           async () => { throw new Error('should not be called in this test'); },
     generateStream:     async function* () { throw new Error('should not be called in this test'); },
@@ -189,10 +189,10 @@ describe('POST /v1/messages — standard path', () => {
     await close();
   });
 
-  it('creates user message in non-openai window (anthropic), returns single message', async () => {
+  it('creates user message in unsupported-provider window (perplexity), returns single message', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
       resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('anthropic'),
+      findChatWindow: async () => mockChatWindow('perplexity'),
       createMessage:  async (chatWindowId, _userId, role, content) =>
         mockMessage(chatWindowId, { id: 'new-msg', role, content }),
     }));
@@ -358,7 +358,7 @@ describe('POST /v1/messages — openai generation path', () => {
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('provider_not_configured');
-    expect(body.error.message).toContain('OpenAI');
+    expect(body.error.message).toContain('openai');
     await close();
   });
 
@@ -450,7 +450,7 @@ describe('POST /v1/messages — openai generation path', () => {
       getApiKey:          async () => 'sk-key',
       listMessages:       async () => history,
       maxContextMessages: 3,
-      generate: async (_, msgs) => {
+      generate: async (_provider, _apiKey, msgs) => {
         capturedMessages.push(...msgs);
         return { content: 'reply', model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } };
       },
@@ -485,7 +485,7 @@ describe('POST /v1/messages — openai generation path', () => {
       getApiKey:          async () => 'sk-key',
       listMessages:       async () => history,
       maxContextMessages: 20,
-      generate: async (_, msgs) => {
+      generate: async (_provider, _apiKey, msgs) => {
         capturedMessages.push(...msgs);
         return { content: 'ok', model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } };
       },
@@ -666,10 +666,10 @@ describe('POST /v1/messages/stream — authenticated', () => {
     await close();
   });
 
-  it('returns 412 provider_not_configured when chat-window provider is not openai', async () => {
+  it('returns 412 provider_not_configured when chat-window provider is unsupported (perplexity)', async () => {
     const { baseUrl, close } = await startServer(makeDeps({
       resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('anthropic'),
+      findChatWindow: async () => mockChatWindow('perplexity'),
     }));
     const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
     expect(res.status).toBe(412);

--- a/apps/api/src/routes/provider-connections.test.ts
+++ b/apps/api/src/routes/provider-connections.test.ts
@@ -238,9 +238,9 @@ describe('PUT /v1/provider-connections/:provider — authenticated', () => {
     await close();
   });
 
-  it('returns 400 for unsupported but valid provider (anthropic)', async () => {
+  it('returns 400 for unsupported but valid provider (perplexity)', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
-    const res = await put(baseUrl, '/v1/provider-connections/anthropic', { apiKey: 'sk-ant-test' });
+    const res = await put(baseUrl, '/v1/provider-connections/perplexity', { apiKey: 'pplx-test' });
     expect(res.status).toBe(400);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');


### PR DESCRIPTION
Closes #14. Adds a working Anthropic adapter and wires it into the existing flows (chat-window create, provider-connections upsert, non-stream and SSE message generation). OpenAI behaviour unchanged.

## What's new
- `apps/api/src/providers/anthropic.provider.ts`: `verifyAnthropicKey`, `createAnthropicClient.createChatCompletion`, `createAnthropicClient.createChatCompletionStream`. Splits `system` messages into Anthropic's top-level `system` field. Parses the `content[].text` blocks and the SSE event-named JSON payload (`message_start` / `content_block_delta` / `message_delta` / `message_stop`).
- `apps/api/src/providers/registry.ts`: single source of truth for `SUPPORTED_PROVIDERS = {openai, anthropic}`, `getProviderClient`, `verifyProviderKey`, `isSupportedProvider`.

## Wiring
- `chat-windows[-db].controller.ts` import `SUPPORTED_PROVIDERS` from the registry.
- `provider-connections.controller.ts`: `ENABLED_PROVIDERS` = registry's set; `pingProvider` + `verifyKey` route through `verifyProviderKey`.
- `messages-db.controller.ts`: generation deps now take `provider` as the first argument and resolve the client via the registry. The generation gate is `isSupportedProvider(cw.provider)` for both POST `/v1/messages` and POST `/v1/messages/stream`.

Existing "anthropic = unsupported" test assertions migrated to `perplexity` to preserve their intent.

## Stack
This PR is the **base of the provider stack**. Subsequent PRs depend on the registry introduced here:
- #33 perplexity adapter
- smoke-multi-provider
- verify-timeout
- health-deep
- rl-reset-on-success

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 291/291 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓