### PR TITLE
feat(api): CORS echoes matching origin from comma-separated allowlist

### DIFF
--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -140,6 +140,32 @@ describe('CORS with explicit origin — credentialed auth', () => {
   });
 });
 
+describe('CORS with comma-separated allowlist (multi-origin)', () => {
+  const APP_ORIGIN     = 'https://app.example.com';
+  const STAGING_ORIGIN = 'https://staging.example.com';
+  const ALLOW          = `${APP_ORIGIN},${STAGING_ORIGIN}`;
+  let s: { baseUrl: string; close: () => Promise<void> };
+
+  beforeAll(async () => { s = await startServerWithOrigin(ALLOW); });
+  afterAll(async () => { await s.close(); });
+
+  it('echoes APP_ORIGIN when the request Origin matches it', async () => {
+    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`, { headers: { Origin: APP_ORIGIN } });
+    expect(res.headers.get('access-control-allow-origin')).toBe(APP_ORIGIN);
+    expect(res.headers.get('access-control-allow-credentials')).toBe('true');
+  });
+
+  it('echoes STAGING_ORIGIN when the request Origin matches it', async () => {
+    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`, { headers: { Origin: STAGING_ORIGIN } });
+    expect(res.headers.get('access-control-allow-origin')).toBe(STAGING_ORIGIN);
+  });
+
+  it('falls back to the first allowed origin when the request Origin is unknown', async () => {
+    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`, { headers: { Origin: 'https://attacker.example.com' } });
+    expect(res.headers.get('access-control-allow-origin')).toBe(APP_ORIGIN);
+  });
+});
+
 describe('CORS with wildcard — non-credentialed default', () => {
   let harness: Harness;
 

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -12,16 +12,32 @@ import type { Router } from '../lib/router.js';
 import { captureException } from '../lib/sentry.js';
 import { checkCsrf } from '../lib/csrf.js';
 
-function buildCorsHeaders(origin: string): Record<string, string> {
-  if (origin === '*') {
+function parseAllowedOrigins(corsOrigin: string): string[] {
+  return corsOrigin
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Record<string, string> {
+  if (corsOrigin === '*') {
     return {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
     };
   }
+  const allowed = parseAllowedOrigins(corsOrigin);
+  // ACAO must echo the actual request Origin when credentials are involved.
+  // For a multi-origin allowlist we pick the matching entry; for a single-
+  // origin config we keep the historical behaviour (always echo the configured
+  // value, even when no Origin header is on the response request).
+  const echoed =
+    requestOrigin && allowed.includes(requestOrigin)
+      ? requestOrigin
+      : (allowed[0] ?? corsOrigin);
   return {
-    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Origin': echoed,
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Allow-Credentials': 'true',
@@ -42,7 +58,8 @@ export async function handleRequest(
   const url = new URL(req.url ?? '/', `http://${host}`);
   const path = url.pathname;
 
-  for (const [k, v] of Object.entries(buildCorsHeaders(corsOrigin))) {
+  const reqOrigin = typeof req.headers.origin === 'string' ? req.headers.origin : null;
+  for (const [k, v] of Object.entries(buildCorsHeaders(corsOrigin, reqOrigin))) {
     res.setHeader(k, v);
   }
 


### PR DESCRIPTION
Companion to `feat/api-csrf-multi-origin`. Browsers reject `Access-Control-Allow-Origin` when its value isn't a single origin matching the request, so a multi-origin `CORS_ORIGIN` was unusable for credentialed requests even after the CSRF check accepted it.

## Change
`buildCorsHeaders` now splits `CORS_ORIGIN` on commas and echoes the first entry that matches the request `Origin` header. Single-origin deployments are unchanged. When the request carries no `Origin` or an unknown one, the first allowlist entry is used (preserves the "never echo arbitrary attacker origin" guarantee).

## Note
Land this **before** the CSRF multi-origin PR (or together) so multi-origin `CORS_ORIGIN` works end-to-end.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 363/363 ✓ (+3 cors tests)
- `pnpm typecheck` ✓ · `pnpm build` ✓