### PR TITLE
fix(auth): reset rate-limit bucket on successful signup/login

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -47,6 +47,7 @@ export interface AuthDeps {
   findSessionByTokenHash: (tokenHash: string) => Promise<DbSession | null>;
   deleteSession:   (tokenHash: string) => Promise<void>;
   checkRateLimit:  (key: string) => RateLimitResult;
+  resetRateLimit:  (key: string) => void;
 }
 
 // 10 attempts per IP per 15 minutes for both signup and login.
@@ -62,6 +63,7 @@ export function makeAuthDeps(db: Db): AuthDeps {
     findSessionByTokenHash: (tokenHash)                    => sessionsRepo.findSessionByTokenHash(db, tokenHash),
     deleteSession:          (tokenHash)                    => sessionsRepo.deleteSession(db, tokenHash),
     checkRateLimit:         (key)                          => authLimiter.check(key),
+    resetRateLimit:         (key)                          => authLimiter.reset(key),
   };
 }
 
@@ -120,6 +122,10 @@ export async function signupController(ctx: RequestContext, deps: AuthDeps): Pro
   const tokenHash = hashSessionToken(token);
   await deps.createSession(tokenHash, user.id, sessionExpiresAt());
 
+  // Successful signup → clear the bucket so a legit user who fat-fingered
+  // earlier attempts is not still inside the brute-force window.
+  deps.resetRateLimit(getClientIp(ctx.req));
+
   return { httpStatus: 201, body: { ok: true, data: toSafeUser(user) }, headers: cookieHeader(token) };
 }
 
@@ -143,6 +149,10 @@ export async function loginController(ctx: RequestContext, deps: AuthDeps): Prom
   const token     = generateSessionToken();
   const tokenHash = hashSessionToken(token);
   await deps.createSession(tokenHash, user.id, sessionExpiresAt());
+
+  // Successful login → clear the bucket so a legit user who fat-fingered
+  // their password is not still inside the brute-force window.
+  deps.resetRateLimit(getClientIp(ctx.req));
 
   return { httpStatus: 200, body: { ok: true, data: toSafeUser(user) }, headers: cookieHeader(token) };
 }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -47,6 +47,7 @@ function makeDeps(overrides: Partial<AuthDeps> = {}): AuthDeps {
     findSessionByTokenHash: async () => null,
     deleteSession:          async () => {},
     checkRateLimit:         () => ({ ok: true, retryAfterSecs: 0 }),
+    resetRateLimit:         () => {},
     ...overrides,
   };
 }
@@ -367,6 +368,44 @@ describe('rate limiting — login', () => {
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('rate_limited');
     expect(res.headers.get('retry-after')).toBe('120');
+    await close();
+  });
+
+  it('resets the bucket after a successful login (legit user is not penalised)', async () => {
+    const realHash = await hashPassword('validpassword');
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => mockUser({ passwordHash: realHash }),
+      resetRateLimit:  (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: 'test@example.com', password: 'validpassword' });
+    expect(res.status).toBe(200);
+    expect(resetCalls).toHaveLength(1);
+    await close();
+  });
+
+  it('does NOT reset the bucket after a failed login (brute-force window stays)', async () => {
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => null,
+      resetRateLimit:  (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: 'no@one.com', password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(resetCalls).toHaveLength(0);
+    await close();
+  });
+});
+
+describe('rate limiting — signup', () => {
+  it('resets the bucket after a successful signup', async () => {
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      resetRateLimit: (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/signup', { email: 'fresh@example.com', password: 'password123' });
+    expect(res.status).toBe(201);
+    expect(resetCalls).toHaveLength(1);
     await close();
   });
 });


### PR DESCRIPTION
**Stacked on #114 (health-deep).** Merge #114 first.

Brute-force defense was correct, but a legit user who fat-fingered their password a few times then succeeded would still be inside the 10/15min window for any later attempt — penalising the wrong people.

After a successful POST `/v1/auth/signup` or POST `/v1/auth/login`, the bucket for that IP is now cleared via a new `resetRateLimit` dep. Failed attempts still increment as before; the brute-force defense is unchanged for attackers.

`AuthDeps` gains `resetRateLimit(key)`; `makeAuthDeps` wires it to `authLimiter.reset`.

## Tests
- login success → reset called once
- login failure → reset NOT called (window stays)
- signup success → reset called once

## Note
Trivial textual rebase against #107 (`test/api-rate-limiter-#15`) when both reach `main` — both extend `routes/auth.test.ts` in different blocks. Land #107 first if possible.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 306/306 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓