### PR TITLE
feat(web): keyboard shortcuts overlay + composer focus shortcut + Help button

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import '@/styles/globals.css';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { KeyboardShortcutsOverlay } from '@/components/KeyboardShortcutsOverlay';
 import { ToastHost } from '@/components/ToastHost';
 import { SessionProvider } from '@/features/auth/SessionContext';
 
@@ -19,6 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <Suspense fallback={null}>
               <SessionProvider>{children}</SessionProvider>
             </Suspense>
+            <KeyboardShortcutsOverlay />
           </ToastHost>
         </ErrorBoundary>
       </body>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
+import { HelpButton } from '@/components/HelpButton';
 import { UserMenu } from '@/features/auth/UserMenu';
 
 interface AppShellProps {
@@ -46,6 +47,7 @@ export function AppShell({ title = 'AI Workspace V1', subtitle, right, children 
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
           {right}
+          <HelpButton />
           <UserMenu />
         </div>
       </header>

--- a/apps/web/src/components/HelpButton.tsx
+++ b/apps/web/src/components/HelpButton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+export function HelpButton() {
+  return (
+    <button
+      type="button"
+      aria-label="Show keyboard shortcuts"
+      title="Keyboard shortcuts (?)"
+      onClick={() => {
+        if (typeof window === 'undefined') return;
+        window.dispatchEvent(new Event('wav:toggle-shortcuts'));
+      }}
+      style={{
+        background: 'transparent',
+        border: '1px solid #2a2a30',
+        borderRadius: 999,
+        width: 26,
+        height: 26,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#cfcfd6',
+        fontSize: '0.85rem',
+        fontFamily: 'inherit',
+        cursor: 'pointer',
+      }}
+    >
+      ?
+    </button>
+  );
+}

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+const SHORTCUTS: Shortcut[] = [
+  { keys: ['?'], description: 'Show this help' },
+  { keys: ['Esc'], description: 'Close menus, modals, search bar, this help' },
+  { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
+  { keys: ['Enter'], description: 'In Find: jump to next match' },
+  { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
+  { keys: ['Enter'], description: 'In composer: send message' },
+];
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function KeyboardShortcutsOverlay() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (isTypingTarget(e.target)) return;
+        e.preventDefault();
+        setOpen((v) => !v);
+        return;
+      }
+      if (e.key === 'Escape' && open) {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="kbd-shortcuts-title"
+      onClick={() => setOpen(false)}
+      style={backdropStyle}
+    >
+      <div onClick={(e) => e.stopPropagation()} style={modalStyle}>
+        <div style={headerRow}>
+          <h2 id="kbd-shortcuts-title" style={{ margin: 0, fontSize: '1.05rem' }}>
+            Keyboard shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            aria-label="Close keyboard shortcuts"
+            style={closeButtonStyle}
+          >
+            ×
+          </button>
+        </div>
+        <ul style={listStyle}>
+          {SHORTCUTS.map((s, i) => (
+            <li key={i} style={rowStyle}>
+              <span style={keysCellStyle}>
+                {s.keys.map((k, j) => (
+                  <kbd key={j} style={kbdStyle}>{k}</kbd>
+                ))}
+              </span>
+              <span style={descStyle}>{s.description}</span>
+            </li>
+          ))}
+        </ul>
+        <div style={footnoteStyle}>
+          Press <kbd style={kbdStyle}>?</kbd> to toggle this list.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 60,
+};
+
+const modalStyle: React.CSSProperties = {
+  background: '#141418',
+  border: '1px solid #2a2a30',
+  borderRadius: 12,
+  padding: '1.25rem 1.4rem',
+  width: '100%',
+  maxWidth: 480,
+  color: '#f5f5f5',
+  fontFamily: 'inherit',
+  boxShadow: '0 18px 48px rgba(0,0,0,0.5)',
+};
+
+const headerRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: '0.75rem',
+};
+
+const closeButtonStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: 'none',
+  color: '#a0a0aa',
+  cursor: 'pointer',
+  fontSize: '1.1rem',
+  lineHeight: 1,
+  padding: '0 6px',
+  borderRadius: 4,
+  fontFamily: 'inherit',
+};
+
+const listStyle: React.CSSProperties = {
+  listStyle: 'none',
+  padding: 0,
+  margin: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const rowStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '170px 1fr',
+  gap: 12,
+  alignItems: 'center',
+  fontSize: '0.85rem',
+};
+
+const keysCellStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  gap: 4,
+  alignItems: 'center',
+};
+
+const descStyle: React.CSSProperties = {
+  color: '#cfcfd6',
+};
+
+const kbdStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '1px 6px',
+  background: '#1b1b23',
+  border: '1px solid #2a2a30',
+  borderBottom: '2px solid #2a2a30',
+  borderRadius: 4,
+  fontFamily: 'inherit',
+  fontSize: '0.75rem',
+  color: '#e8e8ef',
+};
+
+const footnoteStyle: React.CSSProperties = {
+  marginTop: 12,
+  fontSize: '0.72rem',
+  color: '#8a8a95',
+};

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -11,6 +11,7 @@ const SHORTCUTS: Shortcut[] = [
   { keys: ['?'], description: 'Show this help' },
   { keys: ['Esc'], description: 'Close menus, modals, search bar, this help' },
   { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
+  { keys: ['⌘', 'J'], description: 'Focus the composer of the active chat window (Ctrl+J on Linux/Win)' },
   { keys: ['Enter'], description: 'In Find: jump to next match' },
   { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
   { keys: ['Enter'], description: 'In composer: send message' },

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -41,8 +41,13 @@ export function KeyboardShortcutsOverlay() {
         setOpen(false);
       }
     };
+    const onCustom = () => setOpen((v) => !v);
     window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener('wav:toggle-shortcuts', onCustom);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('wav:toggle-shortcuts', onCustom);
+    };
   }, [open]);
 
   if (!open) return null;

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -156,6 +156,11 @@ export function ChatWindow({
           searchInputRef.current?.focus();
           searchInputRef.current?.select();
         });
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'j' || e.key === 'J')) {
+        e.preventDefault();
+        textareaRef.current?.focus();
       }
     };
     window.addEventListener('keydown', onKey);

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -290,7 +290,7 @@ export function ChatWindow({
             }}
             aria-label={searchOpen ? 'Close search' : 'Find in chat'}
             aria-pressed={searchOpen}
-            title={searchOpen ? 'Close search' : 'Find in chat'}
+            title={searchOpen ? 'Close search' : 'Find in chat (⌘F / Ctrl+F)'}
             style={{
               background: 'transparent',
               border: 'none',

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -633,6 +633,7 @@ export function ChatWindow({
           <button
             type="submit"
             disabled={!canSend}
+            title="Send (Enter)"
             style={{
               background: canSend ? '#f5f5f5' : '#2a2a30',
               color: canSend ? '#0b0b0d' : '#6a6a75',
@@ -644,9 +645,22 @@ export function ChatWindow({
               cursor: canSend ? 'pointer' : 'not-allowed',
               fontFamily: 'inherit',
               alignSelf: 'stretch',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
             }}
           >
             Send
+            <span
+              aria-hidden
+              style={{
+                fontSize: '0.7rem',
+                opacity: 0.6,
+                fontWeight: 400,
+              }}
+            >
+              ↵
+            </span>
           </button>
         )}
       </form>


### PR DESCRIPTION
Discoverable keyboard layer on top of the search work in #136 / #137.

## What
- **Shortcuts overlay (?)** — new `KeyboardShortcutsOverlay` mounted globally inside `layout.tsx`. Pressing `?` outside any input/textarea/contenteditable toggles a modal listing the keystrokes. Esc closes; backdrop click closes; isTypingTarget guard prevents the trigger while composing.
- **Cmd / Ctrl + J** — focuses the textarea composer of the **active** chat window. Mirrors the Cmd+F search shortcut already shipped, listening only on the active window.
- **Help (?) button in AppShell** — small round `?` next to UserMenu. Dispatches a custom `wav:toggle-shortcuts` event so the overlay's mounted state stays the single source of truth (no duplicated open state).
- **Send button polish** — title attribute `Send (Enter)` + small dimmed `↵` glyph at the end of the label. Aria-hidden so screen readers don't announce it twice.
- **Find button hover** — title now reads `Find in chat (⌘F / Ctrl+F)` to close the discoverability loop on the Cmd/Ctrl+F shortcut shipped previously.

## Files changed
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx` — new
- `apps/web/src/components/HelpButton.tsx` — new
- `apps/web/src/app/layout.tsx` — mount overlay
- `apps/web/src/components/AppShell.tsx` — help button next to UserMenu
- `apps/web/src/features/chat/ChatWindow.tsx` — Cmd/Ctrl+J handler, Send button hint, Find title

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)