### PR TITLE
polish(web): UX & a11y batch 2 (loading skeletons, CapsLock, skip-link, counts, focus ring)

### DIFF
--- a/apps/web/src/app/login/loading.tsx
+++ b/apps/web/src/app/login/loading.tsx
@@ -1,0 +1,86 @@
+export default function LoginLoading() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          width: '100%',
+          maxWidth: 380,
+          padding: '2rem',
+          background: '#141418',
+          border: '1px solid #1d1d22',
+          borderRadius: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+          opacity: 0.85,
+        }}
+      >
+        <SkeletonLine width="40%" />
+        <SkeletonField />
+        <SkeletonField />
+        <SkeletonLine width="100%" tall />
+      </div>
+      <span aria-live="polite" style={srOnlyStyle}>
+        Loading…
+      </span>
+    </div>
+  );
+}
+
+function SkeletonField() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <SkeletonLine width="25%" tiny />
+      <div
+        style={{
+          height: 36,
+          borderRadius: 6,
+          background: '#0f0f13',
+          border: '1px solid #2a2a30',
+        }}
+      />
+    </div>
+  );
+}
+
+function SkeletonLine({
+  width,
+  tall,
+  tiny,
+}: {
+  width: string;
+  tall?: boolean;
+  tiny?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        width,
+        height: tall ? 36 : tiny ? 9 : 14,
+        background: 'linear-gradient(90deg, #1f1f27 0%, #2a2a35 50%, #1f1f27 100%)',
+        backgroundSize: '200% 100%',
+        animation: 'wav-shimmer 1.4s linear infinite',
+        borderRadius: tall ? 8 : 4,
+      }}
+    />
+  );
+}
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -33,7 +33,16 @@ export default async function HomePage() {
   const result = await loadProjects();
 
   return (
-    <AppShell subtitle="Projects" right={<SourceBadge result={result} />}>
+    <AppShell
+      subtitle={
+        result.source === 'error'
+          ? 'Projects'
+          : result.projects.length === 0
+            ? 'Projects'
+            : `Projects · ${result.projects.length}`
+      }
+      right={<SourceBadge result={result} />}
+    >
       <section style={{ padding: '1.5rem', maxWidth: 960, width: '100%', margin: '0 auto' }}>
         <h1 style={{ fontSize: '1.5rem', margin: '0 0 1.25rem 0' }}>Your projects</h1>
         {result.source === 'error' ? (

--- a/apps/web/src/app/register/loading.tsx
+++ b/apps/web/src/app/register/loading.tsx
@@ -1,0 +1,86 @@
+export default function RegisterLoading() {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2rem',
+      }}
+    >
+      <div
+        aria-hidden
+        style={{
+          width: '100%',
+          maxWidth: 380,
+          padding: '2rem',
+          background: '#141418',
+          border: '1px solid #1d1d22',
+          borderRadius: 12,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+          opacity: 0.85,
+        }}
+      >
+        <SkeletonLine width="40%" />
+        <SkeletonField />
+        <SkeletonField />
+        <SkeletonLine width="100%" tall />
+      </div>
+      <span aria-live="polite" style={srOnlyStyle}>
+        Loading…
+      </span>
+    </div>
+  );
+}
+
+function SkeletonField() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <SkeletonLine width="25%" tiny />
+      <div
+        style={{
+          height: 36,
+          borderRadius: 6,
+          background: '#0f0f13',
+          border: '1px solid #2a2a30',
+        }}
+      />
+    </div>
+  );
+}
+
+function SkeletonLine({
+  width,
+  tall,
+  tiny,
+}: {
+  width: string;
+  tall?: boolean;
+  tiny?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        width,
+        height: tall ? 36 : tiny ? 9 : 14,
+        background: 'linear-gradient(90deg, #1f1f27 0%, #2a2a35 50%, #1f1f27 100%)',
+        backgroundSize: '200% 100%',
+        animation: 'wav-shimmer 1.4s linear infinite',
+        borderRadius: tall ? 8 : 4,
+      }}
+    />
+  );
+}
+
+const srOnlyStyle: React.CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  whiteSpace: 'nowrap',
+};

--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -129,7 +129,14 @@ export default function ProviderSettingsPage() {
   return (
     <main style={pageStyle}>
       <header style={headerStyle}>
-        <h1 style={{ fontSize: '1.5rem', margin: 0 }}>Provider connections</h1>
+        <h1 style={{ fontSize: '1.5rem', margin: 0 }}>
+          Provider connections
+          {state.status === 'ready' && state.items.length > 0 ? (
+            <span style={{ marginLeft: 8, color: '#8a8a95', fontWeight: 400, fontSize: '1rem' }}>
+              · {state.items.length}
+            </span>
+          ) : null}
+        </h1>
         <Button variant="ghost" onClick={() => void load()} disabled={state.status === 'loading'}>
           Refresh
         </Button>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -12,6 +12,9 @@ interface AppShellProps {
 export function AppShell({ title = 'AI Workspace V1', subtitle, right, children }: AppShellProps) {
   return (
     <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <a href="#app-main" className="skip-link">
+        Skip to main content
+      </a>
       <header
         style={{
           display: 'flex',
@@ -43,7 +46,10 @@ export function AppShell({ title = 'AI Workspace V1', subtitle, right, children 
           <UserMenu />
         </div>
       </header>
-      <main style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>{children}</main>
+      <main id="app-main" style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        {children}
+      </main>
     </div>
   );
 }
+

--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -29,6 +29,13 @@ const variants: Record<Variant, React.CSSProperties> = {
   },
 };
 
-export function Button({ variant = 'primary', style, ...rest }: ButtonProps) {
-  return <button {...rest} style={{ ...base, ...variants[variant], ...style }} />;
+export function Button({ variant = 'primary', className, style, ...rest }: ButtonProps) {
+  const merged = ['wav-btn', className].filter(Boolean).join(' ');
+  return (
+    <button
+      {...rest}
+      className={merged}
+      style={{ ...base, ...variants[variant], ...style }}
+    />
+  );
 }

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useRef, useState, type FormEvent } from 'react';
+import { useRef, useState, type FormEvent, type KeyboardEvent } from 'react';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
 import { login, register } from '@/lib/api/auth';
@@ -194,45 +194,65 @@ function PasswordInput({
   autoComplete?: string;
 }) {
   const [show, setShow] = useState(false);
+  const [capsOn, setCapsOn] = useState(false);
+  const updateCaps = (e: KeyboardEvent<HTMLInputElement>) => {
+    setCapsOn(e.getModifierState('CapsLock'));
+  };
   return (
-    <div style={{ position: 'relative', display: 'flex' }}>
-      <input
-        type={show ? 'text' : 'password'}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        required
-        minLength={minLength}
-        autoComplete={autoComplete}
-        style={{ ...inputStyle, flex: 1, paddingRight: '3.5rem' }}
-      />
-      <button
-        type="button"
-        onClick={() => setShow((s) => !s)}
-        aria-label={show ? 'Hide password' : 'Show password'}
-        aria-pressed={show}
-        style={{
-          position: 'absolute',
-          top: '50%',
-          right: 6,
-          transform: 'translateY(-50%)',
-          background: 'transparent',
-          border: 'none',
-          color: '#a0a0aa',
-          fontSize: '0.72rem',
-          fontWeight: 500,
-          padding: '4px 8px',
-          borderRadius: 4,
-          cursor: 'pointer',
-          fontFamily: 'inherit',
-          textTransform: 'uppercase',
-          letterSpacing: '0.04em',
-        }}
-      >
-        {show ? 'Hide' : 'Show'}
-      </button>
-    </div>
+    <>
+      <div style={{ position: 'relative', display: 'flex' }}>
+        <input
+          type={show ? 'text' : 'password'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={updateCaps}
+          onKeyUp={updateCaps}
+          onBlur={() => setCapsOn(false)}
+          required
+          minLength={minLength}
+          autoComplete={autoComplete}
+          aria-describedby={capsOn ? 'capslock-hint' : undefined}
+          style={{ ...inputStyle, flex: 1, paddingRight: '3.5rem' }}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((s) => !s)}
+          aria-label={show ? 'Hide password' : 'Show password'}
+          aria-pressed={show}
+          style={{
+            position: 'absolute',
+            top: '50%',
+            right: 6,
+            transform: 'translateY(-50%)',
+            background: 'transparent',
+            border: 'none',
+            color: '#a0a0aa',
+            fontSize: '0.72rem',
+            fontWeight: 500,
+            padding: '4px 8px',
+            borderRadius: 4,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            textTransform: 'uppercase',
+            letterSpacing: '0.04em',
+          }}
+        >
+          {show ? 'Hide' : 'Show'}
+        </button>
+      </div>
+      {capsOn ? (
+        <span id="capslock-hint" style={capsHintStyle} role="status">
+          Caps Lock is on
+        </span>
+      ) : null}
+    </>
   );
 }
+
+const capsHintStyle: React.CSSProperties = {
+  fontSize: '0.72rem',
+  color: '#ffd166',
+};
 
 const inputStyle: React.CSSProperties = {
   padding: '0.55rem 0.7rem',

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -87,7 +87,7 @@ export function WorkspaceSidebar({
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '0.5rem' }}>
-        <SectionLabel>Open</SectionLabel>
+        <SectionLabel>Open · {visibleWindows.length}</SectionLabel>
         {visibleWindows.length === 0 ? (
           <EmptyHint>No windows open</EmptyHint>
         ) : (
@@ -106,7 +106,7 @@ export function WorkspaceSidebar({
 
         {closedWindows.length > 0 ? (
           <>
-            <SectionLabel>Closed</SectionLabel>
+            <SectionLabel>Closed · {closedWindows.length}</SectionLabel>
             {closedWindows.map((w) => (
               <WindowRow
                 key={w.id}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -48,3 +48,12 @@ body {
   outline: 2px solid #4f6bff;
   outline-offset: 2px;
 }
+
+.wav-btn:focus-visible {
+  outline: 2px solid #4f6bff;
+  outline-offset: 2px;
+}
+.wav-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -27,3 +27,24 @@ body {
   0% { background-position: 100% 0; }
   100% { background-position: -100% 0; }
 }
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: #f5f5f5;
+  color: #0b0b0d;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border-radius: 0 0 6px 0;
+  text-decoration: none;
+  transform: translateY(-100%);
+  transition: transform 120ms ease;
+  z-index: 100;
+}
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid #4f6bff;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
A second batch of small frontend polish items, each scoped to one commit for easy review.

## Changes
- **`/login` + `/register` loading.tsx** — shimmering panel skeleton during the SessionContext / AuthForm client-island bootstrap.
- **AuthForm `PasswordInput`** — Caps Lock indicator: tracks `getModifierState('CapsLock')` on key events, shows a small "Caps Lock is on" hint below the field while typing, wired via `aria-describedby`. Cleared on blur.
- **AppShell skip-to-content link** — first focusable element, hidden off-screen, slides in on `:focus`. `<main id="app-main">`. CSS lives in `globals.css` because `:focus` can't be expressed inline.
- **Home subtitle** — `Projects · N` once the list is non-empty (falls back to plain `Projects` on empty/error).
- **WorkspaceSidebar** — `Open · N` / `Closed · N` in the section labels.
- **`/settings/providers` heading** — `Provider connections · N` once the list has loaded with at least one entry.
- **Button** — applies a `.wav-btn` className. `globals.css` adds:
  - `.wav-btn:focus-visible` accent outline (keyboard users only).
  - `.wav-btn:disabled` `cursor: not-allowed` + 0.6 opacity for consistent disabled signal.

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
- Single branch off latest `main`; no stack.
- Touches `AuthForm.tsx`, `WorkspaceSidebar.tsx`, `Button.tsx`, `AppShell.tsx`, `page.tsx` (home + providers), `globals.css`, plus 2 new `loading.tsx` files. No backend, no API contract changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)