### PR TITLE
polish(web): Escape closes every modal / popover / menu (a11y batch)

### DIFF
--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -64,6 +64,15 @@ export default function ProviderSettingsPage() {
     return () => controller.abort();
   }, [load]);
 
+  useEffect(() => {
+    if (!pendingDelete) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !deleting) setPendingDelete(null);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [pendingDelete, deleting]);
+
   const onSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();

--- a/apps/web/src/features/auth/UserMenu.tsx
+++ b/apps/web/src/features/auth/UserMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useToast } from '@/components/ToastHost';
 import { useSession } from '@/features/auth/SessionContext';
 
@@ -9,6 +9,15 @@ export function UserMenu() {
   const { user, logout, loggingOut } = useSession();
   const toast = useToast();
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   if (!user) return null;
 

--- a/apps/web/src/features/projects/CreateProjectEmptyState.tsx
+++ b/apps/web/src/features/projects/CreateProjectEmptyState.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
@@ -29,6 +29,14 @@ function CreateProjectModal({ onClose }: { onClose: () => void }) {
   const toast = useToast();
   const [name, setName] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [submitting, onClose]);
 
   const onSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {

--- a/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
+++ b/apps/web/src/features/workspace/CreateChatWindowCTA.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import type { AIProvider } from '@webapp/types';
 import { Button } from '@/components/Button';
@@ -48,6 +48,14 @@ function CreateChatWindowModal({
   const [provider, setProvider] = useState<AIProvider>('openai');
   const [model, setModel] = useState('gpt-4o-mini');
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [submitting, onClose]);
 
   const onProviderChange = (value: AIProvider) => {
     setProvider(value);

--- a/apps/web/src/features/workspace/CreateWorkspaceCTA.tsx
+++ b/apps/web/src/features/workspace/CreateWorkspaceCTA.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, type FormEvent } from 'react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/Button';
 import { Panel } from '@/components/Panel';
@@ -52,6 +52,14 @@ function CreateWorkspaceModal({
   const toast = useToast();
   const [name, setName] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [submitting, onClose]);
 
   const onSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {

--- a/apps/web/src/features/workspace/NewWindowComposer.tsx
+++ b/apps/web/src/features/workspace/NewWindowComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { AIProvider } from '@webapp/types';
 import { WINDOW_PRESETS, type WindowPreset } from '@/lib/data';
 import { Button } from '@/components/Button';
@@ -21,6 +21,15 @@ export function NewWindowComposer({ onCreate }: NewWindowComposerProps) {
   const [title, setTitle] = useState('');
 
   const preset = WINDOW_PRESETS.find((p) => p.id === presetId) ?? WINDOW_PRESETS[0]!;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   const submit = () => {
     onCreate(preset, title);

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useState, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
 import type { AIProvider, ChatWindow, Workspace } from '@webapp/types';
 import type { WindowPreset } from '@/lib/data';
 import { Button } from '@/components/Button';
@@ -311,6 +311,15 @@ function WorkspaceSwitcher({
   const isLocal =
     activeWorkspaceId.startsWith('local-') || activeWorkspaceId.startsWith('ws-');
   const single = workspaces.length <= 1;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   const commit = () => {
     const trimmed = draft.trim();


### PR DESCRIPTION
Harmonizes Escape-to-close across every dismissable surface in the app. Today most of them only closed via click-outside or via a button inside the surface — keyboard users had no consistent way out.

## Changes (one commit per surface)
- **Create Project modal** (`CreateProjectEmptyState.tsx`)
- **Create Chat Window modal** (`CreateChatWindowCTA.tsx`)
- **Create Workspace modal** (`CreateWorkspaceCTA.tsx`)
- **Delete provider connection dialog** (`/settings/providers/page.tsx`)
- **Workspace switcher dropdown** (`WorkspaceSidebar.tsx`)
- **UserMenu** avatar dropdown (`UserMenu.tsx`)
- **NewWindowComposer** popover (`NewWindowComposer.tsx`) — promoted from input-only Esc to a global handler so focus on a preset button no longer blocks it.

## Pattern
Each surface mounts a `window`-level `keydown` listener only while it is open, and removes it on close / unmount. Modals with an in-flight submit suppress the Esc dismiss to avoid vanishing mid-request. No new dependencies.

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Single branch off `main`. No backend, no API contract changes, no shared-types changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)