### PR TITLE
chore(api): backend ops batch — expired-session cleanup + header coverage

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -179,8 +179,16 @@ export async function meController(ctx: RequestContext, deps: AuthDeps): Promise
 
   if (!token) return respondError('unauthenticated', 'Not authenticated', 401);
 
-  const session = await deps.findSessionByTokenHash(hashSessionToken(token));
-  if (!session || session.expiresAt <= new Date()) {
+  const tokenHash = hashSessionToken(token);
+  const session = await deps.findSessionByTokenHash(tokenHash);
+  if (!session) {
+    return respondError('unauthenticated', 'Session expired or invalid', 401);
+  }
+  if (session.expiresAt <= new Date()) {
+    // Opportunistic cleanup — the matching row is now strictly stale, no
+    // value keeping it in the DB. Fire-and-forget so we don't add latency
+    // to the response, and swallow errors (best-effort hygiene).
+    deps.deleteSession(tokenHash).catch(() => { /* ignore */ });
     return respondError('unauthenticated', 'Session expired or invalid', 401);
   }
 

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -72,6 +72,13 @@ describe('dispatch — error envelopes', () => {
     const b = await fetch(`${harness.baseUrl}/health`);
     expect(a.headers.get('x-request-id')).not.toBe(b.headers.get('x-request-id'));
   });
+
+  it('emits Cache-Control: no-store on JSON responses', async () => {
+    const ok = await fetch(`${harness.baseUrl}/health`);
+    expect(ok.headers.get('cache-control')).toBe('no-store');
+    const notFound = await fetch(`${harness.baseUrl}/nope`);
+    expect(notFound.headers.get('cache-control')).toBe('no-store');
+  });
 });
 
 // ── CSRF protection ───────────────────────────────────────────────────────────

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -79,6 +79,14 @@ describe('dispatch — error envelopes', () => {
     const notFound = await fetch(`${harness.baseUrl}/nope`);
     expect(notFound.headers.get('cache-control')).toBe('no-store');
   });
+
+  it('emits Allow header on 405 listing the methods the path actually supports', async () => {
+    // /health is a GET-only route; a DELETE must surface Allow: GET (RFC 7231).
+    const res = await fetch(`${harness.baseUrl}/health`, { method: 'DELETE' });
+    expect(res.status).toBe(405);
+    const allow = res.headers.get('allow') ?? '';
+    expect(allow).toContain('GET');
+  });
 });
 
 // ── CSRF protection ───────────────────────────────────────────────────────────

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -104,6 +104,10 @@ describe('CSRF protection — explicit origin', () => {
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('csrf_error');
+    // Defensive headers must still ride 403s — they're set before any short-circuit.
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
     await close();
   });
 

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -52,6 +52,26 @@ describe('dispatch — error envelopes', () => {
     expect(res.headers.get('x-frame-options')).toBe('DENY');
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
   });
+
+  it('emits X-Request-Id on a 200 response', async () => {
+    const res = await fetch(`${harness.baseUrl}/health`);
+    const id = res.headers.get('x-request-id');
+    expect(id).toBeTruthy();
+    expect(typeof id).toBe('string');
+    expect(id!.length).toBeGreaterThan(8);
+  });
+
+  it('emits X-Request-Id on a 405 method-not-allowed', async () => {
+    const res = await fetch(`${harness.baseUrl}/health`, { method: 'DELETE' });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+  });
+
+  it('every response gets a fresh X-Request-Id', async () => {
+    const a = await fetch(`${harness.baseUrl}/health`);
+    const b = await fetch(`${harness.baseUrl}/health`);
+    expect(a.headers.get('x-request-id')).not.toBe(b.headers.get('x-request-id'));
+  });
 });
 
 // ── CSRF protection ───────────────────────────────────────────────────────────

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -238,6 +238,41 @@ describe('GET /v1/auth/me', () => {
     expect(res.status).toBe(401);
     await close();
   });
+
+  it('opportunistically cleans up an expired session row', async () => {
+    const EXPIRED_TOKEN = 'e'.repeat(64);
+    const EXPIRED_HASH  = hashSessionToken(EXPIRED_TOKEN);
+    const deletes: string[] = [];
+    let resolveDel!: () => void;
+    const deleteDone = new Promise<void>((r) => { resolveDel = r; });
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async (h) => h === EXPIRED_HASH
+        ? { id: h, userId: 'user-1', expiresAt: new Date(Date.now() - 60_000), createdAt: new Date() }
+        : null,
+      deleteSession: async (h) => { deletes.push(h); resolveDel(); },
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${EXPIRED_TOKEN}` },
+    });
+    expect(res.status).toBe(401);
+    await deleteDone;
+    expect(deletes).toEqual([EXPIRED_HASH]);
+    await close();
+  });
+
+  it('does NOT call deleteSession when token simply does not match', async () => {
+    const calls: string[] = [];
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async () => null,
+      deleteSession:          async (h) => { calls.push(h); },
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${'f'.repeat(64)}` },
+    });
+    expect(res.status).toBe(401);
+    expect(calls).toEqual([]);
+    await close();
+  });
 });
 
 // ── Alias: /v1/me → /v1/auth/me ───────────────────────────────────────────────


### PR DESCRIPTION
Five small backend-only commits, all additive, all tested locally.

## Production fix
1. **fix(auth): /v1/auth/me opportunistically deletes expired session rows.**
   Previously, every call against an expired-but-still-stored session left the row in the DB. Sessions table grew unboundedly with stale garbage. `meController` now fires `deleteSession(tokenHash)` (fire-and-forget, errors swallowed) when it detects an expired row, and still returns 401. Pure ops hygiene; no contract change.

## Regression-guard tests
2. **test(api): X-Request-Id presence on 200 / 405 / multi-call** — three asserts covering the ops-aid header.
3. **test(api): csrf 403 still carries security + request-id headers** — pins the early-return order so a refactor can't silently drop the defensive headers.
4. **test(api): Cache-Control: no-store on every JSON response** — covers happy path + 404.
5. **test(api): Allow header on 405 lists actual supported methods** — RFC 7231 compliance.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → **382/382 ✓**
- `pnpm typecheck` ✓ · `pnpm build` ✓

## Commits
1. `6a1859a` fix(auth): /v1/auth/me cleans up expired session rows opportunistically
2. `e054ebf` test(api): cover X-Request-Id presence on 200 / 405 / multi-call
3. `b7604fd` test(api): csrf 403 still carries security + request-id headers
4. `dd40bc6` test(api): assert Cache-Control: no-store on every JSON response
5. `149df68` test(api): assert Allow header on 405 lists actual supported methods