### PR TITLE
feat(api): GET /v1/health/deep with DB liveness probe

### DIFF
--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -1,0 +1,57 @@
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import type { ApiResponse } from '@webapp/types';
+import { Router } from '../lib/router.js';
+import { createApiServer } from '../lib/server.js';
+import { healthDeepController, type DbStatus, type HealthDeepDeps } from './health-deep.controller.js';
+
+function makeDeps(status: DbStatus): HealthDeepDeps {
+  return { pingDb: async () => status };
+}
+
+async function startServer(deps: HealthDeepDeps): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const router = new Router();
+  router.register({ method: 'GET', path: '/v1/health/deep', handler: (ctx) => healthDeepController(ctx, deps) });
+  const server: Server = createApiServer(router);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+describe('GET /v1/health/deep', () => {
+  it('returns 200 with db=ok when ping succeeds', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('ok'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus; service: string }>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.db).toBe('ok');
+    expect(body.data.service).toBe('webapp-api');
+    await close();
+  });
+
+  it('returns 200 with db=disabled when no DATABASE_URL', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('disabled'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus }>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.db).toBe('disabled');
+    await close();
+  });
+
+  it('returns 503 with db=down when ping fails', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('down'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('internal_error');
+    expect((body.error.details as { db: DbStatus }).db).toBe('down');
+    await close();
+  });
+});

--- a/apps/api/src/controllers/health-deep.controller.ts
+++ b/apps/api/src/controllers/health-deep.controller.ts
@@ -1,0 +1,61 @@
+import { sql } from 'drizzle-orm';
+import { env } from '../config/env.js';
+import { createDb } from '../lib/db.js';
+import { respond, respondError, type InternalResult, type RequestContext } from '../lib/http.js';
+
+export type DbStatus = 'ok' | 'down' | 'disabled';
+
+export interface HealthDeepDeps {
+  /** Returns 'ok' when the DB answers a trivial query, 'down' on any failure,
+   *  'disabled' when no DATABASE_URL is configured. */
+  pingDb: () => Promise<DbStatus>;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+async function defaultPingDb(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<DbStatus> {
+  if (!env.databaseUrl) return 'disabled';
+  let db;
+  try {
+    db = createDb();
+  } catch {
+    return 'down';
+  }
+  try {
+    await Promise.race([
+      db.execute(sql`select 1`),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('db_ping_timeout')), timeoutMs)),
+    ]);
+    return 'ok';
+  } catch {
+    return 'down';
+  }
+}
+
+export function makeHealthDeepDeps(): HealthDeepDeps {
+  return { pingDb: () => defaultPingDb() };
+}
+
+export interface HealthDeepResponse {
+  service: 'webapp-api';
+  version: string;
+  db: DbStatus;
+  timestamp: string;
+}
+
+export async function healthDeepController(
+  _ctx: RequestContext,
+  deps: HealthDeepDeps,
+): Promise<InternalResult> {
+  const db = await deps.pingDb();
+  const body: HealthDeepResponse = {
+    service: 'webapp-api',
+    version: env.serviceVersion,
+    db,
+    timestamp: new Date().toISOString(),
+  };
+  if (db === 'down') {
+    return respondError('internal_error', 'Database is unreachable', 503, body);
+  }
+  return respond(body);
+}

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,4 +1,5 @@
 import { healthController } from '../controllers/health.controller.js';
+import { healthDeepController, makeHealthDeepDeps } from '../controllers/health-deep.controller.js';
 import {
   createChatWindowController,
   deleteChatWindowController,
@@ -147,9 +148,12 @@ const stateHandler = (db && authDeps)
   ? (ctx: Parameters<typeof stateDbController>[0]) => stateDbController(ctx, makeStateDeps(db, authDeps))
   : stateController;
 
+const healthDeepDeps = makeHealthDeepDeps();
+
 export const businessRoutes: RouteDefinition[] = [
-  { method: 'GET', path: API_HEALTH_PATH, handler: healthController },
-  { method: 'GET', path: '/v1/health',    handler: healthController },
+  { method: 'GET', path: API_HEALTH_PATH,     handler: healthController },
+  { method: 'GET', path: '/v1/health',        handler: healthController },
+  { method: 'GET', path: '/v1/health/deep',   handler: (ctx) => healthDeepController(ctx, healthDeepDeps) },
 
   ...projectRoutes,
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -129,6 +129,7 @@ export type ApiErrorResponse       = Extract<ApiResponse<never>, { ok: false }>;
 // ── Canonical API route contract ─────────────────────────────────────────────
 
 export const API_HEALTH_PATH       = '/health' as const;
+export const API_HEALTH_DEEP_PATH  = '/v1/health/deep' as const;
 export const API_PROJECTS_PATH     = '/v1/projects' as const;
 export const API_WORKSPACES_PATH   = '/v1/workspaces' as const;
 export const API_CHAT_WINDOWS_PATH = '/v1/chat-windows' as const;


### PR DESCRIPTION
**Stacked on #113 (verify-timeout).** Merge #113 first.

Adds a deep health endpoint that runs a `select 1` against the configured Postgres connection (5s ceiling on the query). Returns:
- 200 + `{ db: 'ok', ... }` when the DB answers
- 200 + `{ db: 'disabled', ... }` when `DATABASE_URL` is unset
- 503 + `{ db: 'down', ... }` when the DB ping throws or times out

The shallow `GET /v1/health` endpoint stays unchanged (always 200). `/v1/health/deep` is the readiness-style check: orchestrators can use it to drain traffic when the DB is unhealthy.

## Implementation
- new `apps/api/src/controllers/health-deep.controller.ts`: pure controller with an injected `pingDb` dep; default deps build a real Drizzle client and run `sql\`select 1\`` with a 5s timeout race.
- `packages/types`: `API_HEALTH_DEEP_PATH` constant (additive).
- `routes/index.ts`: `GET /v1/health/deep` wired alongside the shallow path.
- new `health-deep.controller.test.ts`: 3 integration tests (ok / disabled / down) using a stub ping dep so no live DB needed.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 303/303 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓