### PR TITLE
feat(api): perplexity adapter + flip into supported set

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -223,11 +223,12 @@ export async function createMessageDbController(
       );
     }
 
-    // Non-openai provider: persist user message only, no generation.
-    // Provider support for this window is not yet enabled.
+    // Provider unsupported (no adapter): persist user message only, no generation.
+    // Reachable only if a chat-window was created with a provider that has since
+    // been removed from SUPPORTED_PROVIDERS — defensive fall-through.
   }
 
-  // Default path: persist the message as-is (non-user role, or non-openai provider).
+  // Default path: persist the message as-is (non-user role, or unsupported provider).
   const row = await deps.createMessage(chatWindowId, user.id, role, content);
   if (row === null) return respondNotFound(`ChatWindow ${chatWindowId} not found`);
   const msg = toMessage(row);

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPerplexityClient, verifyPerplexityKey } from './perplexity.provider.js';
+import { ProviderError } from './provider.interface.js';
+
+const MESSAGES = [{ role: 'user' as const, content: 'Hello' }];
+const MODEL    = 'sonar';
+const API_KEY  = 'pplx-test';
+
+function ok(body: object): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+function bad(status: number, msg: string): Response {
+  return new Response(JSON.stringify({ error: { message: msg } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('verifyPerplexityKey', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns ok on 2xx', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ choices: [{ message: { role: 'assistant', content: '' } }] }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('ok');
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.headers).toMatchObject({ Authorization: `Bearer ${API_KEY}` });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 401 }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns unauthorized on 403', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 403 }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns provider_error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('boom'));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('provider_error');
+  });
+});
+
+describe('createPerplexityClient.createChatCompletion', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns normalized result with content + model + usage', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      choices: [{ message: { role: 'assistant', content: 'Hello!' }, finish_reason: 'stop' }],
+      usage:   { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+    }));
+    const r = await createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+    expect(r.content).toBe('Hello!');
+    expect(r.model).toBe(MODEL);
+    expect(r.usage).toEqual({ promptTokens: 7, completionTokens: 2, totalTokens: 9 });
+  });
+
+  it('throws ProviderError on non-2xx with the upstream message', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'invalid bearer token'));
+    await expect(createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toMatchObject({ code: 'api_error' });
+  });
+
+  it('throws invalid_response when content is empty', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      choices: [{ message: { role: 'assistant', content: '' } }],
+      usage:   { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }));
+    await expect(createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toBeInstanceOf(ProviderError);
+  });
+});
+
+describe('createPerplexityClient.createChatCompletionStream', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  function sse(payloads: string[]): Response {
+    const body = payloads.map((p) => `data: ${p}\n\n`).join('') + 'data: [DONE]\n\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode(body)); c.close(); },
+    });
+    return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  it('parses delta + final chunk with usage', async () => {
+    vi.mocked(fetch).mockResolvedValue(sse([
+      JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'Hi ' } }] }),
+      JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'there' } }] }),
+      JSON.stringify({ model: MODEL, choices: [{ delta: {} }], usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 } }),
+    ]));
+
+    const chunks = [];
+    for await (const c of createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+      chunks.push(c);
+    }
+    const text = chunks.filter((c) => c.type === 'delta').map((c) => c.type === 'delta' ? c.content : '').join('');
+    const done = chunks.find((c) => c.type === 'done');
+    expect(text).toBe('Hi there');
+    if (done?.type !== 'done') throw new Error('expected done');
+    expect(done.usage.promptTokens).toBe(4);
+    expect(done.usage.completionTokens).toBe(2);
+    expect(done.usage.totalTokens).toBe(6);
+    expect(done.model).toBe(MODEL);
+  });
+
+  it('throws ProviderError on non-2xx upstream', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'bad key'));
+    const it = createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
+    await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -1,0 +1,210 @@
+import type {
+  ChatCompletionResult,
+  ChatCompletionStreamChunk,
+  ChatMessage,
+  ProviderClient,
+} from './provider.interface.js';
+import { ProviderError } from './provider.interface.js';
+
+// Perplexity is OpenAI-compatible at the chat-completions schema level.
+// We post the same shape and parse the same response, with a different base URL
+// and model namespace ('sonar', 'sonar-pro', ...).
+
+const PERPLEXITY_CHAT_URL = 'https://api.perplexity.ai/chat/completions';
+
+// Used by verifyPerplexityKey: smallest possible completion that the API will
+// accept just to confirm the bearer token is valid. Non-streaming, max_tokens=1.
+const VERIFY_MODEL = 'sonar';
+
+// ── Key verification ──────────────────────────────────────────────────────────
+
+export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
+
+export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
+  let res: Response;
+  try {
+    res = await fetch(PERPLEXITY_CHAT_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: VERIFY_MODEL,
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+        stream: false,
+      }),
+    });
+  } catch {
+    return 'provider_error';
+  }
+  if (res.ok)              return 'ok';
+  if (res.status === 401)  return 'unauthorized';
+  if (res.status === 403)  return 'unauthorized';
+  return 'provider_error';
+}
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+interface PerplexityUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface PerplexityMessage {
+  role: string;
+  content: string | null;
+}
+
+interface PerplexityChoice {
+  message?: PerplexityMessage;
+  delta?:   { content?: string };
+  finish_reason?: string;
+}
+
+interface PerplexityResponse {
+  model: string;
+  choices: PerplexityChoice[];
+  usage:   PerplexityUsage;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export function createPerplexityClient(apiKey: string): ProviderClient {
+  return {
+    async createChatCompletion(
+      messages: ChatMessage[],
+      model: string,
+    ): Promise<ChatCompletionResult> {
+      let res: Response;
+      try {
+        res = await fetch(PERPLEXITY_CHAT_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({ model, messages, stream: false }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Perplexity request failed: ${(err as Error).message}`,
+          'api_error',
+          'perplexity',
+        );
+      }
+
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Perplexity API error: ${detail}`, 'api_error', 'perplexity');
+      }
+
+      let data: PerplexityResponse;
+      try {
+        data = (await res.json()) as PerplexityResponse;
+      } catch {
+        throw new ProviderError('Failed to parse Perplexity response', 'invalid_response', 'perplexity');
+      }
+
+      const content = data.choices?.[0]?.message?.content;
+      if (typeof content !== 'string' || content.length === 0) {
+        throw new ProviderError('Perplexity response missing content', 'invalid_response', 'perplexity');
+      }
+
+      return {
+        content,
+        model: data.model ?? model,
+        usage: {
+          promptTokens:     data.usage?.prompt_tokens     ?? 0,
+          completionTokens: data.usage?.completion_tokens ?? 0,
+          totalTokens:      data.usage?.total_tokens      ?? 0,
+        },
+      };
+    },
+
+    async *createChatCompletionStream(
+      messages: ChatMessage[],
+      model: string,
+    ): AsyncIterable<ChatCompletionStreamChunk> {
+      let res: Response;
+      try {
+        res = await fetch(PERPLEXITY_CHAT_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+            'Accept':        'text/event-stream',
+          },
+          body: JSON.stringify({ model, messages, stream: true }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Perplexity request failed: ${(err as Error).message}`,
+          'api_error',
+          'perplexity',
+        );
+      }
+
+      if (!res.ok || !res.body) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Perplexity API error: ${detail}`, 'api_error', 'perplexity');
+      }
+
+      const decoder = new TextDecoder();
+      let buf = '';
+      let finalModel = model;
+      let usage: ChatCompletionResult['usage'] = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+
+          let idx;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            if (line === '' || !line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '[DONE]') continue;
+
+            let event: PerplexityResponse;
+            try {
+              event = JSON.parse(payload) as PerplexityResponse;
+            } catch {
+              throw new ProviderError('Failed to parse Perplexity stream chunk', 'invalid_response', 'perplexity');
+            }
+            if (event.model) finalModel = event.model;
+            if (event.usage) {
+              usage = {
+                promptTokens:     event.usage.prompt_tokens     ?? usage.promptTokens,
+                completionTokens: event.usage.completion_tokens ?? usage.completionTokens,
+                totalTokens:      event.usage.total_tokens      ?? usage.totalTokens,
+              };
+            }
+            const delta = event.choices?.[0]?.delta?.content;
+            if (typeof delta === 'string' && delta.length > 0) {
+              yield { type: 'delta', content: delta };
+            }
+          }
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* ignore */ }
+      }
+
+      yield { type: 'done', model: finalModel, usage };
+    },
+  };
+}

--- a/apps/api/src/providers/registry.test.ts
+++ b/apps/api/src/providers/registry.test.ts
@@ -2,24 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { SUPPORTED_PROVIDERS, getProviderClient, isSupportedProvider } from './registry.js';
 
 describe('providers/registry', () => {
-  it('lists openai and anthropic as supported', () => {
+  it('lists openai, anthropic and perplexity as supported', () => {
     expect(SUPPORTED_PROVIDERS.has('openai')).toBe(true);
     expect(SUPPORTED_PROVIDERS.has('anthropic')).toBe(true);
-    expect(SUPPORTED_PROVIDERS.has('perplexity')).toBe(false);
+    expect(SUPPORTED_PROVIDERS.has('perplexity')).toBe(true);
   });
 
   it('isSupportedProvider mirrors the set', () => {
     expect(isSupportedProvider('openai')).toBe(true);
     expect(isSupportedProvider('anthropic')).toBe(true);
-    expect(isSupportedProvider('perplexity')).toBe(false);
+    expect(isSupportedProvider('perplexity')).toBe(true);
   });
 
   it('returns a client for each supported provider', () => {
-    expect(getProviderClient('openai',    'k')).toBeDefined();
-    expect(getProviderClient('anthropic', 'k')).toBeDefined();
-  });
-
-  it('throws for an unsupported provider', () => {
-    expect(() => getProviderClient('perplexity', 'k')).toThrow();
+    expect(getProviderClient('openai',     'k')).toBeDefined();
+    expect(getProviderClient('anthropic',  'k')).toBeDefined();
+    expect(getProviderClient('perplexity', 'k')).toBeDefined();
   });
 });

--- a/apps/api/src/providers/registry.ts
+++ b/apps/api/src/providers/registry.ts
@@ -1,12 +1,13 @@
 import type { AIProvider } from '@webapp/types';
 import type { ProviderClient } from './provider.interface.js';
-import { createOpenAIClient,    verifyOpenAIKey,    type OpenAIVerifyResult }    from './openai.provider.js';
-import { createAnthropicClient, verifyAnthropicKey, type AnthropicVerifyResult } from './anthropic.provider.js';
+import { createOpenAIClient,     verifyOpenAIKey,     type OpenAIVerifyResult }     from './openai.provider.js';
+import { createAnthropicClient,  verifyAnthropicKey,  type AnthropicVerifyResult }  from './anthropic.provider.js';
+import { createPerplexityClient, verifyPerplexityKey, type PerplexityVerifyResult } from './perplexity.provider.js';
 
-export type VerifyResult = OpenAIVerifyResult | AnthropicVerifyResult; // identical union shape today
+export type VerifyResult = OpenAIVerifyResult | AnthropicVerifyResult | PerplexityVerifyResult;
 
 /** Providers that have a working adapter. Single source of truth for upserts and chat-window creation. */
-export const SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set(['openai', 'anthropic']);
+export const SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set(['openai', 'anthropic', 'perplexity']);
 
 export function isSupportedProvider(p: AIProvider): boolean {
   return SUPPORTED_PROVIDERS.has(p);
@@ -14,8 +15,9 @@ export function isSupportedProvider(p: AIProvider): boolean {
 
 export function getProviderClient(provider: AIProvider, apiKey: string): ProviderClient {
   switch (provider) {
-    case 'openai':    return createOpenAIClient(apiKey);
-    case 'anthropic': return createAnthropicClient(apiKey);
+    case 'openai':     return createOpenAIClient(apiKey);
+    case 'anthropic':  return createAnthropicClient(apiKey);
+    case 'perplexity': return createPerplexityClient(apiKey);
     default:
       throw new Error(`No provider client for '${provider}'`);
   }
@@ -23,8 +25,9 @@ export function getProviderClient(provider: AIProvider, apiKey: string): Provide
 
 export function verifyProviderKey(provider: AIProvider, apiKey: string): Promise<VerifyResult> {
   switch (provider) {
-    case 'openai':    return verifyOpenAIKey(apiKey);
-    case 'anthropic': return verifyAnthropicKey(apiKey);
+    case 'openai':     return verifyOpenAIKey(apiKey);
+    case 'anthropic':  return verifyAnthropicKey(apiKey);
+    case 'perplexity': return verifyPerplexityKey(apiKey);
     default:
       return Promise.resolve('provider_error');
   }

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -203,28 +203,6 @@ describe('POST /v1/chat-windows — authenticated', () => {
     await close();
   });
 
-  for (const provider of ['perplexity'] as const) {
-    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error (no silent dead-end)`, async () => {
-      let createCalled = false;
-      const { baseUrl, close } = await startServer(makeDeps({
-        resolveUser:      async () => USER_1,
-        createChatWindow: async (workspaceId, _userId, title, p, model) => {
-          createCalled = true;
-          return mockChatWindow(workspaceId, { title, provider: p, model });
-        },
-      }));
-      const res = await post(baseUrl, '/v1/chat-windows', {
-        workspaceId: 'ws-1', title: 'X', provider, model: 'm',
-      });
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as ApiResponse<never>;
-      if (body.ok) throw new Error('expected error');
-      expect(body.error.code).toBe('validation_error');
-      expect(body.error.message).toContain('not yet supported');
-      expect(createCalled).toBe(false);
-      await close();
-    });
-  }
 });
 
 // ── Get chat window by id ─────────────────────────────────────────────────────

--- a/apps/api/src/routes/chat-windows.test.ts
+++ b/apps/api/src/routes/chat-windows.test.ts
@@ -117,19 +117,4 @@ describe('POST /v1/chat-windows', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
-  for (const provider of ['perplexity'] as const) {
-    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error`, async () => {
-      const ws = await createWorkspace(harness.baseUrl);
-      const res = await fetch(`${harness.baseUrl}/v1/chat-windows`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workspaceId: ws.id, title: 'CW', provider, model: 'm' }),
-      });
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as ApiResponse<unknown>;
-      if (body.ok) throw new Error('expected error envelope');
-      expect(body.error.code).toBe('validation_error');
-      expect(body.error.message).toContain('not yet supported');
-    });
-  }
 });

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -32,7 +32,7 @@ function mockMessage(chatWindowId: string, overrides: Partial<{
   };
 }
 
-function mockChatWindow(provider: AIProvider = 'perplexity', model = 'sonar') {
+function mockChatWindow(provider: AIProvider = 'openai', model = 'gpt-4o-mini') {
   return {
     id:          'cw-1',
     workspaceId: 'ws-1',
@@ -59,8 +59,9 @@ function makeDeps(overrides: Partial<MessagesDeps> = {}): MessagesDeps {
     persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) =>
       mockPair(chatWindowId, userContent, assistantContent),
     findMessage:        async () => null,
-    // Default: unsupported-provider window so existing tests bypass generation path.
-    findChatWindow:     async () => mockChatWindow('perplexity'),
+    // Default: openai window. Tests that exercise the user-role generation path
+    // override this and getApiKey/generate explicitly.
+    findChatWindow:     async () => mockChatWindow('openai'),
     getApiKey:          async () => null,
     generate:           async () => { throw new Error('should not be called in this test'); },
     generateStream:     async function* () { throw new Error('should not be called in this test'); },
@@ -186,25 +187,6 @@ describe('POST /v1/messages — standard path', () => {
     expect(body.data.content).toBe('Replying manually');
     expect(body.data.role).toBe('assistant');
     expect(res.headers.get('location')).toMatch(/\/v1\/messages\//);
-    await close();
-  });
-
-  it('creates user message in unsupported-provider window (perplexity), returns single message', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('perplexity'),
-      createMessage:  async (chatWindowId, _userId, role, content) =>
-        mockMessage(chatWindowId, { id: 'new-msg', role, content }),
-    }));
-    const res = await post(baseUrl, '/v1/messages', {
-      chatWindowId: 'cw-1', role: 'user', content: 'Hello',
-    });
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as ApiResponse<Message>;
-    if (!body.ok) throw new Error('expected ok');
-    // Single message returned — no assistantMessage field
-    expect(body.data.content).toBe('Hello');
-    expect('assistantMessage' in body.data).toBe(false);
     await close();
   });
 
@@ -663,19 +645,6 @@ describe('POST /v1/messages/stream — authenticated', () => {
     const { baseUrl, close } = await startServer(makeDeps());
     const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
     expect(res.status).toBe(401);
-    await close();
-  });
-
-  it('returns 412 provider_not_configured when chat-window provider is unsupported (perplexity)', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('perplexity'),
-    }));
-    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
-    expect(res.status).toBe(412);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('provider_not_configured');
     await close();
   });
 

--- a/apps/api/src/routes/provider-connections.test.ts
+++ b/apps/api/src/routes/provider-connections.test.ts
@@ -238,16 +238,6 @@ describe('PUT /v1/provider-connections/:provider — authenticated', () => {
     await close();
   });
 
-  it('returns 400 for unsupported but valid provider (perplexity)', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
-    const res = await put(baseUrl, '/v1/provider-connections/perplexity', { apiKey: 'pplx-test' });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
-    await close();
-  });
-
   it('returns 400 for unknown provider param', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await put(baseUrl, '/v1/provider-connections/gpt99', { apiKey: 'sk-test' });


### PR DESCRIPTION
Closes #33. **Stacked on #110 (anthropic adapter).** Merge #110 first.

Drops a third adapter into the registry, making all three providers in `@webapp/types` `AIProvider` union usable end-to-end.

## What's new
- `apps/api/src/providers/perplexity.provider.ts` (new): `verifyPerplexityKey` (max_tokens=1 ping), `createPerplexityClient` with OpenAI-compatible chat-completions schema and SSE parsing.
- `providers/registry.ts`: SUPPORTED_PROVIDERS now `{openai, anthropic, perplexity}`; getProviderClient + verifyProviderKey route to the new adapter.

## Side effect
There are no longer any "valid-but-unsupported" providers, so the bypass branches in tests are removed:
- `chat-windows[-db].test.ts`: drop the perplexity rejection block.
- `provider-connections.test.ts`: drop the "unsupported but valid" test (unknown-provider 400 still asserted).
- `messages-db.test.ts`: default `mockChatWindow` flipped back to `'openai'` / `'gpt-4o-mini'`; the now-impossible "single message in unsupported window" route test and "stream 412 when unsupported" test are dropped. Controller comments updated to note the fall-through is now defensive only.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 294/294 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓