### PR TITLE
feat(api): defensive security headers on every response

### DIFF
--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -38,6 +38,20 @@ describe('dispatch — error envelopes', () => {
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('method_not_allowed');
   });
+
+  it('emits defensive security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy) on every response', async () => {
+    const res = await fetch(`${harness.baseUrl}/health`);
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer');
+  });
+
+  it('emits security headers even on a 404 envelope', async () => {
+    const res = await fetch(`${harness.baseUrl}/nope`);
+    expect(res.status).toBe(404);
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+  });
 });
 
 // ── CSRF protection ───────────────────────────────────────────────────────────

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -63,6 +63,12 @@ export async function handleRequest(
     res.setHeader(k, v);
   }
 
+  // Defensive security headers — cheap, no behavioural change. Opt-out is per-route
+  // via res.removeHeader if a future use case ever needs framing or sniffing.
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', 'no-referrer');
+
   if (rawMethod === 'OPTIONS') {
     res.writeHead(204);
     res.end();


### PR DESCRIPTION
Adds three cheap, opt-out-able defensive headers to every response emitted by `handle-request`:

- `X-Frame-Options: DENY` — no clickjacking via iframe
- `X-Content-Type-Options: nosniff` — browsers honour our `Content-Type`
- `Referrer-Policy: no-referrer` — don't leak request paths in cross-origin nav

These are always-on defaults for an API that returns JSON or SSE. Any future route that genuinely needs framing or sniffing can `res.removeHeader` before responding — no controller does today.

## Tests
2 new asserts that the headers ride 200 (`/health`) and 404 (`/nope`) responses alike.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 372/372 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓