### PR TITLE
polish(web): UX batch 3 (chat draft persistence, toast cap, char counter, a11y, noindex)

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import { AuthForm } from '@/features/auth/AuthForm';
 
 export const metadata: Metadata = {
   title: 'Log in · AI Workspace V1',
+  robots: { index: false, follow: false },
 };
 
 export default function LoginPage() {

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -3,6 +3,7 @@ import { AuthForm } from '@/features/auth/AuthForm';
 
 export const metadata: Metadata = {
   title: 'Create account · AI Workspace V1',
+  robots: { index: false, follow: false },
 };
 
 export default function RegisterPage() {

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -28,6 +28,8 @@ export function AppShell({ title = 'AI Workspace V1', subtitle, right, children 
         <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.75rem' }}>
           <Link
             href="/"
+            prefetch={false}
+            aria-label="Home — projects"
             style={{
               fontSize: '1rem',
               fontWeight: 600,

--- a/apps/web/src/components/ToastHost.tsx
+++ b/apps/web/src/components/ToastHost.tsx
@@ -39,6 +39,7 @@ interface ToastContextValue {
 const ToastContext = createContext<ToastContextValue | null>(null);
 
 const AUTO_DISMISS_MS = 5000;
+const MAX_VISIBLE_TOASTS = 5;
 
 let counter = 0;
 function nextId(): string {
@@ -63,7 +64,12 @@ export function ToastHost({ children }: { children: ReactNode }) {
 
   const push = useCallback((tone: ToastTone, message: string, options?: PushOptions) => {
     const id = nextId();
-    setToasts((prev) => [...prev, { id, tone, message, action: options?.action }]);
+    setToasts((prev) => {
+      const next = [...prev, { id, tone, message, action: options?.action }];
+      return next.length > MAX_VISIBLE_TOASTS
+        ? next.slice(next.length - MAX_VISIBLE_TOASTS)
+        : next;
+    });
   }, []);
 
   const pushError = useCallback(

--- a/apps/web/src/features/auth/SessionContext.tsx
+++ b/apps/web/src/features/auth/SessionContext.tsx
@@ -169,7 +169,7 @@ function FullScreenLoader() {
   return (
     <div role="status" aria-live="polite" style={loaderStyle}>
       <div style={spinnerStyle} aria-hidden />
-      <span style={{ color: '#8a8a95', fontSize: '0.875rem' }}>Loading…</span>
+      <span style={{ color: '#8a8a95', fontSize: '0.875rem' }}>Verifying session…</span>
     </div>
   );
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useLayoutEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react';
 import type { AIProvider } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
 
@@ -51,7 +58,8 @@ export function ChatWindow({
   onRegenerate,
   onCancel,
 }: ChatWindowProps) {
-  const [draft, setDraft] = useState('');
+  const draftStorageKey = `wav.chat.draft.${id}`;
+  const [draft, setDraft] = useState<string>(() => readDraft(draftStorageKey));
   const [editing, setEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState(title);
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -81,6 +89,10 @@ export function ChatWindow({
     const next = Math.min(ta.scrollHeight, 160);
     ta.style.height = `${Math.max(36, next)}px`;
   }, [draft]);
+
+  useEffect(() => {
+    writeDraft(draftStorageKey, draft);
+  }, [draft, draftStorageKey]);
 
   const commitRename = () => {
     const trimmed = titleDraft.trim();
@@ -721,4 +733,23 @@ function formatLatency(ms: number): string {
   if (s < 60) return `${s.toFixed(s >= 10 ? 0 : 1)}s`;
   const m = Math.floor(s / 60);
   return `${m}m ${Math.round(s - m * 60)}s`;
+}
+
+function readDraft(key: string): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function writeDraft(key: string, value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) window.localStorage.setItem(key, value);
+    else window.localStorage.removeItem(key);
+  } catch {
+    // localStorage unavailable / quota exceeded; ignore
+  }
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -389,6 +389,20 @@ export function ChatWindow({
           </button>
         )}
       </form>
+      {draft.length > 2000 ? (
+        <div
+          aria-live="polite"
+          style={{
+            padding: '0 0.75rem 0.5rem',
+            background: '#0f0f13',
+            fontSize: '0.7rem',
+            color: draft.length > 8000 ? '#ff8b8b' : '#8a8a95',
+            textAlign: 'right',
+          }}
+        >
+          {draft.length.toLocaleString()} chars
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Third batch of small frontend polish. One commit per concern.

## Changes
- **ChatWindow draft persistence** — each window stores its in-progress draft under `wav.chat.draft.<windowId>` in `localStorage`. Survives accidental close/reopen and tab refresh. SSR-safe + quota-safe.
- **ToastHost** — caps visible toasts at 5 (drops oldest on overflow) so a burst of errors can't flood the viewport.
- **ChatWindow composer** — character counter under the form when the draft exceeds 2000 chars (turns red past 8000). `aria-live="polite"`. Hidden for typical short messages.
- **AppShell title link** — `aria-label="Home — projects"` so screen readers announce it as a nav link, plus `prefetch={false}` to avoid re-fetching the RSC project list (and re-running `cookies()` / `serverApiHeaders()`) every time the user hovers it.
- **`/login` + `/register`** — `robots: { index: false, follow: false }` in metadata. Privacy hygiene.
- **SessionContext loader** — "Loading…" → "Verifying session…" so the user knows what's blocking.

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Single branch off `main`. No backend, no API contract changes, no new dependencies, no shared-types changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)