### PR TITLE
chore(api): backend batch 2 — cancel upstream stream on client disconnect + sentry coverage

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -84,7 +84,7 @@ export interface MessagesDeps {
   findChatWindow:    (chatWindowId: string, userId: string) => Promise<DbChatWindow | null>;
   getApiKey:         (userId: string, provider: AIProvider) => Promise<string | null>;
   generate:          (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string) => Promise<ChatCompletionResult>;
-  generateStream:    (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string) => AsyncIterable<ChatCompletionStreamChunk>;
+  generateStream:    (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string, opts?: { signal?: AbortSignal }) => AsyncIterable<ChatCompletionStreamChunk>;
   maxContextMessages: number;
   providerTimeoutMs?: number;
 }
@@ -99,7 +99,7 @@ export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps
     findChatWindow:    (chatWindowId, userId)              => chatWindowsRepo.findChatWindowById(db, chatWindowId, userId),
     getApiKey:         (userId, provider)                  => getDecryptedApiKey(db, userId, provider),
     generate:          (provider, apiKey, msgs, model)     => getProviderClient(provider, apiKey).createChatCompletion(msgs, model),
-    generateStream:    (provider, apiKey, msgs, model)     => getProviderClient(provider, apiKey).createChatCompletionStream(msgs, model),
+    generateStream:    (provider, apiKey, msgs, model, opts) => getProviderClient(provider, apiKey).createChatCompletionStream(msgs, model, opts),
     maxContextMessages: env.openaiMaxContextMessages,
   };
 }
@@ -313,10 +313,17 @@ export async function streamMessageDbController(
   let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
   let aborted = false;
 
-  ctx.req.on('close', () => { aborted = true; });
+  // Cancel the upstream provider call when the downstream client drops the
+  // connection — stops billing for tokens nobody will read. The for-await
+  // loop will throw on read; we catch the abort below and return cleanly.
+  const upstreamAbort = new AbortController();
+  ctx.req.on('close', () => {
+    aborted = true;
+    upstreamAbort.abort();
+  });
 
   try {
-    for await (const chunk of deps.generateStream(cw.provider, apiKey, contextMessages, cw.model)) {
+    for await (const chunk of deps.generateStream(cw.provider, apiKey, contextMessages, cw.model, { signal: upstreamAbort.signal })) {
       if (aborted) break;
       if (chunk.type === 'delta') {
         assistantContent += chunk.content;
@@ -327,6 +334,13 @@ export async function streamMessageDbController(
       }
     }
   } catch (err) {
+    // Aborted-by-us (client disconnected) is not a real error — the for-await
+    // throw happens because we asked the upstream to stop. Don't ship an
+    // 'error' SSE event (the client is gone anyway) and don't capture it.
+    if (aborted) {
+      try { res.end(); } catch { /* socket already closed */ }
+      return respondStreamed(499);
+    }
     captureException(err, { provider: cw.provider, model: cw.model, route: '/v1/messages/stream' });
     const detail = err instanceof Error ? err.message : 'Unknown provider error';
     sseWrite(res, { error: detail });

--- a/apps/api/src/lib/sentry.test.ts
+++ b/apps/api/src/lib/sentry.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { captureException, flushSentry, isSentryEnabled } from './sentry.js';
+
+describe('lib/sentry — uninitialized (no DSN)', () => {
+  it('isSentryEnabled is false in test env (no SENTRY_DSN_API)', () => {
+    expect(isSentryEnabled()).toBe(false);
+  });
+
+  it('captureException is a no-op when uninitialized — never throws, never blocks', () => {
+    expect(() => captureException(new Error('boom'))).not.toThrow();
+    expect(() => captureException(new Error('boom'), { provider: 'openai' })).not.toThrow();
+    expect(() => captureException('not even an Error')).not.toThrow();
+  });
+
+  it('flushSentry resolves immediately when uninitialized', async () => {
+    const startedAt = Date.now();
+    await flushSentry(2_000);
+    expect(Date.now() - startedAt).toBeLessThan(100);
+  });
+});

--- a/apps/api/src/providers/anthropic.provider.ts
+++ b/apps/api/src/providers/anthropic.provider.ts
@@ -145,11 +145,15 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
     async *createChatCompletionStream(
       messages: ChatMessage[],
       model: string,
+      opts?: { signal?: AbortSignal },
     ): AsyncIterable<ChatCompletionStreamChunk> {
       const shape = toAnthropicShape(messages);
 
       const connectController = new AbortController();
       const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
+      const fetchSignal = opts?.signal
+        ? AbortSignal.any([connectController.signal, opts.signal])
+        : connectController.signal;
       let res: Response;
       try {
         res = await fetch(ANTHROPIC_MESSAGES_URL, {
@@ -167,7 +171,7 @@ export function createAnthropicClient(apiKey: string): ProviderClient {
             messages: shape.messages,
             stream: true,
           }),
-          signal: connectController.signal,
+          signal: fetchSignal,
         });
       } catch (err) {
         throw new ProviderError(

--- a/apps/api/src/providers/openai.provider.ts
+++ b/apps/api/src/providers/openai.provider.ts
@@ -135,12 +135,19 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
     async *createChatCompletionStream(
       messages: ChatMessage[],
       model: string,
+      opts?: { signal?: AbortSignal },
     ): AsyncIterable<ChatCompletionStreamChunk> {
       // Connect-only timeout: aborts the fetch if response headers haven't
       // arrived after STREAM_CONNECT_TIMEOUT_MS. Cleared once headers land
       // so a long legitimate stream is never cut.
+      // The caller-supplied opts.signal also propagates: when it aborts (e.g.
+      // the downstream HTTP client disconnected), the fetch body read throws
+      // and the for-await below ends — releasing the upstream socket.
       const connectController = new AbortController();
       const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
+      const fetchSignal = opts?.signal
+        ? AbortSignal.any([connectController.signal, opts.signal])
+        : connectController.signal;
       let res: Response;
       try {
         res = await fetch(OPENAI_CHAT_URL, {
@@ -156,7 +163,7 @@ export function createOpenAIClient(apiKey: string): ProviderClient {
             stream: true,
             stream_options: { include_usage: true },
           }),
-          signal: connectController.signal,
+          signal: fetchSignal,
         });
       } catch (err) {
         throw new ProviderError(

--- a/apps/api/src/providers/perplexity.provider.ts
+++ b/apps/api/src/providers/perplexity.provider.ts
@@ -137,9 +137,13 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
     async *createChatCompletionStream(
       messages: ChatMessage[],
       model: string,
+      opts?: { signal?: AbortSignal },
     ): AsyncIterable<ChatCompletionStreamChunk> {
       const connectController = new AbortController();
       const connectTimer = setTimeout(() => connectController.abort(), STREAM_CONNECT_TIMEOUT_MS);
+      const fetchSignal = opts?.signal
+        ? AbortSignal.any([connectController.signal, opts.signal])
+        : connectController.signal;
       let res: Response;
       try {
         res = await fetch(PERPLEXITY_CHAT_URL, {
@@ -150,7 +154,7 @@ export function createPerplexityClient(apiKey: string): ProviderClient {
             'Accept':        'text/event-stream',
           },
           body: JSON.stringify({ model, messages, stream: true }),
-          signal: connectController.signal,
+          signal: fetchSignal,
         });
       } catch (err) {
         throw new ProviderError(

--- a/apps/api/src/providers/provider.interface.ts
+++ b/apps/api/src/providers/provider.interface.ts
@@ -25,6 +25,12 @@ export type ChatCompletionStreamChunk =
 
 // ── Provider client contract ──────────────────────────────────────────────────
 
+export interface StreamOptions {
+  /** Abort the upstream stream early. Useful when the downstream client
+   *  disconnects so we stop billing for tokens nobody will read. */
+  signal?: AbortSignal;
+}
+
 export interface ProviderClient {
   createChatCompletion(
     messages: ChatMessage[],
@@ -34,6 +40,7 @@ export interface ProviderClient {
   createChatCompletionStream(
     messages: ChatMessage[],
     model: string,
+    opts?: StreamOptions,
   ): AsyncIterable<ChatCompletionStreamChunk>;
 }
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -678,4 +678,26 @@ describe('POST /v1/messages/stream — authenticated', () => {
     expect(res.status).toBe(404);
     await close();
   });
+
+  it('passes an AbortSignal opts.signal to generateStream so client disconnect can cancel upstream', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      generateStream: async function* (_p, _k, _msgs, _model, opts) {
+        receivedSignal = opts?.signal;
+        yield { type: 'delta',  content: 'x' };
+        yield { type: 'done',   model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } };
+      },
+      persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) =>
+        mockPair(chatWindowId, userContent, assistantContent),
+    }));
+    const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hi' });
+    expect(res.status).toBe(200);
+    await readSseEvents(res); // drain
+    expect(receivedSignal).toBeInstanceOf(AbortSignal);
+    await close();
+  });
 });


### PR DESCRIPTION
Three small backend-only commits, one production fix + two tests.

## Production fix
1. **fix(api): cancel upstream provider stream on client disconnect.**
   `/v1/messages/stream` previously flagged `aborted` on `req.on('close')` and broke its for-await loop, but the underlying provider fetch kept draining tokens — paid keys were billed for completions nobody read. The streaming path now threads an `AbortController` from the controller down through `MessagesDeps.generateStream` into the provider client, where it merges with the existing connect-only signal via `AbortSignal.any`. Closing the tab now releases the upstream socket within one event-loop tick.

   Additive interface change: `ProviderClient.createChatCompletionStream` accepts an optional `opts: { signal?: AbortSignal }`. All existing callers pass nothing and behave identically.

   Aborted-by-us is detected in the catch block: no SSE error event (client is gone), no Sentry capture, return 499.

## Tests
2. **test(api): /v1/messages/stream passes opts.signal to generateStream.** Locks the controller→dep contract so a future refactor can't silently drop the cancellation hook.
3. **test(lib): cover sentry no-op behaviour when DSN is absent.** 3 tests asserting `isSentryEnabled()` false, `captureException` never throws, `flushSentry` returns immediately.

## Checks
- `pnpm --filter @webapp/api typecheck` ✓
- `pnpm --filter @webapp/api test` → **386/386 ✓**
- `pnpm typecheck` ✓ · `pnpm build` ✓

## Commits
1. `16aefc8` fix(api): cancel upstream provider stream on client disconnect
2. `a18f6d9` test(api): /v1/messages/stream passes opts.signal to generateStream
3. `e0d20ae` test(lib): cover sentry no-op behaviour when DSN is absent