### PR TITLE
polish(web): loading skeletons + error/not-found routes

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (typeof console !== 'undefined') {
+      console.error('[GlobalError]', error);
+    }
+  }, [error]);
+
+  return (
+    <main style={pageStyle} role="alert">
+      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Something went wrong</h1>
+      <p style={{ margin: 0, color: '#c9c9d2', fontSize: '0.9rem' }}>
+        {error.message || 'Unknown error'}
+      </p>
+      {error.digest ? (
+        <p style={{ margin: 0, color: '#6a6a75', fontSize: '0.72rem' }}>
+          Reference: <code>{error.digest}</code>
+        </p>
+      ) : null}
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+        <button type="button" onClick={reset} style={primaryButton}>
+          Try again
+        </button>
+        <Link href="/" style={ghostButton}>
+          Go home
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 560,
+  margin: '4rem auto',
+  padding: '1.5rem',
+  background: '#1b1b23',
+  border: '1px solid #3a1d1d',
+  borderRadius: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+};
+
+const primaryButton: React.CSSProperties = {
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+};
+
+const ghostButton: React.CSSProperties = {
+  background: 'transparent',
+  color: '#e8e8ef',
+  border: '1px solid #2a2a30',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+  display: 'inline-flex',
+  alignItems: 'center',
+};

--- a/apps/web/src/app/loading.tsx
+++ b/apps/web/src/app/loading.tsx
@@ -1,0 +1,74 @@
+import { AppShell } from '@/components/AppShell';
+import { Panel } from '@/components/Panel';
+
+export default function HomeLoading() {
+  return (
+    <AppShell subtitle="Projects">
+      <section style={{ padding: '1.5rem', maxWidth: 960, width: '100%', margin: '0 auto' }}>
+        <h1 style={{ fontSize: '1.5rem', margin: '0 0 1.25rem 0' }}>Your projects</h1>
+        <div
+          aria-hidden
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+            gap: '1rem',
+          }}
+        >
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Panel
+              key={i}
+              style={{
+                padding: '1rem',
+                height: 96,
+                opacity: 0.65,
+                background: '#141418',
+                borderColor: '#1d1d22',
+              }}
+            >
+              <SkeletonLine width="55%" />
+              <SkeletonLine width="80%" small />
+              <SkeletonLine width="35%" tiny />
+            </Panel>
+          ))}
+        </div>
+        <span aria-live="polite" style={srOnlyStyle}>
+          Loading your projects…
+        </span>
+      </section>
+    </AppShell>
+  );
+}
+
+function SkeletonLine({
+  width,
+  small,
+  tiny,
+}: {
+  width: string;
+  small?: boolean;
+  tiny?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        width,
+        height: tiny ? 8 : small ? 10 : 12,
+        background: 'linear-gradient(90deg, #1f1f27 0%, #2a2a35 50%, #1f1f27 100%)',
+        backgroundSize: '200% 100%',
+        animation: 'wav-shimmer 1.4s linear infinite',
+        borderRadius: 4,
+        marginTop: tiny ? 14 : small ? 8 : 0,
+      }}
+    />
+  );
+}
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <main style={pageStyle}>
+      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Page not found</h1>
+      <p style={{ margin: 0, color: '#c9c9d2', fontSize: '0.9rem' }}>
+        The page you tried to reach doesn&apos;t exist or was moved.
+      </p>
+      <Link href="/" style={primaryButton}>
+        Back to projects
+      </Link>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 480,
+  margin: '4rem auto',
+  padding: '1.5rem',
+  background: '#1b1b23',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+};
+
+const primaryButton: React.CSSProperties = {
+  alignSelf: 'flex-start',
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+};

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -98,9 +98,27 @@ function ErrorPanel({ message }: { message: string }) {
       <div style={{ color: '#8a8a95', fontSize: '0.78rem', marginTop: 10 }}>
         Check that <code>apps/api</code> is running and <code>NEXT_PUBLIC_API_URL</code> points to it.
       </div>
+      <div style={{ marginTop: 12 }}>
+        <Link href="/" style={retryButtonStyle} prefetch={false}>
+          Try again
+        </Link>
+      </div>
     </Panel>
   );
 }
+
+const retryButtonStyle: React.CSSProperties = {
+  display: 'inline-block',
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.4rem 0.8rem',
+  fontFamily: 'inherit',
+  fontSize: '0.8rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+};
 
 function SourceBadge({ result }: { result: ProjectsResult }) {
   const config =

--- a/apps/web/src/app/project/[id]/error.tsx
+++ b/apps/web/src/app/project/[id]/error.tsx
@@ -18,7 +18,7 @@ export default function ProjectError({
 
   return (
     <main style={pageStyle} role="alert">
-      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Couldn't load this project</h1>
+      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Couldn&apos;t load this project</h1>
       <p style={{ margin: 0, color: '#c9c9d2', fontSize: '0.9rem' }}>
         {error.message || 'Unknown error'}
       </p>

--- a/apps/web/src/app/project/[id]/error.tsx
+++ b/apps/web/src/app/project/[id]/error.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+export default function ProjectError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (typeof console !== 'undefined') {
+      console.error('[ProjectError]', error);
+    }
+  }, [error]);
+
+  return (
+    <main style={pageStyle} role="alert">
+      <h1 style={{ margin: 0, fontSize: '1.25rem' }}>Couldn't load this project</h1>
+      <p style={{ margin: 0, color: '#c9c9d2', fontSize: '0.9rem' }}>
+        {error.message || 'Unknown error'}
+      </p>
+      {error.digest ? (
+        <p style={{ margin: 0, color: '#6a6a75', fontSize: '0.72rem' }}>
+          Reference: <code>{error.digest}</code>
+        </p>
+      ) : null}
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+        <button type="button" onClick={reset} style={primaryButton}>
+          Try again
+        </button>
+        <Link href="/" style={ghostButton}>
+          Back to projects
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 560,
+  margin: '4rem auto',
+  padding: '1.5rem',
+  background: '#1b1b23',
+  border: '1px solid #3a1d1d',
+  borderRadius: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+};
+
+const primaryButton: React.CSSProperties = {
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+};
+
+const ghostButton: React.CSSProperties = {
+  background: 'transparent',
+  color: '#e8e8ef',
+  border: '1px solid #2a2a30',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+  display: 'inline-flex',
+  alignItems: 'center',
+};

--- a/apps/web/src/app/project/[id]/loading.tsx
+++ b/apps/web/src/app/project/[id]/loading.tsx
@@ -1,0 +1,97 @@
+export default function ProjectLoading() {
+  return (
+    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+      <aside style={sidebarStyle}>
+        <div style={{ padding: '0.9rem 1rem', borderBottom: '1px solid #24242c' }}>
+          <SkeletonLine width="60%" tiny />
+          <SkeletonLine width="80%" />
+          <div style={{ height: 8 }} />
+          <SkeletonLine width="100%" small />
+        </div>
+        <div style={{ flex: 1, padding: '0.5rem' }}>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                height: 44,
+                background: '#141418',
+                borderRadius: 8,
+                marginBottom: 6,
+                opacity: 0.7,
+              }}
+            />
+          ))}
+        </div>
+      </aside>
+      <div
+        style={{
+          flex: 1,
+          padding: '1.25rem',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+          gap: '1rem',
+          alignContent: 'start',
+        }}
+      >
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              minHeight: 360,
+              background: '#131318',
+              border: '1px solid #1d1d22',
+              borderRadius: 12,
+              opacity: 0.7,
+            }}
+          />
+        ))}
+      </div>
+      <span aria-live="polite" style={srOnlyStyle}>
+        Loading workspace…
+      </span>
+    </div>
+  );
+}
+
+function SkeletonLine({
+  width,
+  small,
+  tiny,
+}: {
+  width: string;
+  small?: boolean;
+  tiny?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        width,
+        height: tiny ? 8 : small ? 10 : 14,
+        background: 'linear-gradient(90deg, #1f1f27 0%, #2a2a35 50%, #1f1f27 100%)',
+        backgroundSize: '200% 100%',
+        animation: 'wav-shimmer 1.4s linear infinite',
+        borderRadius: 4,
+        marginTop: tiny ? 0 : 8,
+      }}
+    />
+  );
+}
+
+const sidebarStyle: React.CSSProperties = {
+  width: 260,
+  flexShrink: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  borderRight: '1px solid #24242c',
+  background: '#0f0f13',
+};
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};

--- a/apps/web/src/app/settings/providers/loading.tsx
+++ b/apps/web/src/app/settings/providers/loading.tsx
@@ -1,0 +1,82 @@
+export default function ProvidersLoading() {
+  return (
+    <main style={pageStyle}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', margin: 0 }}>Provider connections</h1>
+      </header>
+      <section style={sectionStyle}>
+        <SkeletonLine width="35%" small />
+        <SkeletonLine width="70%" tiny />
+        <div style={{ height: 8 }} />
+        <SkeletonRow />
+        <SkeletonRow />
+      </section>
+      <span aria-live="polite" style={srOnlyStyle}>
+        Loading provider settings…
+      </span>
+    </main>
+  );
+}
+
+function SkeletonRow() {
+  return (
+    <div
+      style={{
+        height: 36,
+        borderRadius: 6,
+        background: '#141418',
+        opacity: 0.7,
+        marginTop: 6,
+      }}
+    />
+  );
+}
+
+function SkeletonLine({
+  width,
+  small,
+  tiny,
+}: {
+  width: string;
+  small?: boolean;
+  tiny?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        width,
+        height: tiny ? 8 : small ? 12 : 14,
+        background: 'linear-gradient(90deg, #1f1f27 0%, #2a2a35 50%, #1f1f27 100%)',
+        backgroundSize: '200% 100%',
+        animation: 'wav-shimmer 1.4s linear infinite',
+        borderRadius: 4,
+        marginTop: tiny ? 8 : 0,
+      }}
+    />
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 880,
+  margin: '0 auto',
+  padding: '2rem 1.5rem',
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+};
+
+const sectionStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #1d1d22',
+  borderRadius: 10,
+  padding: '1rem 1.1rem',
+};
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
@@ -49,9 +50,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           >
             Reload page
           </button>
-          <a href="/" style={ghostButtonStyle}>
+          <Link href="/" style={ghostButtonStyle}>
             Go home
-          </a>
+          </Link>
         </div>
       </div>
     );

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -36,25 +36,23 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       <div role="alert" style={fallbackStyle}>
         <h2 style={{ margin: 0, fontSize: '1.1rem' }}>Something went wrong</h2>
         <p style={{ margin: 0, color: '#c9c9d2' }}>{error.message || 'Unknown error'}</p>
-        <button
-          type="button"
-          onClick={this.reset}
-          style={{
-            marginTop: '0.5rem',
-            background: '#f5f5f5',
-            color: '#0b0b0d',
-            border: 'none',
-            borderRadius: 8,
-            padding: '0.5rem 0.9rem',
-            cursor: 'pointer',
-            fontFamily: 'inherit',
-            fontSize: '0.875rem',
-            fontWeight: 500,
-            alignSelf: 'flex-start',
-          }}
-        >
-          Try again
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+          <button type="button" onClick={this.reset} style={primaryButtonStyle}>
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (typeof window !== 'undefined') window.location.reload();
+            }}
+            style={ghostButtonStyle}
+          >
+            Reload page
+          </button>
+          <a href="/" style={ghostButtonStyle}>
+            Go home
+          </a>
+        </div>
       </div>
     );
   }
@@ -72,4 +70,31 @@ const fallbackStyle: React.CSSProperties = {
   flexDirection: 'column',
   gap: '0.75rem',
   fontFamily: 'inherit',
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+};
+
+const ghostButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  color: '#e8e8ef',
+  border: '1px solid #2a2a30',
+  borderRadius: 8,
+  padding: '0.5rem 0.9rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.875rem',
+  fontWeight: 500,
+  textDecoration: 'none',
+  display: 'inline-flex',
+  alignItems: 'center',
 };

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -22,3 +22,8 @@ body {
   0%, 50% { opacity: 1; }
   50.01%, 100% { opacity: 0; }
 }
+
+@keyframes wav-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}


### PR DESCRIPTION
Adds Next file-convention `loading.tsx`, `error.tsx`, `not-found.tsx` and improves recovery affordances on the home `ErrorPanel` and the global `ErrorBoundary`. Touches only files that no other in-flight branch touches — fully orthogonal.

## Changes
- `apps/web/src/app/loading.tsx` — home shimmering skeleton during `loadProjects` (RSC).
- `apps/web/src/app/project/[id]/loading.tsx` — sidebar + canvas skeleton during the project RSC fetch chain.
- `apps/web/src/app/settings/providers/loading.tsx` — panel skeleton for the settings page chrome.
- `apps/web/src/app/error.tsx` — app-wide error fallback with `Try again` + `Go home`.
- `apps/web/src/app/project/[id]/error.tsx` — segment error fallback with the same affordances + `Back to projects`.
- `apps/web/src/app/not-found.tsx` — styled 404.
- `apps/web/src/app/page.tsx` — `Try again` link inside the home `ErrorPanel`.
- `apps/web/src/components/ErrorBoundary.tsx` — fallback now offers `Try again`, `Reload page`, `Go home` (via `next/link`).
- `apps/web/src/styles/globals.css` — adds `wav-shimmer` keyframes used by skeleton lines.

## Checks
- pnpm --filter @webapp/web typecheck ✅
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Independent of PR #116/#117/#118 and PR `polish/web-batch-ux-robustness` — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)