### PR TITLE
feat(api): /v1/health/deep reports DB ping latency

### DIFF
--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -6,8 +6,8 @@ import { Router } from '../lib/router.js';
 import { createApiServer } from '../lib/server.js';
 import { healthDeepController, type DbStatus, type HealthDeepDeps } from './health-deep.controller.js';
 
-function makeDeps(status: DbStatus): HealthDeepDeps {
-  return { pingDb: async () => status };
+function makeDeps(status: DbStatus, latencyMs: number | null = status === 'disabled' ? null : 7): HealthDeepDeps {
+  return { pingDb: async () => ({ status, latencyMs }) };
 }
 
 async function startServer(deps: HealthDeepDeps): Promise<{ baseUrl: string; close: () => Promise<void> }> {
@@ -23,35 +23,39 @@ async function startServer(deps: HealthDeepDeps): Promise<{ baseUrl: string; clo
 }
 
 describe('GET /v1/health/deep', () => {
-  it('returns 200 with db=ok when ping succeeds', async () => {
-    const { baseUrl, close } = await startServer(makeDeps('ok'));
+  it('returns 200 with db=ok and dbLatencyMs when ping succeeds', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('ok', 12));
     const res = await fetch(`${baseUrl}/v1/health/deep`);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as ApiResponse<{ db: DbStatus; service: string }>;
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus; dbLatencyMs: number | null; service: string }>;
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.db).toBe('ok');
+    expect(body.data.dbLatencyMs).toBe(12);
     expect(body.data.service).toBe('webapp-api');
     await close();
   });
 
-  it('returns 200 with db=disabled when no DATABASE_URL', async () => {
+  it('returns 200 with db=disabled and dbLatencyMs=null when no DATABASE_URL', async () => {
     const { baseUrl, close } = await startServer(makeDeps('disabled'));
     const res = await fetch(`${baseUrl}/v1/health/deep`);
     expect(res.status).toBe(200);
-    const body = (await res.json()) as ApiResponse<{ db: DbStatus }>;
+    const body = (await res.json()) as ApiResponse<{ db: DbStatus; dbLatencyMs: number | null }>;
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.db).toBe('disabled');
+    expect(body.data.dbLatencyMs).toBeNull();
     await close();
   });
 
-  it('returns 503 with db=down when ping fails', async () => {
-    const { baseUrl, close } = await startServer(makeDeps('down'));
+  it('returns 503 with db=down + dbLatencyMs when ping fails', async () => {
+    const { baseUrl, close } = await startServer(makeDeps('down', 4_999));
     const res = await fetch(`${baseUrl}/v1/health/deep`);
     expect(res.status).toBe(503);
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('internal_error');
-    expect((body.error.details as { db: DbStatus }).db).toBe('down');
+    const details = body.error.details as { db: DbStatus; dbLatencyMs: number | null };
+    expect(details.db).toBe('down');
+    expect(details.dbLatencyMs).toBe(4_999);
     await close();
   });
 });

--- a/apps/api/src/controllers/health-deep.controller.ts
+++ b/apps/api/src/controllers/health-deep.controller.ts
@@ -5,30 +5,37 @@ import { respond, respondError, type InternalResult, type RequestContext } from 
 
 export type DbStatus = 'ok' | 'down' | 'disabled';
 
+export interface DbPingResult {
+  status: DbStatus;
+  /** Wall-clock time spent on the ping (including connect). null when disabled. */
+  latencyMs: number | null;
+}
+
 export interface HealthDeepDeps {
   /** Returns 'ok' when the DB answers a trivial query, 'down' on any failure,
    *  'disabled' when no DATABASE_URL is configured. */
-  pingDb: () => Promise<DbStatus>;
+  pingDb: () => Promise<DbPingResult>;
 }
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 
-async function defaultPingDb(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<DbStatus> {
-  if (!env.databaseUrl) return 'disabled';
+async function defaultPingDb(timeoutMs = DEFAULT_TIMEOUT_MS): Promise<DbPingResult> {
+  if (!env.databaseUrl) return { status: 'disabled', latencyMs: null };
+  const startedAt = Date.now();
   let db;
   try {
     db = createDb();
   } catch {
-    return 'down';
+    return { status: 'down', latencyMs: Date.now() - startedAt };
   }
   try {
     await Promise.race([
       db.execute(sql`select 1`),
       new Promise((_, reject) => setTimeout(() => reject(new Error('db_ping_timeout')), timeoutMs)),
     ]);
-    return 'ok';
+    return { status: 'ok', latencyMs: Date.now() - startedAt };
   } catch {
-    return 'down';
+    return { status: 'down', latencyMs: Date.now() - startedAt };
   }
 }
 
@@ -40,6 +47,8 @@ export interface HealthDeepResponse {
   service: 'webapp-api';
   version: string;
   db: DbStatus;
+  /** DB ping latency in ms; null when DB is disabled. */
+  dbLatencyMs: number | null;
   timestamp: string;
 }
 
@@ -47,14 +56,15 @@ export async function healthDeepController(
   _ctx: RequestContext,
   deps: HealthDeepDeps,
 ): Promise<InternalResult> {
-  const db = await deps.pingDb();
+  const ping = await deps.pingDb();
   const body: HealthDeepResponse = {
     service: 'webapp-api',
     version: env.serviceVersion,
-    db,
+    db: ping.status,
+    dbLatencyMs: ping.latencyMs,
     timestamp: new Date().toISOString(),
   };
-  if (db === 'down') {
+  if (ping.status === 'down') {
     return respondError('internal_error', 'Database is unreachable', 503, body);
   }
   return respond(body);


### PR DESCRIPTION
The deep health endpoint already drains a `select 1` against the configured Postgres but only returned a `{ok|down|disabled}` verdict. Ops dashboards that watch readiness lose visibility on DB tail-latency creep — by the time `db=down` trips, the pool has already been struggling.

## Change
Now the controller also returns `dbLatencyMs: number | null`:
- a real number for `ok` / `down` (wall-clock of the ping including the `createDb` connection step)
- `null` when `DATABASE_URL` is not set (`db=disabled`)

The 503 details body for `db=down` also carries the latency, so the last successful timing before failure is captured in logs.

`HealthDeepDeps.pingDb` dep contract widened from `() => Promise<DbStatus>` to `() => Promise<{ status: DbStatus; latencyMs: number | null }>`. Test deps + tests updated.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 367/367 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓