### PR TITLE
Backend stream hardening: client-disconnect fix + SSE flush + sentinel guards

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -331,6 +331,15 @@ export async function streamMessageDbController(
       upstreamAbort.abort();
     }
   });
+  // A mid-stream socket error (ECONNRESET, EPIPE) emits 'error' on the
+  // ServerResponse. With no listener, Node treats it as unhandled and the
+  // process can crash. Treat it like a client disconnect: cancel upstream,
+  // mark aborted, and swallow — the catch block downstream will see the
+  // for-await throw and exit cleanly.
+  res.on('error', () => {
+    aborted = true;
+    upstreamAbort.abort();
+  });
 
   try {
     for await (const chunk of deps.generateStream(cw.provider, apiKey, contextMessages, cw.model, { signal: upstreamAbort.signal })) {

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -321,10 +321,15 @@ export async function streamMessageDbController(
   // Cancel the upstream provider call when the downstream client drops the
   // connection — stops billing for tokens nobody will read. The for-await
   // loop will throw on read; we catch the abort below and return cleanly.
+  // We listen on `res` (not `req`) because once the request body has been
+  // fully read, Node's IncomingMessage 'close' event does not fire on
+  // mid-response socket teardown — only the ServerResponse 'close' does.
   const upstreamAbort = new AbortController();
-  ctx.req.on('close', () => {
-    aborted = true;
-    upstreamAbort.abort();
+  res.on('close', () => {
+    if (!res.writableEnded) {
+      aborted = true;
+      upstreamAbort.abort();
+    }
   });
 
   try {

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -306,6 +306,11 @@ export async function streamMessageDbController(
     'X-Accel-Buffering': 'no',
     'X-Request-Id': ctx.requestId,
   });
+  // Ship headers immediately so reverse proxies / browsers see the SSE
+  // content-type before the first delta arrives — otherwise Node may buffer
+  // the response start until enough body is queued, and proxies that
+  // sniff content-type can decide to buffer the whole response.
+  res.flushHeaders();
 
   const startedAt = Date.now();
   let assistantContent = '';

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -640,6 +640,11 @@ describe('POST /v1/messages/stream — authenticated', () => {
       .map((e) => JSON.parse(e) as { error?: string })
       .find((e) => typeof e.error === 'string');
     expect(errEvent?.error).toContain('upstream boom');
+    // Error path must still terminate the SSE stream with [DONE] as the final
+    // sentinel so clients exit their read loop instead of hanging until the
+    // socket closes.
+    expect(events).toContain('[DONE]');
+    expect(events[events.length - 1]).toBe('[DONE]');
     expect(persisted).toBe(false);
     await close();
   });

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -708,4 +708,52 @@ describe('POST /v1/messages/stream — authenticated', () => {
     expect(receivedSignal).toBeInstanceOf(AbortSignal);
     await close();
   });
+
+  it('aborts the upstream signal when the client disconnects mid-stream', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let persisted = false;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      generateStream: async function* (_p, _k, _msgs, _model, opts) {
+        capturedSignal = opts?.signal;
+        yield { type: 'delta', content: 'first' };
+        // Park here until the controller propagates the client disconnect
+        // via the abort signal. If the wiring is broken, this hangs and the
+        // test times out — that's exactly the regression we want to catch.
+        await new Promise<void>((resolve, reject) => {
+          if (opts?.signal?.aborted) return resolve();
+          opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+          setTimeout(() => reject(new Error('signal never aborted')), 2_000);
+        });
+      },
+      persistMessagePair: async () => { persisted = true; return null; },
+    }));
+    // Use a request-level AbortController so we can tear the TCP socket down
+    // mid-stream — mirrors the browser closing the tab. (reader.cancel alone
+    // doesn't reliably close the keep-alive socket under undici.)
+    const ac = new AbortController();
+    const res = await fetch(`${baseUrl}/v1/messages/stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Connection': 'close' },
+      body: JSON.stringify({ chatWindowId: 'cw-1', role: 'user', content: 'hi' }),
+      signal: ac.signal,
+    });
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error('no body');
+    const reader = res.body.getReader();
+    // Read the first chunk so the generator is parked, then abort.
+    await reader.read();
+    try { await reader.cancel(); } catch { /* expected */ }
+    ac.abort();
+    for (let i = 0; i < 100; i++) {
+      if (capturedSignal?.aborted) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(persisted).toBe(false);
+    await close();
+  });
 });

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -606,6 +606,9 @@ describe('POST /v1/messages/stream — authenticated', () => {
     const events = await readSseEvents(res);
     // Two deltas + final done payload + literal [DONE].
     expect(events).toContain('[DONE]');
+    // [DONE] must be the last sentinel — clients break out of their read loop on it,
+    // so anything emitted after [DONE] would be silently dropped.
+    expect(events[events.length - 1]).toBe('[DONE]');
     const deltas = events
       .filter((e) => e !== '[DONE]')
       .map((e) => JSON.parse(e) as { delta?: string; done?: boolean });


### PR DESCRIPTION
## Summary

Five-commit batch hardening the `/v1/messages/stream` SSE endpoint. The headline change is a real production bug fix: provider streams kept billing tokens after the client disconnected, because Node's `IncomingMessage` 'close' event doesn't fire reliably on socket teardown once the request body has been fully consumed.

### Commits

1. **`flushHeaders`** — ship SSE `Content-Type` + `X-Accel-Buffering: no` immediately so reverse proxies / browsers see them before the first delta, instead of letting Node buffer the response start until enough body is queued.
2. **`[DONE]` is last on success** — regression test locking that `[DONE]` is the final SSE sentinel emitted on the happy path. Anything after it is silently dropped by clients.
3. **`[DONE]` is last on error** — same guarantee on the provider-throws-mid-stream catch path. Without it, error-recovering clients hang on the read loop.
4. **Listen on `res`, not `req`, for client disconnect** — the production fix. Switches `ctx.req.on('close')` → `res.on('close')` (gated on `!res.writableEnded` so `res.end()` from normal completion doesn't trigger the abort path). Adds a regression test that parks the upstream generator on the abort signal and asserts it flips within the test budget — proves the cancel chain reaches the provider in production-equivalent conditions.
5. **Swallow `res 'error'`** — a mid-stream socket error (ECONNRESET, EPIPE) emits 'error' on the ServerResponse. With no listener, Node escalates it to unhandled and the API process can crash. Treat it like a client disconnect: cancel upstream and let the for-await throw exit cleanly.

### Why this matters

Before commit 4, the controller already threaded an `AbortSignal` through to each provider (merged in #135), but the signal never aborted in practice because the close detection was on the wrong event source. Paid OpenAI / Anthropic / Perplexity streams kept running and billing until they completed naturally.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 387 tests pass (was 386; new regression test added)
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)