### PR TITLE
feat(web): chat search extras (prev/next nav, Cmd-F, copy-link, hash anchor, persisted query)

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -65,6 +65,7 @@ export function ChatWindow({
   const [titleDraft, setTitleDraft] = useState(title);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchIndex, setSearchIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickyRef = useRef(true);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -75,6 +76,8 @@ export function ChatWindow({
     ? messages.filter((m) => m.content.toLowerCase().includes(lowerQuery))
     : messages;
   const matchCount = lowerQuery ? filteredMessages.length : 0;
+  const safeIndex = matchCount > 0 ? Math.min(searchIndex, matchCount - 1) : 0;
+  const activeMatchId = matchCount > 0 ? filteredMessages[safeIndex]?.id ?? null : null;
   const messagesSignature = messages
     .map((m) => `${m.id}:${m.content.length}:${m.status ?? 'ok'}`)
     .join('|');
@@ -105,15 +108,17 @@ export function ChatWindow({
   }, [draft, draftStorageKey]);
 
   useEffect(() => {
-    if (!lowerQuery) return;
-    const first = filteredMessages[0];
-    if (!first) return;
-    const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(first.id)}`);
+    if (!lowerQuery || !activeMatchId) return;
+    const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(activeMatchId)}`);
     if (el && 'scrollIntoView' in el) {
       (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'auto' });
     }
     stickyRef.current = false;
-  }, [lowerQuery, filteredMessages]);
+  }, [lowerQuery, activeMatchId]);
+
+  useEffect(() => {
+    setSearchIndex(0);
+  }, [lowerQuery]);
 
   const commitRename = () => {
     const trimmed = titleDraft.trim();
@@ -337,6 +342,14 @@ export function ChatWindow({
                   e.preventDefault();
                   setSearchQuery('');
                   setSearchOpen(false);
+                  return;
+                }
+                if (e.key === 'Enter' && matchCount > 0) {
+                  e.preventDefault();
+                  setSearchIndex((i) => {
+                    const n = matchCount;
+                    return e.shiftKey ? (i - 1 + n) % n : (i + 1) % n;
+                  });
                 }
               }}
               onClick={(e) => e.stopPropagation()}
@@ -384,9 +397,39 @@ export function ChatWindow({
             ) : null}
           </div>
           {trimmedQuery ? (
-            <span style={{ fontSize: '0.7rem', color: '#8a8a95' }} aria-live="polite">
-              {matchCount} {matchCount === 1 ? 'match' : 'matches'}
-            </span>
+            <>
+              <span style={{ fontSize: '0.7rem', color: '#8a8a95' }} aria-live="polite">
+                {matchCount > 0
+                  ? `${safeIndex + 1} of ${matchCount}`
+                  : '0 matches'}
+              </span>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (matchCount > 0) setSearchIndex((i) => (i - 1 + matchCount) % matchCount);
+                }}
+                disabled={matchCount === 0}
+                aria-label="Previous match"
+                title="Previous match (Shift+Enter)"
+                style={searchNavButtonStyle}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (matchCount > 0) setSearchIndex((i) => (i + 1) % matchCount);
+                }}
+                disabled={matchCount === 0}
+                aria-label="Next match"
+                title="Next match (Enter)"
+                style={searchNavButtonStyle}
+              >
+                ↓
+              </button>
+            </>
           ) : null}
           <button
             type="button"
@@ -461,6 +504,7 @@ export function ChatWindow({
               key={m.id}
               message={m}
               highlight={lowerQuery || undefined}
+              isActiveMatch={activeMatchId === m.id}
               onRetry={
                 onRetry && m.clientTempId ? () => onRetry(id, m.clientTempId!) : undefined
               }
@@ -656,11 +700,13 @@ function MessageBubble({
   onRetry,
   onRegenerate,
   highlight,
+  isActiveMatch,
 }: {
   message: MockMessage;
   onRetry?: () => void;
   onRegenerate?: () => void;
   highlight?: string;
+  isActiveMatch?: boolean;
 }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
@@ -696,7 +742,8 @@ function MessageBubble({
         alignSelf: isUser ? 'flex-end' : 'flex-start',
         maxWidth: '85%',
         background: isUser ? '#2b2b36' : '#1b1b23',
-        border: `1px solid ${borderColor}`,
+        border: `1px solid ${isActiveMatch ? '#4f6bff' : borderColor}`,
+        boxShadow: isActiveMatch ? '0 0 0 1px rgba(79,107,255,0.45)' : 'none',
         borderRadius: 10,
         padding: '0.55rem 0.75rem',
         fontSize: '0.85rem',
@@ -705,6 +752,7 @@ function MessageBubble({
         whiteSpace: 'pre-wrap',
         opacity,
         scrollMarginTop: 16,
+        transition: 'border-color 120ms ease, box-shadow 120ms ease',
       }}
     >
       <div
@@ -880,6 +928,18 @@ function MessageActions({
     </div>
   );
 }
+
+const searchNavButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #2a2a30',
+  color: '#cfcfd6',
+  borderRadius: 6,
+  padding: '2px 6px',
+  fontSize: '0.7rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  minWidth: 26,
+};
 
 const messageActionButton: React.CSSProperties = {
   background: 'transparent',

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -120,6 +120,22 @@ export function ChatWindow({
     setSearchIndex(0);
   }, [lowerQuery]);
 
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault();
+        setSearchOpen(true);
+        requestAnimationFrame(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active]);
+
   const commitRename = () => {
     const trimmed = titleDraft.trim();
     if (trimmed && trimmed !== title) onRename?.(id, trimmed);

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -63,8 +63,11 @@ export function ChatWindow({
   const [draft, setDraft] = useState<string>(() => readDraft(draftStorageKey));
   const [editing, setEditing] = useState(false);
   const [titleDraft, setTitleDraft] = useState(title);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const searchStorageKey = `wav.chat.search.${id}`;
+  const [searchOpen, setSearchOpen] = useState<boolean>(() =>
+    readSearchQuery(searchStorageKey).length > 0,
+  );
+  const [searchQuery, setSearchQuery] = useState<string>(() => readSearchQuery(searchStorageKey));
   const [searchIndex, setSearchIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickyRef = useRef(true);
@@ -119,6 +122,10 @@ export function ChatWindow({
   useEffect(() => {
     setSearchIndex(0);
   }, [lowerQuery]);
+
+  useEffect(() => {
+    writeSearchQuery(searchStorageKey, searchQuery);
+  }, [searchStorageKey, searchQuery]);
 
   const [flashedMsgId, setFlashedMsgId] = useState<string | null>(null);
   useEffect(() => {
@@ -1114,4 +1121,23 @@ function cssEscapeId(id: string): string {
     return CSS.escape(id);
   }
   return id.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+function readSearchQuery(key: string): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.sessionStorage.getItem(key) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function writeSearchQuery(key: string, value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value) window.sessionStorage.setItem(key, value);
+    else window.sessionStorage.removeItem(key);
+  } catch {
+    // sessionStorage unavailable / quota; ignore
+  }
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -852,6 +852,7 @@ function MessageBubble({
         </div>
       )}
       <MessageActions
+        messageId={message.id}
         content={message.content}
         absoluteStamp={absoluteStamp}
         relativeStamp={relativeStamp}
@@ -864,6 +865,7 @@ function MessageBubble({
 }
 
 function MessageActions({
+  messageId,
   content,
   absoluteStamp,
   relativeStamp,
@@ -871,6 +873,7 @@ function MessageActions({
   onRegenerate,
   align,
 }: {
+  messageId: string;
   content: string;
   absoluteStamp: string | null;
   relativeStamp: string | null;
@@ -879,26 +882,45 @@ function MessageActions({
   align: 'start' | 'end';
 }) {
   const [copied, setCopied] = useState(false);
+  const [linkCopied, setLinkCopied] = useState(false);
+  const writeToClipboard = async (value: string): Promise<void> => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return;
+    }
+    if (typeof document !== 'undefined') {
+      const ta = document.createElement('textarea');
+      ta.value = value;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  };
   const onCopy = async (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     if (!canCopy) return;
     try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(content);
-      } else if (typeof document !== 'undefined') {
-        const ta = document.createElement('textarea');
-        ta.value = content;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
-        ta.select();
-        document.execCommand('copy');
-        document.body.removeChild(ta);
-      }
+      await writeToClipboard(content);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {
       // ignore — feedback simply won't show
+    }
+  };
+  const onCopyLink = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (typeof window === 'undefined') return;
+    try {
+      const base = `${window.location.origin}${window.location.pathname}${window.location.search}`;
+      const link = `${base}#msg-${messageId}`;
+      await writeToClipboard(link);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 1500);
+    } catch {
+      // ignore
     }
   };
   return (
@@ -927,6 +949,15 @@ function MessageActions({
           {copied ? 'Copied' : 'Copy'}
         </button>
       ) : null}
+      <button
+        type="button"
+        onClick={onCopyLink}
+        aria-label="Copy link to this message"
+        title="Copy link to this message"
+        style={messageActionButton}
+      >
+        {linkCopied ? 'Link copied' : 'Copy link'}
+      </button>
       {onRegenerate ? (
         <button
           type="button"

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -120,6 +120,25 @@ export function ChatWindow({
     setSearchIndex(0);
   }, [lowerQuery]);
 
+  const [flashedMsgId, setFlashedMsgId] = useState<string | null>(null);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const hash = window.location.hash;
+    if (!hash || !hash.startsWith('#msg-')) return;
+    const targetId = hash.slice(5);
+    const exists = messages.some((m) => m.id === targetId);
+    if (!exists) return;
+    const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(targetId)}`);
+    if (el && 'scrollIntoView' in el) {
+      (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'auto' });
+    }
+    stickyRef.current = false;
+    setFlashedMsgId(targetId);
+    const t = setTimeout(() => setFlashedMsgId(null), 1500);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messagesSignature]);
+
   useEffect(() => {
     if (!active) return;
     const onKey = (e: globalThis.KeyboardEvent) => {
@@ -521,6 +540,7 @@ export function ChatWindow({
               message={m}
               highlight={lowerQuery || undefined}
               isActiveMatch={activeMatchId === m.id}
+              isFlashing={flashedMsgId === m.id}
               onRetry={
                 onRetry && m.clientTempId ? () => onRetry(id, m.clientTempId!) : undefined
               }
@@ -717,12 +737,14 @@ function MessageBubble({
   onRegenerate,
   highlight,
   isActiveMatch,
+  isFlashing,
 }: {
   message: MockMessage;
   onRetry?: () => void;
   onRegenerate?: () => void;
   highlight?: string;
   isActiveMatch?: boolean;
+  isFlashing?: boolean;
 }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
@@ -758,8 +780,13 @@ function MessageBubble({
         alignSelf: isUser ? 'flex-end' : 'flex-start',
         maxWidth: '85%',
         background: isUser ? '#2b2b36' : '#1b1b23',
-        border: `1px solid ${isActiveMatch ? '#4f6bff' : borderColor}`,
-        boxShadow: isActiveMatch ? '0 0 0 1px rgba(79,107,255,0.45)' : 'none',
+        border: `1px solid ${isActiveMatch || isFlashing ? '#4f6bff' : borderColor}`,
+        boxShadow:
+          isFlashing
+            ? '0 0 0 3px rgba(79,107,255,0.45)'
+            : isActiveMatch
+              ? '0 0 0 1px rgba(79,107,255,0.45)'
+              : 'none',
         borderRadius: 10,
         padding: '0.55rem 0.75rem',
         fontSize: '0.85rem',


### PR DESCRIPTION
Builds on the in-chat search shipped in #136. Each commit is a self-contained slice.

## What
- **Prev/next match navigation** — `searchIndex` state. Enter = next, Shift+Enter = previous (wrap). New ↑/↓ buttons next to the counter (`aria-label`, kbd hint via `title`). Counter copy is now `<i> of <n>` instead of `<n> matches`. Active match's bubble gets the same accent border + soft halo used for the active window, transitioned smoothly. `scrollIntoView` follows the active match.
- **Cmd / Ctrl + F** — focuses the Find input of the **active** window (the only listener wired). Opens the search bar if closed, focuses the input, selects existing text. Suppresses the browser native find.
- **Copy link** — every `MessageBubble` exposes a `Copy link` pill. Builds `<origin><pathname><search>#msg-<id>` and writes it to clipboard with the same fallback as `Copy`. Inline label flips to `Link copied` for 1.5s.
- **`#msg-<id>` hash anchor** — when ChatWindow's messages settle, it looks at `window.location.hash`. If it points at a real message in this window, the bubble is scrolled to top + flashed with a thicker accent halo for ~1.5s so the user sees the landing.
- **Search query persistence** — search query stored under `wav.chat.search.<windowId>` in `sessionStorage` (per-tab). On mount the search bar opens automatically if a query is restored. Cleared when the user clears or closes search. Quota-safe.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx` (only)

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
Pure client-side. No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)