### PR TITLE
fix(api): capture provider errors via Sentry in messages-db

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
+import { captureException } from '../lib/sentry.js';
 import { env } from '../config/env.js';
 import type { Db, AssistantMessageMetadata } from '../db/messages.repo.js';
 import * as messagesRepo from '../db/messages.repo.js';
@@ -195,6 +196,7 @@ export async function createMessageDbController(
           deps.providerTimeoutMs ?? PROVIDER_TIMEOUT_MS,
         );
       } catch (err) {
+        captureException(err, { provider: cw.provider, model: cw.model, route: '/v1/messages' });
         if (err instanceof Error && err.message === PROVIDER_TIMEOUT_MESSAGE) {
           return respondError('provider_error', 'Provider call timed out after 30s', 502);
         }
@@ -325,6 +327,7 @@ export async function streamMessageDbController(
       }
     }
   } catch (err) {
+    captureException(err, { provider: cw.provider, model: cw.model, route: '/v1/messages/stream' });
     const detail = err instanceof Error ? err.message : 'Unknown provider error';
     sseWrite(res, { error: detail });
     res.write('data: [DONE]\n\n');


### PR DESCRIPTION
Both `POST /v1/messages` and `POST /v1/messages/stream` catch upstream provider failures and translate them into a `502 provider_error` envelope (or an SSE error event). Up to now those throws were swallowed without ever reaching Sentry — ops had no visibility into OpenAI / Anthropic / Perplexity outages until users complained.

## Change
Every provider-call catch block forwards the error through `captureException` with `{ provider, model, route }` context. The existing user-facing response is unchanged.

The Sentry wrapper is a no-op when `SENTRY_DSN_API` is not set (dev/test/CI), so behaviour and tests are identical without a DSN.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 360/360 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓