### PR TITLE
polish(web): UX robustness batch (Toast a11y, AuthForm, document.title, sidebar a11y, composer auto-resize)

### DIFF
--- a/apps/web/src/components/ToastHost.tsx
+++ b/apps/web/src/components/ToastHost.tsx
@@ -87,6 +87,17 @@ export function ToastHost({ children }: { children: ReactNode }) {
     };
   }, [toasts, dismiss]);
 
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setToasts([]);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [toasts.length]);
+
   const value = useMemo<ToastContextValue>(
     () => ({ push, pushError, dismiss }),
     [push, pushError, dismiss],
@@ -101,9 +112,21 @@ export function ToastHost({ children }: { children: ReactNode }) {
             key={t.id}
             role="status"
             style={{ ...toastStyle, ...toneStyles[t.tone] }}
-            onClick={() => dismiss(t.id)}
           >
-            <div>{t.message}</div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+              <div style={{ flex: 1, minWidth: 0 }}>{t.message}</div>
+              <button
+                type="button"
+                aria-label="Dismiss notification"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dismiss(t.id);
+                }}
+                style={toastCloseStyle}
+              >
+                ×
+              </button>
+            </div>
             {t.action ? (
               <Link
                 href={t.action.href}
@@ -139,11 +162,23 @@ const toastStyle: React.CSSProperties = {
   borderRadius: 8,
   fontSize: '0.875rem',
   boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
-  cursor: 'pointer',
   color: '#f5f5f5',
   display: 'flex',
   flexDirection: 'column',
   gap: 6,
+};
+
+const toastCloseStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: 'inherit',
+  cursor: 'pointer',
+  fontSize: '1.05rem',
+  lineHeight: 1,
+  padding: '0 4px',
+  opacity: 0.65,
+  fontFamily: 'inherit',
+  flexShrink: 0,
 };
 
 const toastActionStyle: React.CSSProperties = {

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, type FormEvent } from 'react';
+import { useRef, useState, type FormEvent } from 'react';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
 import { login, register } from '@/lib/api/auth';
@@ -68,17 +68,20 @@ export function AuthForm({ mode }: AuthFormProps) {
   const [displayName, setDisplayName] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const emailRef = useRef<HTMLInputElement | null>(null);
 
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (pending) return;
     setError(null);
     setPending(true);
+    const trimmedEmail = email.trim();
     try {
       if (mode === 'login') {
-        await login({ email, password });
+        await login({ email: trimmedEmail, password });
       } else {
         await register({
-          email,
+          email: trimmedEmail,
           password,
           ...(displayName.trim() ? { displayName: displayName.trim() } : {}),
         });
@@ -91,6 +94,8 @@ export function AuthForm({ mode }: AuthFormProps) {
     } catch (err) {
       setError(messageFor(err as ApiCallError, mode));
       setPending(false);
+      emailRef.current?.focus();
+      emailRef.current?.select();
     }
   }
 
@@ -114,11 +119,14 @@ export function AuthForm({ mode }: AuthFormProps) {
           ) : null}
           <Field label="Email">
             <input
+              ref={emailRef}
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
               autoComplete="email"
+              autoFocus
+              spellCheck={false}
               style={inputStyle}
             />
           </Field>

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -140,6 +140,9 @@ export function AuthForm({ mode }: AuthFormProps) {
               autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
               style={inputStyle}
             />
+            {mode === 'register' ? (
+              <span style={hintStyle}>At least 8 characters.</span>
+            ) : null}
           </Field>
 
           {error ? (
@@ -191,4 +194,9 @@ const inputStyle: React.CSSProperties = {
   fontSize: '0.9rem',
   fontFamily: 'inherit',
   outline: 'none',
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: '0.72rem',
+  color: '#8a8a95',
 };

--- a/apps/web/src/features/auth/UserMenu.tsx
+++ b/apps/web/src/features/auth/UserMenu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import { useToast } from '@/components/ToastHost';
 import { useSession } from '@/features/auth/SessionContext';
@@ -54,9 +55,14 @@ export function UserMenu() {
               <div style={{ fontSize: '0.85rem', fontWeight: 500 }}>{display}</div>
               <div style={{ fontSize: '0.75rem', color: '#8a8a95' }}>{user.email}</div>
             </div>
-            <a href="/settings/providers" role="menuitem" style={menuItemStyle}>
+            <Link
+              href="/settings/providers"
+              role="menuitem"
+              onClick={() => setOpen(false)}
+              style={menuItemStyle}
+            >
               Provider settings
-            </a>
+            </Link>
             <button
               type="button"
               role="menuitem"

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -74,6 +74,14 @@ export function ChatWindow({
     if (stickyRef.current) el.scrollTop = el.scrollHeight;
   }, [messagesSignature]);
 
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = 'auto';
+    const next = Math.min(ta.scrollHeight, 160);
+    ta.style.height = `${Math.max(36, next)}px`;
+  }, [draft]);
+
   const commitRename = () => {
     const trimmed = titleDraft.trim();
     if (trimmed && trimmed !== title) onRename?.(id, trimmed);

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -30,6 +30,14 @@ export function Workspace({
 }: WorkspaceProps) {
   const toast = useToast();
   const router = useRouter();
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const previous = document.title;
+    document.title = `${projectName} · ${activeWorkspace.name} — AI Workspace V1`;
+    return () => {
+      document.title = previous;
+    };
+  }, [projectName, activeWorkspace.name]);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const initialWindowParam = searchParams?.get('window') ?? null;

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -557,8 +557,17 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
   const stamp = formatRelative(window.updatedAt ?? window.createdAt);
   return (
     <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       aria-current={active ? 'true' : undefined}
+      aria-label={`${window.title} — ${window.provider} ${window.model}`}
       style={{
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
A batch of small frontend polish items. Each commit is independently scoped and reviewable.

## Changes (one commit per concern)
- `UserMenu` — replace raw `<a>` to `/settings/providers` with `next/link` for client-side nav; close menu on click.
- `ToastHost` — explicit × close button on every toast; `Escape` dismisses all visible toasts; remove implicit click-anywhere-to-dismiss.
- `AuthForm` — `.trim()` email before submit; ref + auto-select on error so focus returns to the email field; explicit `pending` guard at top of `onSubmit`; `autoFocus` + `spellCheck={false}` on the email input.
- `Workspace` — sets `document.title` to `<project> · <workspace> — AI Workspace V1`; restores previous title on unmount.
- `AuthForm` (register) — `At least 8 characters.` hint under the password field.
- `ChatWindow` — composer textarea now auto-resizes between 36–160px based on content via a `useLayoutEffect`.
- `WorkspaceSidebar` — `WindowRow` is now keyboard-activatable (`role="button"`, `tabIndex={0}`, Enter/Space handlers, `aria-label` combining title + provider + model).

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Touches `AuthForm.tsx` like the `/settings/providers` stack does, but on disjoint regions — git's `ort` strategy resolves the merge automatically (verified locally with a dry-run merge against the stack tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)