### PR TITLE
feat(web): in-chat search (Find toggle, highlight, match count, clear)

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
 } from 'react';
 import type { AIProvider } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
@@ -62,9 +63,18 @@ export function ChatWindow({
   const [draft, setDraft] = useState<string>(() => readDraft(draftStorageKey));
   const [editing, setEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState(title);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickyRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const trimmedQuery = searchQuery.trim();
+  const lowerQuery = trimmedQuery.toLowerCase();
+  const filteredMessages = lowerQuery
+    ? messages.filter((m) => m.content.toLowerCase().includes(lowerQuery))
+    : messages;
+  const matchCount = lowerQuery ? filteredMessages.length : 0;
   const messagesSignature = messages
     .map((m) => `${m.id}:${m.content.length}:${m.status ?? 'ok'}`)
     .join('|');
@@ -201,6 +211,40 @@ export function ChatWindow({
           <ProviderBadge provider={provider} model={model} />
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSearchOpen((v) => {
+                const next = !v;
+                if (next) {
+                  requestAnimationFrame(() => searchInputRef.current?.focus());
+                } else {
+                  setSearchQuery('');
+                }
+                return next;
+              });
+            }}
+            aria-label={searchOpen ? 'Close search' : 'Find in chat'}
+            aria-pressed={searchOpen}
+            title={searchOpen ? 'Close search' : 'Find in chat'}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: searchOpen ? '#9aa6ff' : '#8a8a95',
+              cursor: 'pointer',
+              fontSize: '0.7rem',
+              fontWeight: 500,
+              padding: '0.25rem 0.5rem',
+              borderRadius: 6,
+              lineHeight: 1,
+              fontFamily: 'inherit',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            Find
+          </button>
           {onDelete ? (
             <button
               type="button"
@@ -261,6 +305,72 @@ export function ChatWindow({
         </div>
       </div>
 
+      {searchOpen ? (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '0.45rem 0.75rem',
+            borderBottom: '1px solid #24242c',
+            background: '#10101a',
+          }}
+        >
+          <input
+            ref={searchInputRef}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setSearchQuery('');
+                setSearchOpen(false);
+              }
+            }}
+            onClick={(e) => e.stopPropagation()}
+            placeholder="Find in chat…"
+            aria-label="Find in chat"
+            style={{
+              flex: 1,
+              background: '#1b1b23',
+              border: '1px solid #2a2a30',
+              borderRadius: 6,
+              padding: '0.35rem 0.55rem',
+              color: '#f5f5f5',
+              fontSize: '0.8rem',
+              fontFamily: 'inherit',
+              outline: 'none',
+            }}
+          />
+          {trimmedQuery ? (
+            <span style={{ fontSize: '0.7rem', color: '#8a8a95' }} aria-live="polite">
+              {matchCount} {matchCount === 1 ? 'match' : 'matches'}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setSearchQuery('');
+              setSearchOpen(false);
+            }}
+            aria-label="Close search"
+            style={{
+              background: 'transparent',
+              border: '1px solid #2a2a30',
+              color: '#cfcfd6',
+              borderRadius: 6,
+              padding: '2px 8px',
+              fontSize: '0.7rem',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+            }}
+          >
+            Close
+          </button>
+        </div>
+      ) : null}
+
       <div
         ref={scrollRef}
         onScroll={updateStickiness}
@@ -293,11 +403,23 @@ export function ChatWindow({
               Type below — Enter to send, Shift+Enter for a newline.
             </div>
           </div>
+        ) : lowerQuery && filteredMessages.length === 0 ? (
+          <div
+            style={{
+              margin: 'auto',
+              textAlign: 'center',
+              color: '#8a8a95',
+              fontSize: '0.85rem',
+            }}
+          >
+            No messages match &ldquo;{trimmedQuery}&rdquo;.
+          </div>
         ) : (
-          messages.map((m) => (
+          filteredMessages.map((m) => (
             <MessageBubble
               key={m.id}
               message={m}
+              highlight={lowerQuery || undefined}
               onRetry={
                 onRetry && m.clientTempId ? () => onRetry(id, m.clientTempId!) : undefined
               }
@@ -492,10 +614,12 @@ function MessageBubble({
   message,
   onRetry,
   onRegenerate,
+  highlight,
 }: {
   message: MockMessage;
   onRetry?: () => void;
   onRegenerate?: () => void;
+  highlight?: string;
 }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
@@ -564,7 +688,7 @@ function MessageBubble({
           </span>
         )}
       </div>
-      {message.content}
+      {highlight ? renderWithHighlight(message.content, highlight) : message.content}
       {isStreaming && <StreamingCursor />}
       {isFailed && (
         <div
@@ -772,4 +896,36 @@ function writeDraft(key: string, value: string): void {
   } catch {
     // localStorage unavailable / quota exceeded; ignore
   }
+}
+
+function renderWithHighlight(content: string, query: string): ReactNode {
+  if (!query) return content;
+  const out: ReactNode[] = [];
+  const lowerContent = content.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let cursor = 0;
+  let key = 0;
+  while (cursor < content.length) {
+    const idx = lowerContent.indexOf(lowerQuery, cursor);
+    if (idx < 0) {
+      out.push(content.slice(cursor));
+      break;
+    }
+    if (idx > cursor) out.push(content.slice(cursor, idx));
+    out.push(
+      <mark
+        key={key++}
+        style={{
+          background: '#4f6bff44',
+          color: 'inherit',
+          borderRadius: 2,
+          padding: '0 1px',
+        }}
+      >
+        {content.slice(idx, idx + query.length)}
+      </mark>,
+    );
+    cursor = idx + query.length;
+  }
+  return out;
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -327,32 +327,62 @@ export function ChatWindow({
             background: '#10101a',
           }}
         >
-          <input
-            ref={searchInputRef}
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setSearchQuery('');
-                setSearchOpen(false);
-              }
-            }}
-            onClick={(e) => e.stopPropagation()}
-            placeholder="Find in chat…"
-            aria-label="Find in chat"
-            style={{
-              flex: 1,
-              background: '#1b1b23',
-              border: '1px solid #2a2a30',
-              borderRadius: 6,
-              padding: '0.35rem 0.55rem',
-              color: '#f5f5f5',
-              fontSize: '0.8rem',
-              fontFamily: 'inherit',
-              outline: 'none',
-            }}
-          />
+          <div style={{ position: 'relative', flex: 1, display: 'flex' }}>
+            <input
+              ref={searchInputRef}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setSearchQuery('');
+                  setSearchOpen(false);
+                }
+              }}
+              onClick={(e) => e.stopPropagation()}
+              placeholder="Find in chat…"
+              aria-label="Find in chat"
+              style={{
+                flex: 1,
+                background: '#1b1b23',
+                border: '1px solid #2a2a30',
+                borderRadius: 6,
+                padding: '0.35rem 1.6rem 0.35rem 0.55rem',
+                color: '#f5f5f5',
+                fontSize: '0.8rem',
+                fontFamily: 'inherit',
+                outline: 'none',
+              }}
+            />
+            {searchQuery ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSearchQuery('');
+                  searchInputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                style={{
+                  position: 'absolute',
+                  top: '50%',
+                  right: 4,
+                  transform: 'translateY(-50%)',
+                  background: 'transparent',
+                  border: 'none',
+                  color: '#8a8a95',
+                  cursor: 'pointer',
+                  fontSize: '0.95rem',
+                  lineHeight: 1,
+                  padding: '2px 6px',
+                  borderRadius: 4,
+                  fontFamily: 'inherit',
+                }}
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
           {trimmedQuery ? (
             <span style={{ fontSize: '0.7rem', color: '#8a8a95' }} aria-live="polite">
               {matchCount} {matchCount === 1 ? 'match' : 'matches'}

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -104,6 +104,17 @@ export function ChatWindow({
     writeDraft(draftStorageKey, draft);
   }, [draft, draftStorageKey]);
 
+  useEffect(() => {
+    if (!lowerQuery) return;
+    const first = filteredMessages[0];
+    if (!first) return;
+    const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(first.id)}`);
+    if (el && 'scrollIntoView' in el) {
+      (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'auto' });
+    }
+    stickyRef.current = false;
+  }, [lowerQuery, filteredMessages]);
+
   const commitRename = () => {
     const trimmed = titleDraft.trim();
     if (trimmed && trimmed !== title) onRename?.(id, trimmed);
@@ -932,4 +943,11 @@ function renderWithHighlight(content: string, query: string): ReactNode {
     cursor = idx + query.length;
   }
   return out;
+}
+
+function cssEscapeId(id: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(id);
+  }
+  return id.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -648,6 +648,9 @@ function MessageBubble({
 
   return (
     <div
+      id={`msg-${message.id}`}
+      data-role={message.role}
+      data-status={status}
       style={{
         alignSelf: isUser ? 'flex-end' : 'flex-start',
         maxWidth: '85%',
@@ -660,6 +663,7 @@ function MessageBubble({
         color: '#e8e8ef',
         whiteSpace: 'pre-wrap',
         opacity,
+        scrollMarginTop: 16,
       }}
     >
       <div


### PR DESCRIPTION
Adds a per-window message search inside ChatWindow. Cohesive feature, no backend.

## What
- **Find toggle** — new `Find` button in the chat window header (next to Delete / Close). `aria-pressed` reflects state. Active state colored to match the active-window accent.
- **Search bar** — appears between the header and the message list when toggled. Placeholder `Find in chat…`, live filter as you type.
- **Filtered list** — only matches render; matches inside content are wrapped in `<mark>` tiles (translucent accent fill, color: inherit).
- **Match count** — `aria-live` chip ("3 matches") next to the input.
- **Clear (×)** — non-empty queries show a × inside the input. Click clears, refocuses, keeps the bar open.
- **Esc** — clears the query and closes the search bar (works whether focus is inside the input or via the existing modal-Esc pattern).
- **Auto-scroll** — when a query is set, the first match scrolls to the top of the visible area; `stickyRef` is flipped to false so a streaming token can't yank the view back to the bottom while the user reviews matches.
- **Empty filter state** — `No messages match "<query>".` centered.
- **Stable anchors** — every `MessageBubble` now renders with `id="msg-<message.id>"`, `data-role`, `data-status`, and `scrollMarginTop: 16`. Useful for the search auto-scroll today, and for shareable message links / e2e selectors later.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx` (only)

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Pure client-side filter on the existing `messages` prop. Highlighter is a small string-walking helper — no regex, no escaping issues. No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)