### PR TITLE
polish(web): UX & a11y batch 5 (project cards, return-target hint, a11y across surfaces)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import type { Project } from '@webapp/types';
 import { AppShell } from '@/components/AppShell';
 import { Panel } from '@/components/Panel';
-import { listProjects as listMockProjects, listWorkspacesForProject } from '@/lib/data';
+import { listProjects as listMockProjects } from '@/lib/data';
 import { getApiBaseUrl } from '@/lib/api/env';
 import { fetchProjects } from '@/lib/api/projects';
 import { serverApiHeaders } from '@/lib/api/server';
@@ -67,13 +67,13 @@ function ProjectGrid({ projects }: { projects: Project[] }) {
       }}
     >
       {projects.map((project) => {
-        const projectWorkspaces = listWorkspacesForProject(project.id);
-        const totalWindows = projectWorkspaces.reduce((sum, w) => sum + w.windowIds.length, 0);
+        const updated = formatYYYYMMDD(project.updatedAt ?? project.createdAt);
         return (
           <Link
             key={project.id}
             href={`/project/${project.id}`}
             style={{ textDecoration: 'none', color: 'inherit' }}
+            aria-label={`Open project ${project.name}`}
           >
             <Panel style={{ padding: '1rem', height: '100%' }}>
               <div style={{ fontSize: '1rem', fontWeight: 600 }}>{project.name}</div>
@@ -82,11 +82,14 @@ function ProjectGrid({ projects }: { projects: Project[] }) {
                   {project.description}
                 </div>
               ) : null}
-              <div style={{ color: '#6a6a75', fontSize: '0.75rem', marginTop: 12 }}>
-                {projectWorkspaces.length === 0
-                  ? 'No workspace'
-                  : `${projectWorkspaces.length} workspace${projectWorkspaces.length > 1 ? 's' : ''} · ${totalWindows} windows`}
-              </div>
+              {updated ? (
+                <div
+                  style={{ color: '#6a6a75', fontSize: '0.72rem', marginTop: 12 }}
+                  title={project.updatedAt ?? project.createdAt}
+                >
+                  Updated {updated}
+                </div>
+              ) : null}
             </Panel>
           </Link>
         );
@@ -170,4 +173,11 @@ function SourceBadge({ result }: { result: ProjectsResult }) {
       {config.label}
     </span>
   );
+}
+
+function formatYYYYMMDD(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return new Date(t).toISOString().slice(0, 10);
 }

--- a/apps/web/src/app/settings/providers/page.tsx
+++ b/apps/web/src/app/settings/providers/page.tsx
@@ -154,7 +154,12 @@ export default function ProviderSettingsPage() {
       <section aria-labelledby="add-connection-title" style={formSectionStyle}>
         <h2 id="add-connection-title" style={{ margin: 0, fontSize: '1rem' }}>Add connection</h2>
         <p style={mutedStyle}>Your key is sent to the API, then cleared from this page.</p>
-        <form onSubmit={onSubmit} autoComplete="off" style={formStyle}>
+        <form
+          onSubmit={onSubmit}
+          autoComplete="off"
+          aria-busy={saving || undefined}
+          style={formStyle}
+        >
           <label style={labelStyle}>
             <span>Provider</span>
             <select

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -16,6 +16,7 @@ export function AppShell({ title = 'AI Workspace V1', subtitle, right, children 
         Skip to main content
       </a>
       <header
+        role="banner"
         style={{
           display: 'flex',
           alignItems: 'center',

--- a/apps/web/src/components/ToastHost.tsx
+++ b/apps/web/src/components/ToastHost.tsx
@@ -112,7 +112,12 @@ export function ToastHost({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <div aria-live="polite" style={viewportStyle}>
+      <div
+        role="region"
+        aria-label="Notifications"
+        aria-live="polite"
+        style={viewportStyle}
+      >
         {toasts.map((t) => (
           <div
             key={t.id}

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -100,11 +100,22 @@ export function AuthForm({ mode }: AuthFormProps) {
   }
 
   const c = copy[mode];
+  const rawNext = searchParams?.get('next') ?? null;
+  const nextHint = isSafeNext(rawNext) && rawNext !== '/'
+    ? `You'll be returned to ${rawNext} after signing in.`
+    : null;
 
   return (
     <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem' }}>
       <Panel style={{ padding: '2rem', width: '100%', maxWidth: 380 }}>
-        <h1 style={{ fontSize: '1.25rem', margin: '0 0 1.25rem 0', color: '#f5f5f5' }}>{c.title}</h1>
+        <h1 style={{ fontSize: '1.25rem', margin: '0 0 0.5rem 0', color: '#f5f5f5' }}>{c.title}</h1>
+        {nextHint ? (
+          <div style={{ fontSize: '0.78rem', color: '#8a8a95', margin: '0 0 1rem 0' }}>
+            {nextHint}
+          </div>
+        ) : (
+          <div style={{ height: '0.75rem' }} />
+        )}
         <form onSubmit={onSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '0.9rem' }}>
           {mode === 'register' ? (
             <Field label="Display name (optional)">

--- a/apps/web/src/features/auth/AuthForm.tsx
+++ b/apps/web/src/features/auth/AuthForm.tsx
@@ -158,7 +158,7 @@ export function AuthForm({ mode }: AuthFormProps) {
             </div>
           ) : null}
 
-          <Button type="submit" disabled={pending}>
+          <Button type="submit" disabled={pending} aria-busy={pending || undefined}>
             {pending ? 'Please wait…' : c.cta}
           </Button>
         </form>

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -203,6 +203,7 @@ export function ChatWindow({
         <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           {onDelete ? (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 if (typeof window === 'undefined') {
@@ -236,6 +237,7 @@ export function ChatWindow({
           ) : null}
           {onClose ? (
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onClose(id);

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -262,6 +262,10 @@ export function ChatWindow({
       <div
         ref={scrollRef}
         onScroll={updateStickiness}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions text"
+        aria-label={`Conversation with ${title}`}
         style={{
           flex: 1,
           overflowY: 'auto',

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -414,11 +414,15 @@ function WorkspaceSwitcher({
           />
         ) : (
           <button
+            type="button"
             onClick={() => !single && setOpen((v) => !v)}
             onDoubleClick={() => {
               setDraft(name);
               setEditing(true);
             }}
+            aria-haspopup={single ? undefined : 'listbox'}
+            aria-expanded={single ? undefined : open}
+            aria-label={single ? `Workspace: ${name}` : `Switch workspace (current: ${name})`}
             title={single ? 'Double-click to rename' : 'Switch · double-click to rename'}
             style={{
               flex: 1,


### PR DESCRIPTION
Fifth polish batch. One commit per concern.

## Changes
- **Home project cards** — drop misleading mock-based "<n> workspaces · <m> windows" line that always said "No workspace" in API mode. Replaced with a real "Updated YYYY-MM-DD" derived from `project.updatedAt` (falls back to `createdAt`). Card link gets `aria-label="Open project <name>"`.
- **A11y micro-fixes**:
  - AuthForm submit `<Button>` gets `aria-busy={pending}`.
  - ToastHost viewport becomes a named landmark (`role="region"` + `aria-label="Notifications"`).
  - ChatWindow message list becomes `role="log"`, `aria-live="polite"`, `aria-relevant="additions text"`, with a stable `aria-label` tied to the window title.
  - AppShell `<header>` gets `role="banner"`.
  - Workspace switcher trigger: explicit `type="button"`, `aria-haspopup="listbox"` + `aria-expanded`, descriptive `aria-label`.
  - ChatWindow header Delete + Close buttons: explicit `type="button"`.
  - `/settings/providers` form gets `aria-busy={saving}`.
- **AuthForm `?next=` hint** — when the session guard redirects to `/login?next=/project/<id>`, the screen now shows a small "You'll be returned to /project/<id> after signing in." note under the title (login + register).

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Single branch off `main`. No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)