### PR TITLE
fix(api): provider chat completion uses AbortSignal.timeout (60s)

### DIFF
--- a/apps/api/src/providers/anthropic.provider.test.ts
+++ b/apps/api/src/providers/anthropic.provider.test.ts
@@ -96,6 +96,17 @@ describe('createAnthropicClient.createChatCompletion', () => {
     await expect(createAnthropicClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
       .rejects.toBeInstanceOf(ProviderError);
   });
+
+  it('passes an AbortSignal so a completion call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      content: [{ type: 'text', text: 'ok' }],
+      usage:   { input_tokens: 1, output_tokens: 1 },
+    }));
+    await createAnthropicClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createAnthropicClient.createChatCompletionStream', () => {

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -19,7 +19,8 @@ const DEFAULT_MAX_TOKENS = 1024;
 
 export type AnthropicVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
-const VERIFY_TIMEOUT_MS = 10_000;
+const VERIFY_TIMEOUT_MS  = 10_000;
+const RUNTIME_TIMEOUT_MS = 60_000;
 
 export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerifyResult> {
   let res: Response;
@@ -95,6 +96,7 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
             messages: shape.messages,
             stream: false,
           }),
+          signal: AbortSignal.timeout(RUNTIME_TIMEOUT_MS),
         });
       } catch (err) {
         throw new ProviderError(

--- a/apps/api/src/providers/openai.provider.test.ts
+++ b/apps/api/src/providers/openai.provider.test.ts
@@ -105,6 +105,13 @@ describe('createOpenAIClient', () => {
       const result = await client.createChatCompletion(MESSAGES, MODEL);
       expect(result.model).toBe('gpt-4o-2024-11-20');
     });
+
+    it('passes an AbortSignal so a completion call cannot hang forever', async () => {
+      vi.mocked(fetch).mockResolvedValue(makeOkResponse(openAIBody('ok')));
+      await createOpenAIClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+      const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
   });
 
   describe('createChatCompletion — API errors', () => {

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -58,6 +58,11 @@ interface OpenAIResponse {
 
 const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions';
 
+/** Hard cap on a single completion request — prevents an unresponsive upstream
+ *  from holding our request handler hostage. Streaming intentionally has no
+ *  total cap (only the connect needs guarding); a long stream is legitimate. */
+const RUNTIME_TIMEOUT_MS = 60_000;
+
 export function createOpenAIClient(apiKey: string): ProviderClient {
   return {
     async createChatCompletion(
@@ -73,6 +78,7 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
             'Authorization': `Bearer ${apiKey}`,
           },
           body: JSON.stringify({ model, messages, stream: false }),
+          signal: AbortSignal.timeout(RUNTIME_TIMEOUT_MS),
         });
       } catch (err) {
         throw new ProviderError(

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -81,6 +81,17 @@ describe('createPerplexityClient.createChatCompletion', () => {
     await expect(createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL))
       .rejects.toBeInstanceOf(ProviderError);
   });
+
+  it('passes an AbortSignal so a completion call cannot hang forever', async () => {
+    vi.mocked(fetch).mockResolvedValue(ok({
+      model: MODEL,
+      choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+      usage:   { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }));
+    await createPerplexityClient(API_KEY).createChatCompletion(MESSAGES, MODEL);
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('createPerplexityClient.createChatCompletionStream', () => {

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -20,7 +20,8 @@ const VERIFY_MODEL = 'sonar';
 
 export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
-const VERIFY_TIMEOUT_MS = 10_000;
+const VERIFY_TIMEOUT_MS  = 10_000;
+const RUNTIME_TIMEOUT_MS = 60_000;
 
 export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
   let res: Response;
@@ -90,6 +91,7 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
             'Authorization': `Bearer ${apiKey}`,
           },
           body: JSON.stringify({ model, messages, stream: false }),
+          signal: AbortSignal.timeout(RUNTIME_TIMEOUT_MS),
         });
       } catch (err) {
         throw new ProviderError(


### PR DESCRIPTION
Each provider (openai, anthropic, perplexity) already had a 30s race in `messages-db.controller` via `withTimeout()`, but that race only rejected our promise — the underlying `fetch` kept running, holding the socket and event-loop slot until the upstream actually responded. Aborting now releases the resource and matches what the surrounding code already advertises.

## Change
`createChatCompletion` fetches now pass `AbortSignal.timeout(60_000)`:
- 60s is intentionally **wider** than the 30s controller race so the race fires first and is what users see; the `AbortSignal` is a backstop that releases the underlying TCP socket if upstream keeps hanging beyond 60s.
- **Streaming intentionally has no total cap** — long legitimate streams must not be cut. The existing `req.on('close')` already handles client-side aborts; upstream-side stream stalls would need an idle-only watchdog (out of scope here).

## Tests
3 new "passes an AbortSignal" assertions on the completion `init`, one per provider. Verify fetches already covered.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 370/370 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓