### PR TITLE
feat(api): provider stack — perplexity + smoke flags + verify timeouts + /v1/health/deep + auth rl-reset

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -60,25 +60,33 @@ End-to-end check of the full chat flow against a running API and a real OpenAI a
 
 ```bash
 # 1. API up + Postgres up + migrations applied (see "Local Postgres" below).
-# 2. apps/api/.env contains OPENAI_API_KEY (loaded automatically).
+# 2. apps/api/.env carries the relevant key:
+#    OPENAI_API_KEY (default), ANTHROPIC_API_KEY, or PERPLEXITY_API_KEY.
 pnpm api:smoke:ai
 # or equivalently:
 pnpm --filter @webapp/api smoke:ai
 ```
 
-The script signs up a fresh user, creates a project / workspace / chat-window, upserts the OpenAI key, posts a message "hello", and asserts an assistant reply was persisted. It **never logs the key value**. Missing `OPENAI_API_KEY` fails fast with a clear message.
+Default provider is `openai`. Override via `--provider=`:
+
+```bash
+pnpm api:smoke:ai -- --provider=anthropic
+pnpm api:smoke:ai -- --provider=perplexity --model=sonar
+```
+
+The script signs up a fresh user, creates a project / workspace / chat-window, upserts the provider key, posts a message "hello", and asserts an assistant reply was persisted with the right provider. It **never logs the key value**. A missing `<PROVIDER>_API_KEY` fails fast with a clear message.
 
 For the streaming endpoint (`POST /v1/messages/stream`):
 
 ```bash
 pnpm api:smoke:ai:stream
 # or
-pnpm --filter @webapp/api smoke:ai:stream
+pnpm --filter @webapp/api smoke:ai:stream -- --provider=anthropic
 ```
 
 Same setup, but exercises the SSE path: opens the stream, parses every `data:` event, asserts ≥1 `delta` chunk + the `[DONE]` sentinel + a final `{done:true,assistantMessage:…}` event, and confirms the persisted content equals the concatenated deltas. Then re-fetches `/v1/messages` to verify the assistant row landed in the DB.
 
-Both scripts are **not** wired into CI: they spend real OpenAI tokens and assume a live API on `http://localhost:4000`. Override the target with `SMOKE_API_BASE_URL=…` or the model with `SMOKE_MODEL=…`.
+Both scripts are **not** wired into CI: they spend real provider tokens and assume a live API on `http://localhost:4000`. Override the target with `SMOKE_API_BASE_URL=…` or the model with `SMOKE_MODEL=…` / `--model=…`.
 
 ## Env vars
 

--- a/apps/api/scripts/smoke-ai-stream.mjs
+++ b/apps/api/scripts/smoke-ai-stream.mjs
@@ -6,7 +6,26 @@
 // and a [DONE] sentinel. Spends real OpenAI tokens. Not wired into CI.
 
 const BASE_URL = process.env.SMOKE_API_BASE_URL ?? 'http://localhost:4000';
-const MODEL    = process.env.SMOKE_MODEL ?? 'gpt-4o-mini';
+
+const PROVIDER_DEFAULTS = {
+  openai:     { envVar: 'OPENAI_API_KEY',     defaultModel: 'gpt-4o-mini' },
+  anthropic:  { envVar: 'ANTHROPIC_API_KEY',  defaultModel: 'claude-3-5-haiku-latest' },
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', defaultModel: 'sonar' },
+};
+
+function parseFlag(name, fallback) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+const PROVIDER = parseFlag('provider', 'openai');
+if (!Object.prototype.hasOwnProperty.call(PROVIDER_DEFAULTS, PROVIDER)) {
+  console.error(`✗ unknown --provider='${PROVIDER}' (expected: openai | anthropic | perplexity)`);
+  process.exit(1);
+}
+const { envVar, defaultModel } = PROVIDER_DEFAULTS[PROVIDER];
+const MODEL = parseFlag('model', process.env.SMOKE_MODEL ?? defaultModel);
 
 function fail(msg, extra) {
   console.error(`✗ ${msg}`);
@@ -16,10 +35,10 @@ function fail(msg, extra) {
 
 function pass(msg) { console.log(`✓ ${msg}`); }
 
-if (!process.env.OPENAI_API_KEY) {
-  fail('OPENAI_API_KEY required (set it in apps/api/.env or in your shell)');
+const PROVIDER_API_KEY = process.env[envVar];
+if (!PROVIDER_API_KEY) {
+  fail(`${envVar} required (set it in apps/api/.env or in your shell)`);
 }
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 // ── Cookie jar ────────────────────────────────────────────────────────────────
 
@@ -76,7 +95,7 @@ const ts    = Date.now();
 const EMAIL = `smoke-stream-${ts}@example.test`;
 const PASS  = `smoke-pass-${ts}-${Math.random().toString(36).slice(2)}`;
 
-console.log(`▶ smoke-ai-stream against ${BASE_URL} as ${EMAIL}`);
+console.log(`▶ smoke-ai-stream against ${BASE_URL} (provider=${PROVIDER}, model=${MODEL}) as ${EMAIL}`);
 
 {
   const { status, body } = await req('GET', '/v1/health');
@@ -90,14 +109,14 @@ if (!user?.id) fail('signup returned no user.id');
 const project = await expectOk('create project', req('POST', '/v1/projects', { name: `Smoke Stream ${ts}` }));
 const workspace = await expectOk('create workspace', req('POST', '/v1/workspaces', { projectId: project.id, name: 'Smoke WS' }));
 
-await expectOk('upsert openai connection', req('PUT', '/v1/provider-connections/openai', { apiKey: OPENAI_API_KEY }));
+await expectOk(`upsert ${PROVIDER} connection`, req('PUT', `/v1/provider-connections/${PROVIDER}`, { apiKey: PROVIDER_API_KEY }));
 
 const cw = await expectOk(
   'create chat-window',
   req('POST', '/v1/chat-windows', {
     workspaceId: workspace.id,
     title:       'Smoke Stream Chat',
-    provider:    'openai',
+    provider:    PROVIDER,
     model:       MODEL,
   }),
 );
@@ -168,7 +187,7 @@ if (typeof finalEvent.assistantMessage.content !== 'string' || finalEvent.assist
 if (finalEvent.assistantMessage.content !== assistantContent) {
   fail(`stream: streamed content (${assistantContent.length}b) != persisted content (${finalEvent.assistantMessage.content.length}b)`);
 }
-if (finalEvent.assistantMessage.provider !== 'openai') fail('stream: assistant provider wrong');
+if (finalEvent.assistantMessage.provider !== PROVIDER) fail(`stream: assistant provider wrong (got '${finalEvent.assistantMessage.provider}')`);
 
 const totalMs = Date.now() - startedAt;
 pass(`received ${deltaCount} deltas, ${assistantContent.length} chars`);

--- a/apps/api/scripts/smoke-ai.mjs
+++ b/apps/api/scripts/smoke-ai.mjs
@@ -1,12 +1,39 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 // Local AI smoke test for @webapp/api.
-// Walks the full chat flow: signup → project → workspace → openai key →
+// Walks the full chat flow: signup → project → workspace → provider key →
 // chat-window → POST message → expect assistant reply.
-// Spends real OpenAI tokens. Not wired into CI on purpose.
+// Spends real provider tokens. Not wired into CI on purpose.
+//
+// Usage:
+//   pnpm api:smoke:ai
+//   pnpm api:smoke:ai -- --provider=anthropic
+//   pnpm api:smoke:ai -- --provider=perplexity --model=sonar
+//
+// Reads OPENAI_API_KEY / ANTHROPIC_API_KEY / PERPLEXITY_API_KEY from env;
+// never prints the key.
 
 const BASE_URL = process.env.SMOKE_API_BASE_URL ?? 'http://localhost:4000';
-const MODEL    = process.env.SMOKE_MODEL ?? 'gpt-4o-mini';
+
+const PROVIDER_DEFAULTS = {
+  openai:     { envVar: 'OPENAI_API_KEY',     defaultModel: 'gpt-4o-mini' },
+  anthropic:  { envVar: 'ANTHROPIC_API_KEY',  defaultModel: 'claude-3-5-haiku-latest' },
+  perplexity: { envVar: 'PERPLEXITY_API_KEY', defaultModel: 'sonar' },
+};
+
+function parseFlag(name, fallback) {
+  const prefix = `--${name}=`;
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+const PROVIDER = parseFlag('provider', 'openai');
+if (!Object.prototype.hasOwnProperty.call(PROVIDER_DEFAULTS, PROVIDER)) {
+  console.error(`✗ unknown --provider='${PROVIDER}' (expected: openai | anthropic | perplexity)`);
+  process.exit(1);
+}
+const { envVar, defaultModel } = PROVIDER_DEFAULTS[PROVIDER];
+const MODEL = parseFlag('model', process.env.SMOKE_MODEL ?? defaultModel);
 
 function fail(msg, extra) {
   console.error(`✗ ${msg}`);
@@ -14,14 +41,12 @@ function fail(msg, extra) {
   process.exit(1);
 }
 
-function pass(msg) {
-  console.log(`✓ ${msg}`);
-}
+function pass(msg) { console.log(`✓ ${msg}`); }
 
-if (!process.env.OPENAI_API_KEY) {
-  fail('OPENAI_API_KEY required (set it in apps/api/.env or in your shell)');
+const PROVIDER_API_KEY = process.env[envVar];
+if (!PROVIDER_API_KEY) {
+  fail(`${envVar} required (set it in apps/api/.env or in your shell)`);
 }
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
 // ── Cookie jar ────────────────────────────────────────────────────────────────
 
@@ -79,7 +104,7 @@ const ts    = Date.now();
 const EMAIL = `smoke-${ts}@example.test`;
 const PASS  = `smoke-pass-${ts}-${Math.random().toString(36).slice(2)}`;
 
-console.log(`▶ smoke-ai against ${BASE_URL} as ${EMAIL}`);
+console.log(`▶ smoke-ai against ${BASE_URL} (provider=${PROVIDER}, model=${MODEL}) as ${EMAIL}`);
 
 // 1. Health
 {
@@ -105,10 +130,10 @@ const workspace = await expectOk(
 );
 if (!workspace?.id) fail('workspace missing id');
 
-// 5. OpenAI connection (apiKey from env, never printed)
+// 5. Provider connection (apiKey from env, never printed)
 await expectOk(
-  'upsert openai connection',
-  req('PUT', '/v1/provider-connections/openai', { apiKey: OPENAI_API_KEY }),
+  `upsert ${PROVIDER} connection`,
+  req('PUT', `/v1/provider-connections/${PROVIDER}`, { apiKey: PROVIDER_API_KEY }),
 );
 
 // 6. Chat window
@@ -117,7 +142,7 @@ const cw = await expectOk(
   req('POST', '/v1/chat-windows', {
     workspaceId: workspace.id,
     title:       'Smoke Chat',
-    provider:    'openai',
+    provider:    PROVIDER,
     model:       MODEL,
   }),
 );
@@ -139,7 +164,7 @@ if (am.role !== 'assistant')   fail(`assistant role wrong: ${am.role}`);
 if (typeof am.content !== 'string' || am.content.length === 0) {
   fail('assistant content empty');
 }
-if (am.provider !== 'openai')  fail(`assistant provider wrong: ${am.provider}`);
+if (am.provider !== PROVIDER)  fail(`assistant provider wrong: ${am.provider}`);
 
 pass(`assistant reply (${am.content.length} chars, ${am.promptTokens ?? '?'} prompt + ${am.completionTokens ?? '?'} completion tokens, ${am.latencyMs ?? '?'}ms)`);
 

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -47,6 +47,7 @@ export interface AuthDeps {
   findSessionByTokenHash: (tokenHash: string) => Promise<DbSession | null>;
   deleteSession:   (tokenHash: string) => Promise<void>;
   checkRateLimit:  (key: string) => RateLimitResult;
+  resetRateLimit:  (key: string) => void;
 }
 
 // 10 attempts per IP per 15 minutes for both signup and login.
@@ -62,6 +63,7 @@ export function makeAuthDeps(db: Db): AuthDeps {
     findSessionByTokenHash: (tokenHash)                    => sessionsRepo.findSessionByTokenHash(db, tokenHash),
     deleteSession:          (tokenHash)                    => sessionsRepo.deleteSession(db, tokenHash),
     checkRateLimit:         (key)                          => authLimiter.check(key),
+    resetRateLimit:         (key)                          => authLimiter.reset(key),
   };
 }
 
@@ -120,6 +122,10 @@ export async function signupController(ctx: RequestContext, deps: AuthDeps): Pro
   const tokenHash = hashSessionToken(token);
   await deps.createSession(tokenHash, user.id, sessionExpiresAt());
 
+  // Successful signup → clear the bucket so a legit user who fat-fingered
+  // earlier attempts is not still inside the brute-force window.
+  deps.resetRateLimit(getClientIp(ctx.req));
+
   return { httpStatus: 201, body: { ok: true, data: toSafeUser(user) }, headers: cookieHeader(token) };
 }
 
@@ -143,6 +149,10 @@ export async function loginController(ctx: RequestContext, deps: AuthDeps): Prom
   const token     = generateSessionToken();
   const tokenHash = hashSessionToken(token);
   await deps.createSession(tokenHash, user.id, sessionExpiresAt());
+
+  // Successful login → clear the bucket so a legit user who fat-fingered
+  // their password is not still inside the brute-force window.
+  deps.resetRateLimit(getClientIp(ctx.req));
 
   return { httpStatus: 200, body: { ok: true, data: toSafeUser(user) }, headers: cookieHeader(token) };
 }

--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -1,0 +1,57 @@
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import type { ApiResponse } from '@webapp/types';
+import { Router } from '../lib/router.js';
+import { createApiServer } from '../lib/server.js';
+import { healthDeepController, type DbStatus, type HealthDeepDeps } from './health-deep.controller.js';
+
+function makeDeps(status: DbStatus): HealthDeepDeps {
+  return { pingDb: async () => status };
+}
+
+async function startServer(deps: HealthDeepDeps): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const router = new Router();
+  router.register({ method: 'GET', path: '/v1/health/deep', handler: (ctx) => healthDeepController(ctx, deps) });
+  const server: Server = createApiServer(router);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+  };
+}
+
+describe('GET /v1/health/deep', () => {
+  it('returns 200 with db=ok when ping succeeds', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('ok'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus; service: string }>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.db).toBe('ok');
+    expect(body.data.service).toBe('webapp-api');
+    await close();
+  });
+
+  it('returns 200 with db=disabled when no DATABASE_URL', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('disabled'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus }>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.db).toBe('disabled');
+    await close();
+  });
+
+  it('returns 503 with db=down when ping fails', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('down'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('internal_error');
+    expect((body.error.details as { db: DbStatus }).db).toBe('down');
+    await close();
+  });
+});

--- a/apps/api/src/controllers/health-deep.controller.ts
+++ b/apps/api/src/controllers/health-deep.controller.ts
@@ -1,0 +1,61 @@
+import { sql } from 'drizzle-orm';
+import { env } from '../config/env.js';
+import { createDb } from '../lib/db.js';
+import { respond, respondError, type InternalResult, type RequestContext } from '../lib/http.js';
+
+export type DbStatus = 'ok' | 'down' | 'disabled';
+
+export interface HealthDeepDeps {
+  /** Returns 'ok' when the DB answers a trivial query, 'down' on any failure,
+   *  'disabled' when no DATABASE_URL is configured. */
+  pingDb: () => Promise<DbStatus>;
+}
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+async function defaultPingDb(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<DbStatus> {
+  if (!env.databaseUrl) return 'disabled';
+  let db;
+  try {
+    db = createDb();
+  } catch {
+    return 'down';
+  }
+  try {
+    await Promise.race([
+      db.execute(sql`select 1`),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('db_ping_timeout')), timeoutMs)),
+    ]);
+    return 'ok';
+  } catch {
+    return 'down';
+  }
+}
+
+export function makeHealthDeepDeps(): HealthDeepDeps {
+  return { pingDb: () => defaultPingDb() };
+}
+
+export interface HealthDeepResponse {
+  service: 'webapp-api';
+  version: string;
+  db: DbStatus;
+  timestamp: string;
+}
+
+export async function healthDeepController(
+  _ctx: RequestContext,
+  deps: HealthDeepDeps,
+): Promise<InternalResult> {
+  const db = await deps.pingDb();
+  const body: HealthDeepResponse = {
+    service: 'webapp-api',
+    version: env.serviceVersion,
+    db,
+    timestamp: new Date().toISOString(),
+  };
+  if (db === 'down') {
+    return respondError('internal_error', 'Database is unreachable', 503, body);
+  }
+  return respond(body);
+}

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -223,11 +223,12 @@ export async function createMessageDbController(
       );
     }
 
-    // Non-openai provider: persist user message only, no generation.
-    // Provider support for this window is not yet enabled.
+    // Provider unsupported (no adapter): persist user message only, no generation.
+    // Reachable only if a chat-window was created with a provider that has since
+    // been removed from SUPPORTED_PROVIDERS — defensive fall-through.
   }
 
-  // Default path: persist the message as-is (non-user role, or non-openai provider).
+  // Default path: persist the message as-is (non-user role, or unsupported provider).
   const row = await deps.createMessage(chatWindowId, user.id, role, content);
   if (row === null) return respondNotFound(`ChatWindow ${chatWindowId} not found`);
   const msg = toMessage(row);

--- a/apps/api/src/providers/anthropic.provider.test.ts
+++ b/apps/api/src/providers/anthropic.provider.test.ts
@@ -37,6 +37,13 @@ describe('verifyAnthropicKey', () => {
     vi.mocked(fetch).mockRejectedValue(new Error('boom'));
     expect(await verifyAnthropicKey(API_KEY)).toBe('provider_error');
   });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    await verifyAnthropicKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createAnthropicClient.createChatCompletion', () => {

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -19,6 +19,8 @@ const DEFAULT_MAX_TOKENS = 1024;
 
 export type AnthropicVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
+const VERIFY_TIMEOUT_MS = 10_000;
+
 export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerifyResult> {
   let res: Response;
   try {
@@ -28,6 +30,7 @@ export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerif
         'x-api-key':         apiKey,
         'anthropic-version': ANTHROPIC_VERSION,
       },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
     return 'provider_error';

--- a/apps/api/src/providers/openai.provider.test.ts
+++ b/apps/api/src/providers/openai.provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createOpenAIClient } from './openai.provider.js';
+import { createOpenAIClient, verifyOpenAIKey } from './openai.provider.js';
 import { ProviderError } from './provider.interface.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -31,6 +31,33 @@ function openAIBody(content: string, model = MODEL) {
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('verifyOpenAIKey', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns ok on 200', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('ok');
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 401 }));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns provider_error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('boom'));
+    expect(await verifyOpenAIKey(API_KEY)).toBe('provider_error');
+  });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+    await verifyOpenAIKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
 
 describe('createOpenAIClient', () => {
   beforeEach(() => {

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -11,6 +11,7 @@ import { ProviderError } from './provider.interface.js';
 export type OpenAIVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
 const OPENAI_MODELS_URL = 'https://api.openai.com/v1/models';
+const VERIFY_TIMEOUT_MS = 10_000;
 
 export async function verifyOpenAIKey(apiKey: string): Promise<OpenAIVerifyResult> {
   let res: Response;
@@ -18,8 +19,10 @@ export async function verifyOpenAIKey(apiKey: string): Promise<OpenAIVerifyResul
     res = await fetch(OPENAI_MODELS_URL, {
       method: 'GET',
       headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
+    // network failure or abort — treat as transient, surface to caller as 502.
     return 'provider_error';
   }
   if (res.status === 200) return 'ok';

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPerplexityClient, verifyPerplexityKey } from './perplexity.provider.js';
+import { ProviderError } from './provider.interface.js';
+
+const MESSAGES = [{ role: 'user' as const, content: 'Hello' }];
+const MODEL    = 'sonar';
+const API_KEY  = 'pplx-test';
+
+function ok(body: object): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+function bad(status: number, msg: string): Response {
+  return new Response(JSON.stringify({ error: { message: msg } }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('verifyPerplexityKey', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns ok on 2xx', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ choices: [{ message: { role: 'assistant', content: '' } }] }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('ok');
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.headers).toMatchObject({ Authorization: `Bearer ${API_KEY}` });
+  });
+
+  it('returns unauthorized on 401', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 401 }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns unauthorized on 403', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 403 }));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('unauthorized');
+  });
+
+  it('returns provider_error on network failure', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('boom'));
+    expect(await verifyPerplexityKey(API_KEY)).toBe('provider_error');
+  });
+});
+
+describe('createPerplexityClient.createChatCompletion', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns normalized result with content + model + usage', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      choices: [{ message: { role: 'assistant', content: 'Hello!' }, finish_reason: 'stop' }],
+      usage:   { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+    }));
+    const r = await createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+    expect(r.content).toBe('Hello!');
+    expect(r.model).toBe(MODEL);
+    expect(r.usage).toEqual({ promptTokens: 7, completionTokens: 2, totalTokens: 9 });
+  });
+
+  it('throws ProviderError on non-2xx with the upstream message', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'invalid bearer token'));
+    await expect(createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toMatchObject({ code: 'api_error' });
+  });
+
+  it('throws invalid_response when content is empty', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      choices: [{ message: { role: 'assistant', content: '' } }],
+      usage:   { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 },
+    }));
+    await expect(createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
+      .rejects.toBeInstanceOf(ProviderError);
+  });
+});
+
+describe('createPerplexityClient.createChatCompletionStream', () => {
+  beforeEach(() => { vi.stubGlobal('fetch', vi.fn()); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  function sse(payloads: string[]): Response {
+    const body = payloads.map((p) => `data: ${p}\n\n`).join('') + 'data: [DONE]\n\n';
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode(body)); c.close(); },
+    });
+    return new Response(stream, { status: 200, headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  it('parses delta + final chunk with usage', async () => {
+    vi.mocked(fetch).mockResolvedValue(sse([
+      JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'Hi ' } }] }),
+      JSON.stringify({ model: MODEL, choices: [{ delta: { content: 'there' } }] }),
+      JSON.stringify({ model: MODEL, choices: [{ delta: {} }], usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 } }),
+    ]));
+
+    const chunks = [];
+    for await (const c of createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+      chunks.push(c);
+    }
+    const text = chunks.filter((c) => c.type === 'delta').map((c) => c.type === 'delta' ? c.content : '').join('');
+    const done = chunks.find((c) => c.type === 'done');
+    expect(text).toBe('Hi there');
+    if (done?.type !== 'done') throw new Error('expected done');
+    expect(done.usage.promptTokens).toBe(4);
+    expect(done.usage.completionTokens).toBe(2);
+    expect(done.usage.totalTokens).toBe(6);
+    expect(done.model).toBe(MODEL);
+  });
+
+  it('throws ProviderError on non-2xx upstream', async () => {
+    vi.mocked(fetch).mockResolvedValue(bad(401, 'bad key'));
+    const it = createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
+    await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -41,6 +41,13 @@ describe('verifyPerplexityKey', () => {
     vi.mocked(fetch).mockRejectedValue(new Error('boom'));
     expect(await verifyPerplexityKey(API_KEY)).toBe('provider_error');
   });
+
+  it('passes an AbortSignal so the call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({ choices: [{ message: { role: 'assistant', content: '' } }] }));
+    await verifyPerplexityKey(API_KEY);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createPerplexityClient.createChatCompletion', () => {

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -1,0 +1,210 @@
+import type {
+  ChatCompletionResult,
+  ChatCompletionStreamChunk,
+  ChatMessage,
+  ProviderClient,
+} from './provider.interface.js';
+import { ProviderError } from './provider.interface.js';
+
+// Perplexity is OpenAI-compatible at the chat-completions schema level.
+// We post the same shape and parse the same response, with a different base URL
+// and model namespace ('sonar', 'sonar-pro', ...).
+
+const PERPLEXITY_CHAT_URL = 'https://api.perplexity.ai/chat/completions';
+
+// Used by verifyPerplexityKey: smallest possible completion that the API will
+// accept just to confirm the bearer token is valid. Non-streaming, max_tokens=1.
+const VERIFY_MODEL = 'sonar';
+
+// ── Key verification ──────────────────────────────────────────────────────────
+
+export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
+
+export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
+  let res: Response;
+  try {
+    res = await fetch(PERPLEXITY_CHAT_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type':  'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: VERIFY_MODEL,
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+        stream: false,
+      }),
+    });
+  } catch {
+    return 'provider_error';
+  }
+  if (res.ok)              return 'ok';
+  if (res.status === 401)  return 'unauthorized';
+  if (res.status === 403)  return 'unauthorized';
+  return 'provider_error';
+}
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+interface PerplexityUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface PerplexityMessage {
+  role: string;
+  content: string | null;
+}
+
+interface PerplexityChoice {
+  message?: PerplexityMessage;
+  delta?:   { content?: string };
+  finish_reason?: string;
+}
+
+interface PerplexityResponse {
+  model: string;
+  choices: PerplexityChoice[];
+  usage:   PerplexityUsage;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export function createPerplexityClient(apiKey: string): ProviderClient {
+  return {
+    async createChatCompletion(
+      messages: ChatMessage[],
+      model: string,
+    ): Promise<ChatCompletionResult> {
+      let res: Response;
+      try {
+        res = await fetch(PERPLEXITY_CHAT_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({ model, messages, stream: false }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Perplexity request failed: ${(err as Error).message}`,
+          'api_error',
+          'perplexity',
+        );
+      }
+
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Perplexity API error: ${detail}`, 'api_error', 'perplexity');
+      }
+
+      let data: PerplexityResponse;
+      try {
+        data = (await res.json()) as PerplexityResponse;
+      } catch {
+        throw new ProviderError('Failed to parse Perplexity response', 'invalid_response', 'perplexity');
+      }
+
+      const content = data.choices?.[0]?.message?.content;
+      if (typeof content !== 'string' || content.length === 0) {
+        throw new ProviderError('Perplexity response missing content', 'invalid_response', 'perplexity');
+      }
+
+      return {
+        content,
+        model: data.model ?? model,
+        usage: {
+          promptTokens:     data.usage?.prompt_tokens     ?? 0,
+          completionTokens: data.usage?.completion_tokens ?? 0,
+          totalTokens:      data.usage?.total_tokens      ?? 0,
+        },
+      };
+    },
+
+    async *createChatCompletionStream(
+      messages: ChatMessage[],
+      model: string,
+    ): AsyncIterable<ChatCompletionStreamChunk> {
+      let res: Response;
+      try {
+        res = await fetch(PERPLEXITY_CHAT_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type':  'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+            'Accept':        'text/event-stream',
+          },
+          body: JSON.stringify({ model, messages, stream: true }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          `Perplexity request failed: ${(err as Error).message}`,
+          'api_error',
+          'perplexity',
+        );
+      }
+
+      if (!res.ok || !res.body) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: { message?: string } };
+          if (typeof body?.error?.message === 'string') detail = body.error.message;
+        } catch { /* ignore */ }
+        throw new ProviderError(`Perplexity API error: ${detail}`, 'api_error', 'perplexity');
+      }
+
+      const decoder = new TextDecoder();
+      let buf = '';
+      let finalModel = model;
+      let usage: ChatCompletionResult['usage'] = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+
+      const reader = res.body.getReader();
+      try {
+        for (;;) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+
+          let idx;
+          while ((idx = buf.indexOf('\n')) >= 0) {
+            const line = buf.slice(0, idx).trim();
+            buf = buf.slice(idx + 1);
+            if (line === '' || !line.startsWith('data:')) continue;
+            const payload = line.slice(5).trim();
+            if (payload === '[DONE]') continue;
+
+            let event: PerplexityResponse;
+            try {
+              event = JSON.parse(payload) as PerplexityResponse;
+            } catch {
+              throw new ProviderError('Failed to parse Perplexity stream chunk', 'invalid_response', 'perplexity');
+            }
+            if (event.model) finalModel = event.model;
+            if (event.usage) {
+              usage = {
+                promptTokens:     event.usage.prompt_tokens     ?? usage.promptTokens,
+                completionTokens: event.usage.completion_tokens ?? usage.completionTokens,
+                totalTokens:      event.usage.total_tokens      ?? usage.totalTokens,
+              };
+            }
+            const delta = event.choices?.[0]?.delta?.content;
+            if (typeof delta === 'string' && delta.length > 0) {
+              yield { type: 'delta', content: delta };
+            }
+          }
+        }
+      } finally {
+        try { reader.releaseLock(); } catch { /* ignore */ }
+      }
+
+      yield { type: 'done', model: finalModel, usage };
+    },
+  };
+}

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -20,6 +20,8 @@ const VERIFY_MODEL = 'sonar';
 
 export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
+const VERIFY_TIMEOUT_MS = 10_000;
+
 export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
   let res: Response;
   try {
@@ -35,6 +37,7 @@ export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVer
         max_tokens: 1,
         stream: false,
       }),
+      signal: AbortSignal.timeout(VERIFY_TIMEOUT_MS),
     });
   } catch {
     return 'provider_error';

--- a/apps/api/src/providers/registry.test.ts
+++ b/apps/api/src/providers/registry.test.ts
@@ -2,24 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { SUPPORTED_PROVIDERS, getProviderClient, isSupportedProvider } from './registry.js';
 
 describe('providers/registry', () => {
-  it('lists openai and anthropic as supported', () => {
+  it('lists openai, anthropic and perplexity as supported', () => {
     expect(SUPPORTED_PROVIDERS.has('openai')).toBe(true);
     expect(SUPPORTED_PROVIDERS.has('anthropic')).toBe(true);
-    expect(SUPPORTED_PROVIDERS.has('perplexity')).toBe(false);
+    expect(SUPPORTED_PROVIDERS.has('perplexity')).toBe(true);
   });
 
   it('isSupportedProvider mirrors the set', () => {
     expect(isSupportedProvider('openai')).toBe(true);
     expect(isSupportedProvider('anthropic')).toBe(true);
-    expect(isSupportedProvider('perplexity')).toBe(false);
+    expect(isSupportedProvider('perplexity')).toBe(true);
   });
 
   it('returns a client for each supported provider', () => {
-    expect(getProviderClient('openai',    'k')).toBeDefined();
-    expect(getProviderClient('anthropic', 'k')).toBeDefined();
-  });
-
-  it('throws for an unsupported provider', () => {
-    expect(() => getProviderClient('perplexity', 'k')).toThrow();
+    expect(getProviderClient('openai',     'k')).toBeDefined();
+    expect(getProviderClient('anthropic',  'k')).toBeDefined();
+    expect(getProviderClient('perplexity', 'k')).toBeDefined();
   });
 });

--- a/apps/api/src/providers/registry.ts
+++ b/apps/api/src/providers/registry.ts
@@ -1,12 +1,13 @@
 import type { AIProvider } from '@webapp/types';
 import type { ProviderClient } from './provider.interface.js';
-import { createOpenAIClient,    verifyOpenAIKey,    type OpenAIVerifyResult }    from './openai.provider.js';
-import { createAnthropicClient, verifyAnthropicKey, type AnthropicVerifyResult } from './anthropic.provider.js';
+import { createOpenAIClient,     verifyOpenAIKey,     type OpenAIVerifyResult }     from './openai.provider.js';
+import { createAnthropicClient,  verifyAnthropicKey,  type AnthropicVerifyResult }  from './anthropic.provider.js';
+import { createPerplexityClient, verifyPerplexityKey, type PerplexityVerifyResult } from './perplexity.provider.js';
 
-export type VerifyResult = OpenAIVerifyResult | AnthropicVerifyResult; // identical union shape today
+export type VerifyResult = OpenAIVerifyResult | AnthropicVerifyResult | PerplexityVerifyResult;
 
 /** Providers that have a working adapter. Single source of truth for upserts and chat-window creation. */
-export const SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set(['openai', 'anthropic']);
+export const SUPPORTED_PROVIDERS: ReadonlySet<AIProvider> = new Set(['openai', 'anthropic', 'perplexity']);
 
 export function isSupportedProvider(p: AIProvider): boolean {
   return SUPPORTED_PROVIDERS.has(p);
@@ -14,8 +15,9 @@ export function isSupportedProvider(p: AIProvider): boolean {
 
 export function getProviderClient(provider: AIProvider, apiKey: string): ProviderClient {
   switch (provider) {
-    case 'openai':    return createOpenAIClient(apiKey);
-    case 'anthropic': return createAnthropicClient(apiKey);
+    case 'openai':     return createOpenAIClient(apiKey);
+    case 'anthropic':  return createAnthropicClient(apiKey);
+    case 'perplexity': return createPerplexityClient(apiKey);
     default:
       throw new Error(`No provider client for '${provider}'`);
   }
@@ -23,8 +25,9 @@ export function getProviderClient(provider: AIProvider, apiKey: string): Provide
 
 export function verifyProviderKey(provider: AIProvider, apiKey: string): Promise<VerifyResult> {
   switch (provider) {
-    case 'openai':    return verifyOpenAIKey(apiKey);
-    case 'anthropic': return verifyAnthropicKey(apiKey);
+    case 'openai':     return verifyOpenAIKey(apiKey);
+    case 'anthropic':  return verifyAnthropicKey(apiKey);
+    case 'perplexity': return verifyPerplexityKey(apiKey);
     default:
       return Promise.resolve('provider_error');
   }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -48,6 +48,7 @@ function makeDeps(overrides: Partial<AuthDeps> = {}): AuthDeps {
     findSessionByTokenHash: async () => null,
     deleteSession:          async () => {},
     checkRateLimit:         () => ({ ok: true, retryAfterSecs: 0 }),
+    resetRateLimit:         () => {},
     ...overrides,
   };
 }
@@ -368,6 +369,44 @@ describe('rate limiting — login', () => {
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('rate_limited');
     expect(res.headers.get('retry-after')).toBe('120');
+    await close();
+  });
+
+  it('resets the bucket after a successful login (legit user is not penalised)', async () => {
+    const realHash = await hashPassword('validpassword');
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => mockUser({ passwordHash: realHash }),
+      resetRateLimit:  (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: 'test@example.com', password: 'validpassword' });
+    expect(res.status).toBe(200);
+    expect(resetCalls).toHaveLength(1);
+    await close();
+  });
+
+  it('does NOT reset the bucket after a failed login (brute-force window stays)', async () => {
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => null,
+      resetRateLimit:  (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: 'no@one.com', password: 'wrong' });
+    expect(res.status).toBe(401);
+    expect(resetCalls).toHaveLength(0);
+    await close();
+  });
+});
+
+describe('rate limiting — signup', () => {
+  it('resets the bucket after a successful signup', async () => {
+    const resetCalls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      resetRateLimit: (key) => { resetCalls.push(key); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/signup', { email: 'fresh@example.com', password: 'password123' });
+    expect(res.status).toBe(201);
+    expect(resetCalls).toHaveLength(1);
     await close();
   });
 });

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -203,28 +203,6 @@ describe('POST /v1/chat-windows — authenticated', () => {
     await close();
   });
 
-  for (const provider of ['perplexity'] as const) {
-    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error (no silent dead-end)`, async () => {
-      let createCalled = false;
-      const { baseUrl, close } = await startServer(makeDeps({
-        resolveUser:      async () => USER_1,
-        createChatWindow: async (workspaceId, _userId, title, p, model) => {
-          createCalled = true;
-          return mockChatWindow(workspaceId, { title, provider: p, model });
-        },
-      }));
-      const res = await post(baseUrl, '/v1/chat-windows', {
-        workspaceId: 'ws-1', title: 'X', provider, model: 'm',
-      });
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as ApiResponse<never>;
-      if (body.ok) throw new Error('expected error');
-      expect(body.error.code).toBe('validation_error');
-      expect(body.error.message).toContain('not yet supported');
-      expect(createCalled).toBe(false);
-      await close();
-    });
-  }
 });
 
 // ── Get chat window by id ─────────────────────────────────────────────────────

--- a/apps/api/src/routes/chat-windows.test.ts
+++ b/apps/api/src/routes/chat-windows.test.ts
@@ -117,19 +117,4 @@ describe('POST /v1/chat-windows', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
-  for (const provider of ['perplexity'] as const) {
-    it(`rejects valid-but-unsupported provider '${provider}' with 400 validation_error`, async () => {
-      const ws = await createWorkspace(harness.baseUrl);
-      const res = await fetch(`${harness.baseUrl}/v1/chat-windows`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ workspaceId: ws.id, title: 'CW', provider, model: 'm' }),
-      });
-      expect(res.status).toBe(400);
-      const body = (await res.json()) as ApiResponse<unknown>;
-      if (body.ok) throw new Error('expected error envelope');
-      expect(body.error.code).toBe('validation_error');
-      expect(body.error.message).toContain('not yet supported');
-    });
-  }
 });

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { healthController } from '../controllers/health.controller.js';
 import { versionController } from '../controllers/version.controller.js';
+import { healthDeepController, makeHealthDeepDeps } from '../controllers/health-deep.controller.js';
 import {
   createChatWindowController,
   deleteChatWindowController,
@@ -148,10 +149,13 @@ const stateHandler = (db && authDeps)
   ? (ctx: Parameters<typeof stateDbController>[0]) => stateDbController(ctx, makeStateDeps(db, authDeps))
   : stateController;
 
+const healthDeepDeps = makeHealthDeepDeps();
+
 export const businessRoutes: RouteDefinition[] = [
-  { method: 'GET', path: API_HEALTH_PATH, handler: healthController },
-  { method: 'GET', path: '/v1/health',    handler: healthController },
-  { method: 'GET', path: '/v1/version',   handler: versionController },
+  { method: 'GET', path: API_HEALTH_PATH,     handler: healthController },
+  { method: 'GET', path: '/v1/health',        handler: healthController },
+  { method: 'GET', path: '/v1/health/deep',   handler: (ctx) => healthDeepController(ctx, healthDeepDeps) },
+  { method: 'GET', path: '/v1/version',       handler: versionController },
 
   ...projectRoutes,
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -32,7 +32,7 @@ function mockMessage(chatWindowId: string, overrides: Partial<{
   };
 }
 
-function mockChatWindow(provider: AIProvider = 'perplexity', model = 'sonar') {
+function mockChatWindow(provider: AIProvider = 'openai', model = 'gpt-4o-mini') {
   return {
     id:          'cw-1',
     workspaceId: 'ws-1',
@@ -59,8 +59,9 @@ function makeDeps(overrides: Partial<MessagesDeps> = {}): MessagesDeps {
     persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) =>
       mockPair(chatWindowId, userContent, assistantContent),
     findMessage:        async () => null,
-    // Default: unsupported-provider window so existing tests bypass generation path.
-    findChatWindow:     async () => mockChatWindow('perplexity'),
+    // Default: openai window. Tests that exercise the user-role generation path
+    // override this and getApiKey/generate explicitly.
+    findChatWindow:     async () => mockChatWindow('openai'),
     getApiKey:          async () => null,
     generate:           async () => { throw new Error('should not be called in this test'); },
     generateStream:     async function* () { throw new Error('should not be called in this test'); },
@@ -186,25 +187,6 @@ describe('POST /v1/messages — standard path', () => {
     expect(body.data.content).toBe('Replying manually');
     expect(body.data.role).toBe('assistant');
     expect(res.headers.get('location')).toMatch(/\/v1\/messages\//);
-    await close();
-  });
-
-  it('creates user message in unsupported-provider window (perplexity), returns single message', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('perplexity'),
-      createMessage:  async (chatWindowId, _userId, role, content) =>
-        mockMessage(chatWindowId, { id: 'new-msg', role, content }),
-    }));
-    const res = await post(baseUrl, '/v1/messages', {
-      chatWindowId: 'cw-1', role: 'user', content: 'Hello',
-    });
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as ApiResponse<Message>;
-    if (!body.ok) throw new Error('expected ok');
-    // Single message returned — no assistantMessage field
-    expect(body.data.content).toBe('Hello');
-    expect('assistantMessage' in body.data).toBe(false);
     await close();
   });
 
@@ -663,19 +645,6 @@ describe('POST /v1/messages/stream — authenticated', () => {
     const { baseUrl, close } = await startServer(makeDeps());
     const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
     expect(res.status).toBe(401);
-    await close();
-  });
-
-  it('returns 412 provider_not_configured when chat-window provider is unsupported (perplexity)', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({
-      resolveUser:    async () => USER_1,
-      findChatWindow: async () => mockChatWindow('perplexity'),
-    }));
-    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
-    expect(res.status).toBe(412);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('provider_not_configured');
     await close();
   });
 

--- a/apps/api/src/routes/provider-connections.test.ts
+++ b/apps/api/src/routes/provider-connections.test.ts
@@ -238,16 +238,6 @@ describe('PUT /v1/provider-connections/:provider — authenticated', () => {
     await close();
   });
 
-  it('returns 400 for unsupported but valid provider (perplexity)', async () => {
-    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
-    const res = await put(baseUrl, '/v1/provider-connections/perplexity', { apiKey: 'pplx-test' });
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as ApiResponse<never>;
-    if (body.ok) throw new Error('expected error');
-    expect(body.error.code).toBe('validation_error');
-    await close();
-  });
-
   it('returns 400 for unknown provider param', async () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await put(baseUrl, '/v1/provider-connections/gpt99', { apiKey: 'sk-test' });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -131,6 +131,7 @@ export type ApiErrorResponse       = Extract<ApiResponse<never>, { ok: false }>;
 
 export const API_HEALTH_PATH       = '/health' as const;
 export const API_VERSION_PATH      = '/v1/version' as const;
+export const API_HEALTH_DEEP_PATH  = '/v1/health/deep' as const;
 export const API_PROJECTS_PATH     = '/v1/projects' as const;
 export const API_WORKSPACES_PATH   = '/v1/workspaces' as const;
 export const API_CHAT_WINDOWS_PATH = '/v1/chat-windows' as const;


### PR DESCRIPTION
Consolidated re-PR of the merged stack #111–#115, which merged into predecessor branches instead of main. Contains: Perplexity adapter, multi-provider smoke flags, provider verify timeouts, deep health endpoint, and auth rate-limit reset on success. Previously reviewed and green on their original PRs.