### PR TITLE
fix(api): provider verify uses AbortSignal.timeout (10s)

### DIFF
--- a/apps/api/src/providers/anthropic.provider.test.ts
+++ b/apps/api/src/providers/anthropic.provider.test.ts
@@ -37,6 +37,13 @@ describe('verifyAnthropicKey', () => {
     vi.mocked(fetch).mockRejectedValue(new Error('boom'));
     expect(await verifyAnthropicKey(API_KEY)).toBe('provider_error');
   });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    await verifyAnthropicKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createAnthropicClient.createChatCompletion', () => {

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -19,6 +19,8 @@ const DEFAULT_MAX_TOKENS = 1024;
 
 export type AnthropicVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
+const VERIFY_TIMEOUT_MS = 10_000;
+
 export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerifyResult> {
   let res: Response;
   try {
@@ -28,6 +30,7 @@ export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerif
         'x-api-key':         apiKey,
         'anthropic-version': ANTHROPIC_VERSION,
       },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
     return 'provider_error';

--- a/apps/api/src/providers/openai.provider.test.ts
+++ b/apps/api/src/providers/openai.provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createOpenAIClient } from './openai.provider.js';
+import { createOpenAIClient, verifyOpenAIKey } from './openai.provider.js';
 import { ProviderError } from './provider.interface.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -31,6 +31,33 @@ function openAIBody(content: string, model = MODEL) {
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('verifyOpenAIKey', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns ok on 200', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('ok');
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 401 }));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns provider_error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('boom'));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('provider_error');
+  });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    await verifyOpenAIKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
 
 describe('createOpenAIClient', () => {
   beforeEach(() => {

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -11,6 +11,7 @@ import { ProviderError } from './provider.interface.js';
 export type OpenAIVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
 const OPENAI_MODELS_URL = 'https://api.openai.com/v1/models';
+const VERIFY_TIMEOUT_MS = 10_000;
 
 export async function verifyOpenAIKey(apiKey: string): Promise<OpenAIVerifyResult> {
   let res: Response;
@@ -18,8 +19,10 @@ export async function verifyOpenAIKey(apiKey: string): Promise<OpenAIVerifyResul
     res = await fetch(OPENAI_MODELS_URL, {
       method: 'GET',
       headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
+    // network failure or abort — treat as transient, surface to caller as 502.
     return 'provider_error';
   }
   if (res.status === 200) return 'ok';

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -41,6 +41,13 @@ describe('verifyPerplexityKey', () => {
     vi.mocked(fetch).mockRejectedValue(new Error('boom'));
     expect(await verifyPerplexityKey(API_KEY)).toBe('provider_error');
   });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ choices: [{ message: { role: 'assistant', content: '' } }] }));
+    await verifyPerplexityKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createPerplexityClient.createChatCompletion', () => {

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -20,6 +20,8 @@ const VERIFY_MODEL = 'sonar';
 
 export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
+const VERIFY_TIMEOUT_MS = 10_000;
+
 export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
   let res: Response;
   try {
@@ -35,6 +37,7 @@ export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVer
         max_tokens: 1,
         stream: false,
       }),
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
     return 'provider_error';


### PR DESCRIPTION
**Stacked on #112 (smoke multi-provider).** Merge #112 first.

Hardening. `verifyOpenAIKey`, `verifyAnthropicKey`, and `verifyPerplexityKey` each pass `AbortSignal.timeout(10_000)` into `fetch`.

Previously the `PUT /v1/provider-connections/:provider` endpoint could hang indefinitely if the upstream silently dropped the connection mid-handshake — the existing catch already maps any throw to `'provider_error'` so an aborted request now returns a clean 502 to the user instead of stalling.

Adds AbortSignal-presence checks to each provider's verify test, plus a missing `verifyOpenAIKey` test block (status routing + AbortSignal plumbing).

No types changes. No behaviour change for happy paths.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 300/300 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓