### PR TITLE
feat(api): csrf supports comma-separated CORS_ORIGIN allowlist

### DIFF
--- a/apps/api/src/lib/csrf.test.ts
+++ b/apps/api/src/lib/csrf.test.ts
@@ -57,4 +57,31 @@ describe('checkCsrf', () => {
     );
     expect(r.ok).toBe(false);
   });
+
+  it('accepts any origin from a comma-separated allowlist', () => {
+    const allow = 'https://app.example.com,https://staging.example.com';
+    expect(checkCsrf(reqWith({ origin: 'https://app.example.com'     }), 'POST', allow).ok).toBe(true);
+    expect(checkCsrf(reqWith({ origin: 'https://staging.example.com' }), 'POST', allow).ok).toBe(true);
+  });
+
+  it('rejects an origin not in the comma-separated allowlist', () => {
+    const allow = 'https://app.example.com, https://staging.example.com';
+    const r = checkCsrf(reqWith({ origin: 'https://attacker.example.com' }), 'POST', allow);
+    expect(r.ok).toBe(false);
+  });
+
+  it('Referer fallback works against any origin in the allowlist', () => {
+    const allow = 'https://app.example.com,https://staging.example.com';
+    const r = checkCsrf(
+      reqWith({ referer: 'https://staging.example.com/some/page' }),
+      'POST',
+      allow,
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it('tolerates surrounding whitespace in the allowlist entries', () => {
+    const allow = '  https://app.example.com  ,  https://staging.example.com ';
+    expect(checkCsrf(reqWith({ origin: 'https://app.example.com' }), 'POST', allow).ok).toBe(true);
+  });
 });

--- a/apps/api/src/lib/csrf.ts
+++ b/apps/api/src/lib/csrf.ts
@@ -28,16 +28,26 @@ export function checkCsrf(
   if (SAFE_METHODS.has(method)) return { ok: true };
   if (allowedOrigin === '*')    return { ok: true };
 
+  // CORS_ORIGIN may carry a comma-separated allowlist when the same API serves
+  // multiple frontend origins (e.g. "https://app.example.com,https://staging.example.com").
+  const allowed = allowedOrigin
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
   const origin = headerStr(req.headers.origin);
   if (origin) {
-    return origin === allowedOrigin
+    return allowed.includes(origin)
       ? { ok: true }
       : { ok: false, reason: `Origin '${origin}' is not allowed` };
   }
 
   const referer = headerStr(req.headers.referer);
-  if (referer && referer.startsWith(`${allowedOrigin}/`)) return { ok: true };
-  if (referer === allowedOrigin)                          return { ok: true };
+  if (referer) {
+    for (const o of allowed) {
+      if (referer === o || referer.startsWith(`${o}/`)) return { ok: true };
+    }
+  }
 
   return {
     ok: false,


### PR DESCRIPTION
Production deployments often serve a single API behind multiple frontend origins (preview / staging / production). `CORS_ORIGIN` already accepts a comma-separated list at the cors-header layer, but the CSRF check in `lib/csrf.ts` only compared against the raw string — silently rejecting legit origins from the second entry onward.

## Change
`checkCsrf` now splits `CORS_ORIGIN` on commas, trims each entry, and matches `Origin` / `Referer` against any of them. Single-origin deployments behave identically (one-element list).

## Companion
Pair with #122 (CORS echoes matching origin) — without #122 the browser still rejects ACAO on credentialed multi-origin requests.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 364/364 ✓ (+4 csrf tests)
- `pnpm typecheck` ✓ · `pnpm build` ✓