### PR TITLE
fix(api): CORS Allow-Methods includes PUT/PATCH/DELETE

### DIFF
--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -55,12 +55,12 @@ describe('CORS headers', () => {
     expect(acao.length).toBeGreaterThan(0);
   });
 
-  it('Access-Control-Allow-Methods includes GET, POST, OPTIONS', async () => {
+  it('Access-Control-Allow-Methods includes GET, POST, PUT, PATCH, DELETE, OPTIONS', async () => {
     const res = await fetch(`${harness.baseUrl}${API_HEALTH_PATH}`);
     const acam = res.headers.get('access-control-allow-methods') ?? '';
-    expect(acam).toContain('GET');
-    expect(acam).toContain('POST');
-    expect(acam).toContain('OPTIONS');
+    for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']) {
+      expect(acam).toContain(m);
+    }
   });
 
   it('Access-Control-Allow-Headers includes Content-Type', async () => {

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -23,7 +23,7 @@ function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Rec
   if (corsOrigin === '*') {
     return {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
     };
   }
@@ -38,7 +38,7 @@ function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Rec
       : (allowed[0] ?? corsOrigin);
   return {
     'Access-Control-Allow-Origin': echoed,
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Allow-Credentials': 'true',
     'Vary': 'Origin',


### PR DESCRIPTION
The router serves `PATCH` and `DELETE` on projects, workspaces, chat-windows (per #85) and `PUT` on `/v1/provider-connections` — but the CORS preflight middleware only advertised `GET, POST, OPTIONS` in `Access-Control-Allow-Methods`. Browsers issuing a cross-origin PATCH/DELETE/PUT against an explicit `CORS_ORIGIN` therefore failed the preflight even though the underlying route would have accepted the request.

## Change
Both branches (wildcard and explicit origin) now advertise:
`GET, POST, PUT, PATCH, DELETE, OPTIONS`.

## Note
Trivial textual conflict zone with #122 (`feat/api-cors-multi-origin`) — both edit `buildCorsHeaders`. 3-way auto-resolvable; either land #122 first then rebase this on top, or merge in either order.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 360/360 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓