### PR TITLE
chore(api): smoke scripts gain --provider=openai|anthropic|perplexity flag

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -60,25 +60,33 @@ End-to-end check of the full chat flow against a running API and a real OpenAI a
 
 ```bash
 # 1. API up + Postgres up + migrations applied (see "Local Postgres" below).
-# 2. apps/api/.env contains OPENAI_API_KEY (loaded automatically).
+# 2. apps/api/.env carries the relevant key:
+#    OPENAI_API_KEY (default), ANTHROPIC_API_KEY, or PERPLEXITY_API_KEY.
 pnpm api:smoke:ai
 # or equivalently:
 pnpm --filter @webapp/api smoke:ai
 ```
 
-The script signs up a fresh user, creates a project / workspace / chat-window, upserts the OpenAI key, posts a message "hello", and asserts an assistant reply was persisted. It **never logs the key value**. Missing `OPENAI_API_KEY` fails fast with a clear message.
+Default provider is `openai`. Override via `--provider=`:
+
+```bash
+pnpm api:smoke:ai -- --provider=anthropic
+pnpm api:smoke:ai -- --provider=perplexity --model=sonar
+```
+
+The script signs up a fresh user, creates a project / workspace / chat-window, upserts the provider key, posts a message "hello", and asserts an assistant reply was persisted with the right provider. It **never logs the key value**. A missing `<PROVIDER>_API_KEY` fails fast with a clear message.
 
 For the streaming endpoint (`POST /v1/messages/stream`):
 
 ```bash
 pnpm api:smoke:ai:stream
 # or
-pnpm --filter @webapp/api smoke:ai:stream
+pnpm --filter @webapp/api smoke:ai:stream -- --provider=anthropic
 ```
 
 Same setup, but exercises the SSE path: opens the stream, parses every `data:` event, asserts ≥1 `delta` chunk + the `[DONE]` sentinel + a final `{done:true,assistantMessage:…}` event, and confirms the persisted content equals the concatenated deltas. Then re-fetches `/v1/messages` to verify the assistant row landed in the DB.
 
-Both scripts are **not** wired into CI: they spend real OpenAI tokens and assume a live API on `http://localhost:4000`. Override the target with `SMOKE_API_BASE_URL=…` or the model with `SMOKE_MODEL=…`.
+Both scripts are **not** wired into CI: they spend real provider tokens and assume a live API on `http://localhost:4000`. Override the target with `SMOKE_API_BASE_URL=…` or the model with `SMOKE_MODEL=…` / `--model=…`.
 
 ## Env vars
 

--- a/apps/api/scripts/smoke-ai-stream.mjs
+++ b/apps/api/scripts/smoke-ai-stream.mjs
@@ -6,7 +6,26 @@
 // and a [DONE] sentinel. Spends real OpenAI tokens. Not wired into CI.
 
 const BASE_URL = process.env.SMOKE_API_BASE_URL ?? 'http://localhost:4000';
-const MODEL    = process.env.SMOKE_MODEL ?? 'gpt-4o-mini';
+
+const PROVIDER_DEFAULTS = {
+  openai:     { envVar: 'OPENAI_API_KEY',     defaultModel: 'gpt-4o-mini' },
+  anthropic:  { envVar: 'ANTHROPIC_API_KEY',  defaultModel: 'claude-3-5-haiku-latest' },
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', defaultModel: 'sonar' },
+};
+
+function parseFlag(name, fallback) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+const PROVIDER = parseFlag('provider', 'openai');
+if (!Object.prototype.hasOwnProperty.call(PROVIDER_DEFAULTS, PROVIDER)) {
+  console.error(`✗ unknown --provider='${PROVIDER}' (expected: openai | anthropic | perplexity)`);
+  process.exit(1);
+}
+const { envVar, defaultModel } = PROVIDER_DEFAULTS[PROVIDER];
+const MODEL = parseFlag('model', process.env.SMOKE_MODEL ?? defaultModel);
 
 function fail(msg, extra) {
   console.error(`✗ ${msg}`);
@@ -16,10 +35,10 @@ function fail(msg, extra) {
 
 function pass(msg) { console.log(`✓ ${msg}`); }
 
-if (!process.env.OPENAI_API_KEY) {
-  fail('OPENAI_API_KEY required (set it in apps/api/.env or in your shell)');
+const PROVIDER_API_KEY = process.env[envVar];
+if (!PROVIDER_API_KEY) {
+  fail(`${envVar} required (set it in apps/api/.env or in your shell)`);
 }
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 // ── Cookie jar ────────────────────────────────────────────────────────────────
 
@@ -76,7 +95,7 @@ const ts    = Date.now();
 const EMAIL = `smoke-stream-${ts}@example.test`;
 const PASS  = `smoke-pass-${ts}-${Math.random().toString(36).slice(2)}`;
 
-console.log(`▶ smoke-ai-stream against ${BASE_URL} as ${EMAIL}`);
+console.log(`▶ smoke-ai-stream against ${BASE_URL} (provider=${PROVIDER}, model=${MODEL}) as ${EMAIL}`);
 
 {
   const { status, body } = await req('GET', '/v1/health');
@@ -90,14 +109,14 @@ if (!user?.id) fail('signup returned no user.id');
 const project = await expectOk('create project', req('POST', '/v1/projects', { name: `Smoke Stream ${ts}` }));
 const workspace = await expectOk('create workspace', req('POST', '/v1/workspaces', { projectId: project.id, name: 'Smoke WS' }));
 
-await expectOk('upsert openai connection', req('PUT', '/v1/provider-connections/openai', { apiKey: OPENAI_API_KEY }));
+await expectOk(`upsert ${PROVIDER} connection`, req('PUT', `/v1/provider-connections/${PROVIDER}`, { apiKey: PROVIDER_API_KEY }));
 
 const cw = await expectOk(
   'create chat-window',
   req('POST', '/v1/chat-windows', {
     workspaceId: workspace.id,
     title:       'Smoke Stream Chat',
-    provider:    'openai',
+    provider:    PROVIDER,
     model:       MODEL,
   }),
 );
@@ -168,7 +187,7 @@ if (typeof finalEvent.assistantMessage.content !== 'string' || finalEvent.assist
 if (finalEvent.assistantMessage.content !== assistantContent) {
   fail(`stream: streamed content (${assistantContent.length}b) != persisted content (${finalEvent.assistantMessage.content.length}b)`);
 }
-if (finalEvent.assistantMessage.provider !== 'openai') fail('stream: assistant provider wrong');
+if (finalEvent.assistantMessage.provider !== PROVIDER) fail(`stream: assistant provider wrong (got '${finalEvent.assistantMessage.provider}')`);
 
 const totalMs = Date.now() - startedAt;
 pass(`received ${deltaCount} deltas, ${assistantContent.length} chars`);

--- a/apps/api/scripts/smoke-ai.mjs
+++ b/apps/api/scripts/smoke-ai.mjs
@@ -1,12 +1,39 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 // Local AI smoke test for @webapp/api.
-// Walks the full chat flow: signup → project → workspace → openai key →
+// Walks the full chat flow: signup → project → workspace → provider key →
 // chat-window → POST message → expect assistant reply.
-// Spends real OpenAI tokens. Not wired into CI on purpose.
+// Spends real provider tokens. Not wired into CI on purpose.
+//
+// Usage:
+//   pnpm api:smoke:ai
+//   pnpm api:smoke:ai -- --provider=anthropic
+//   pnpm api:smoke:ai -- --provider=perplexity --model=sonar
+//
+// Reads OPENAI_API_KEY / ANTHROPIC_API_KEY / PERPLEXITY_API_KEY from env;
+// never prints the key.
 
 const BASE_URL = process.env.SMOKE_API_BASE_URL ?? 'http://localhost:4000';
-const MODEL    = process.env.SMOKE_MODEL ?? 'gpt-4o-mini';
+
+const PROVIDER_DEFAULTS = {
+  openai:     { envVar: 'OPENAI_API_KEY',     defaultModel: 'gpt-4o-mini' },
+  anthropic:  { envVar: 'ANTHROPIC_API_KEY',  defaultModel: 'claude-3-5-haiku-latest' },
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', defaultModel: 'sonar' },
+};
+
+function parseFlag(name, fallback) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+const PROVIDER = parseFlag('provider', 'openai');
+if (!Object.prototype.hasOwnProperty.call(PROVIDER_DEFAULTS, PROVIDER)) {
+  console.error(`✗ unknown --provider='${PROVIDER}' (expected: openai | anthropic | perplexity)`);
+  process.exit(1);
+}
+const { envVar, defaultModel } = PROVIDER_DEFAULTS[PROVIDER];
+const MODEL = parseFlag('model', process.env.SMOKE_MODEL ?? defaultModel);
 
 function fail(msg, extra) {
   console.error(`✗ ${msg}`);
@@ -14,14 +41,12 @@ function fail(msg, extra) {
   process.exit(1);
 }
 
-function pass(msg) {
-  console.log(`✓ ${msg}`);
-}
+function pass(msg) { console.log(`✓ ${msg}`); }
 
-if (!process.env.OPENAI_API_KEY) {
-  fail('OPENAI_API_KEY required (set it in apps/api/.env or in your shell)');
+const PROVIDER_API_KEY = process.env[envVar];
+if (!PROVIDER_API_KEY) {
+  fail(`${envVar} required (set it in apps/api/.env or in your shell)`);
 }
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 // ── Cookie jar ────────────────────────────────────────────────────────────────
 
@@ -79,7 +104,7 @@ const ts    = Date.now();
 const EMAIL = `smoke-${ts}@example.test`;
 const PASS  = `smoke-pass-${ts}-${Math.random().toString(36).slice(2)}`;
 
-console.log(`▶ smoke-ai against ${BASE_URL} as ${EMAIL}`);
+console.log(`▶ smoke-ai against ${BASE_URL} (provider=${PROVIDER}, model=${MODEL}) as ${EMAIL}`);
 
 // 1. Health
 {
@@ -105,10 +130,10 @@ const workspace = await expectOk(
 );
 if (!workspace?.id) fail('workspace missing id');
 
-// 5. OpenAI connection (apiKey from env, never printed)
+// 5. Provider connection (apiKey from env, never printed)
 await expectOk(
-  'upsert openai connection',
-  req('PUT', '/v1/provider-connections/openai', { apiKey: OPENAI_API_KEY }),
+  `upsert ${PROVIDER} connection`,
+  req('PUT', `/v1/provider-connections/${PROVIDER}`, { apiKey: PROVIDER_API_KEY }),
 );
 
 // 6. Chat window
@@ -117,7 +142,7 @@ const cw = await expectOk(
   req('POST', '/v1/chat-windows', {
     workspaceId: workspace.id,
     title:       'Smoke Chat',
-    provider:    'openai',
+    provider:    PROVIDER,
     model:       MODEL,
   }),
 );
@@ -139,7 +164,7 @@ if (am.role !== 'assistant')   fail(`assistant role wrong: ${am.role}`);
 if (typeof am.content !== 'string' || am.content.length === 0) {
   fail('assistant content empty');
 }
-if (am.provider !== 'openai')  fail(`assistant provider wrong: ${am.provider}`);
+if (am.provider !== PROVIDER)  fail(`assistant provider wrong: ${am.provider}`);
 
 pass(`assistant reply (${am.content.length} chars, ${am.promptTokens ?? '?'} prompt + ${am.completionTokens ?? '?'} completion tokens, ${am.latencyMs ?? '?'}ms)`);
 


### PR DESCRIPTION
**Stacked on #111 (perplexity).** Merge #111 first.

Both `smoke-ai.mjs` and `smoke-ai-stream.mjs` accept `--provider=` and `--model=` CLI flags (default `openai`). Each provider has its own env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `PERPLEXITY_API_KEY`) and a sane default model. Missing key fails fast with a clear message naming the env var. Banner reports provider+model. The assistant-provider assertion checks the requested provider rather than a hardcoded `'openai'`.

## Verified locally
- ✓ openai end-to-end: 34 chars / 1998ms PASSED
- ✓ unknown-provider path exits 1 with helpful message
- ✓ missing-key path exits 1 naming the right env var

README updated under "AI smoke (manual)".

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 294/294 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓