### PR TITLE
fix(api): provider stream gets connect-only AbortSignal (30s)

### DIFF
--- a/apps/api/src/providers/anthropic.provider.test.ts
+++ b/apps/api/src/providers/anthropic.provider.test.ts
@@ -149,4 +149,16 @@ describe('createAnthropicClient.createChatCompletionStream', () => {
     const it = createAnthropicClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
     await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
   });
+
+  it('passes a connect-only AbortSignal to fetch', async () => {
+    vi.mocked(fetch).mockResolvedValue(sse([
+      `data: ${JSON.stringify({ type: 'message_stop' })}\n\n`,
+    ]));
+    const chunks = [];
+    for await (const c of createAnthropicClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+      chunks.push(c);
+    }
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -19,8 +19,9 @@ const DEFAULT_MAX_TOKENS = 1024;
 
 export type AnthropicVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
-const VERIFY_TIMEOUT_MS  = 10_000;
-const RUNTIME_TIMEOUT_MS = 60_000;
+const VERIFY_TIMEOUT_MS         = 10_000;
+const RUNTIME_TIMEOUT_MS        = 60_000;
+const STREAM_CONNECT_TIMEOUT_MS = 30_000;
 
 export async function verifyAnthropicKey(apiKey: string): Promise<AnthropicVerifyResult> {
   let res: Response;
@@ -147,6 +148,8 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
     ): AsyncIterable<ChatCompletionStreamChunk> {
       const shape = toAnthropicShape(messages);
 
+      const connectController = new AbortController();
+      const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
       let res: Response;
       try {
         res = await fetch(ANTHROPIC_MESSAGES_URL, {
@@ -164,6 +167,7 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
             messages: shape.messages,
             stream: true,
           }),
+          signal: connectController.signal,
         });
       } catch (err) {
         throw new ProviderError(
@@ -171,6 +175,8 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
           'api_error',
           'anthropic',
         );
+      } finally {
+        clearTimeout(connectTimer);
       }
 
       if (!res.ok || !res.body) {

--- a/apps/api/src/providers/openai.provider.test.ts
+++ b/apps/api/src/providers/openai.provider.test.ts
@@ -215,5 +215,17 @@ describe('createOpenAIClient', () => {
       const it = createOpenAIClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
       await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
     });
+
+    it('passes a connect-only AbortSignal to fetch (cleared after headers arrive)', async () => {
+      vi.mocked(fetch).mockResolvedValue(sseStream([
+        JSON.stringify({ model: MODEL, choices: [{ delta: {} }], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } }),
+      ]));
+      const chunks = [];
+      for await (const c of createOpenAIClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+        chunks.push(c);
+      }
+      const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
   });
 });

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -61,7 +61,10 @@ const OPENAI_CHAT_URL = 'https://api.openai.com/v1/chat/completions';
 /** Hard cap on a single completion request — prevents an unresponsive upstream
  *  from holding our request handler hostage. Streaming intentionally has no
  *  total cap (only the connect needs guarding); a long stream is legitimate. */
-const RUNTIME_TIMEOUT_MS = 60_000;
+const RUNTIME_TIMEOUT_MS         = 60_000;
+/** Connect-only cap on a streaming request — fires only if headers don't arrive
+ *  in time. Cleared once fetch resolves so the stream itself isn't cut. */
+const STREAM_CONNECT_TIMEOUT_MS  = 30_000;
 
 export function createOpenAIClient(apiKey: string): ProviderClient {
   return {
@@ -133,6 +136,11 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
       messages: ChatMessage[],
       model: string,
     ): AsyncIterable<ChatCompletionStreamChunk> {
+      // Connect-only timeout: aborts the fetch if response headers haven't
+      // arrived after STREAM_CONNECT_TIMEOUT_MS. Cleared once headers land
+      // so a long legitimate stream is never cut.
+      const connectController = new AbortController();
+      const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
       let res: Response;
       try {
         res = await fetch(OPENAI_CHAT_URL, {
@@ -148,6 +156,7 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
             stream: true,
             stream_options: { include_usage: true },
           }),
+          signal: connectController.signal,
         });
       } catch (err) {
         throw new ProviderError(
@@ -155,6 +164,8 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
           'api_error',
           'openai',
         );
+      } finally {
+        clearTimeout(connectTimer);
       }
 
       if (!res.ok || !res.body) {

--- a/apps/api/src/providers/perplexity.provider.test.ts
+++ b/apps/api/src/providers/perplexity.provider.test.ts
@@ -132,4 +132,16 @@ describe('createPerplexityClient.createChatCompletionStream', () => {
     const it = createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)[Symbol.asyncIterator]();
     await expect(it.next()).rejects.toBeInstanceOf(ProviderError);
   });
+
+  it('passes a connect-only AbortSignal to fetch', async () => {
+    vi.mocked(fetch).mockResolvedValue(sse([
+      JSON.stringify({ model: MODEL, choices: [{ delta: {} }], usage: { prompt_tokens: 1, completion_tokens: 0, total_tokens: 1 } }),
+    ]));
+    const chunks = [];
+    for await (const c of createPerplexityClient(API_KEY).createChatCompletionStream(MESSAGES, MODEL)) {
+      chunks.push(c);
+    }
+    const init = vi.mocked(fetch).mock.calls[0]![1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -20,8 +20,9 @@ const VERIFY_MODEL = 'sonar';
 
 export type PerplexityVerifyResult = 'ok' | 'unauthorized' | 'provider_error';
 
-const VERIFY_TIMEOUT_MS  = 10_000;
-const RUNTIME_TIMEOUT_MS = 60_000;
+const VERIFY_TIMEOUT_MS         = 10_000;
+const RUNTIME_TIMEOUT_MS        = 60_000;
+const STREAM_CONNECT_TIMEOUT_MS = 30_000;
 
 export async function verifyPerplexityKey(apiKey: string): Promise<PerplexityVerifyResult> {
   let res: Response;
@@ -137,6 +138,8 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
       messages: ChatMessage[],
       model: string,
     ): AsyncIterable<ChatCompletionStreamChunk> {
+      const connectController = new AbortController();
+      const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
       let res: Response;
       try {
         res = await fetch(PERPLEXITY_CHAT_URL, {
@@ -147,6 +150,7 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
             'Accept':        'text/event-stream',
           },
           body: JSON.stringify({ model, messages, stream: true }),
+          signal: connectController.signal,
         });
       } catch (err) {
         throw new ProviderError(
@@ -154,6 +158,8 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
           'api_error',
           'perplexity',
         );
+      } finally {
+        clearTimeout(connectTimer);
       }
 
       if (!res.ok || !res.body) {


### PR DESCRIPTION
Streaming chat completion fetches had no abort plumbing — if the upstream API hung mid-handshake (no response headers), our request hung forever and the user-side SSE saw nothing.

## Change
Each provider (openai/anthropic/perplexity) now arms an `AbortController` + `setTimeout(30_000)` before the streaming `fetch`, and clears the timer in a `finally` block as soon as `fetch` resolves (i.e. once response headers arrive). The stream itself is therefore **never cut** by the connect timer — only the connect phase is guarded.

Long legitimate streams (multi-minute thinking, etc.) still flow freely. Aborts during connect surface as the existing `'api_error'` `ProviderError`. Aligns with the non-stream path that uses `AbortSignal.timeout(60s)` for the whole request.

## Tests
3 new "passes a connect-only AbortSignal" assertions on the stream `init`, one per provider. Existing happy-path SSE tests stay unchanged.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → 373/373 ✓
- `pnpm typecheck` ✓ · `pnpm build` ✓