### PR TITLE
Backend hardening batch 4: logger crash-proofing + lib coverage backfill

### DIFF
--- a/apps/api/src/lib/cookie.test.ts
+++ b/apps/api/src/lib/cookie.test.ts
@@ -37,6 +37,22 @@ describe('parseCookies', () => {
   it('skips entries with an empty key', () => {
     expect(parseCookies('=nope; sid=ok')).toEqual({ sid: 'ok' });
   });
+
+  it('preserves "=" characters inside the value (base64 / JWT-shaped tokens)', () => {
+    // The first "=" splits name from value; everything after stays in value.
+    // Critical for any future cookie that carries base64 or JWT-style data
+    // with trailing/internal "=" padding.
+    expect(parseCookies('token=eyJhbGciOiJIUzI1NiJ9.payload.signature==')).toEqual({
+      token: 'eyJhbGciOiJIUzI1NiJ9.payload.signature==',
+    });
+  });
+
+  it('takes the LAST entry when the same cookie name appears multiple times', () => {
+    // The cookie spec leaves duplicate-name handling implementation-defined.
+    // The current impl writes into a Map, so the last value wins. Pin that
+    // semantic so anyone changing it has to consciously choose another rule.
+    expect(parseCookies('sid=first; sid=second; sid=third').sid).toBe('third');
+  });
 });
 
 describe('serializeSetCookie', () => {

--- a/apps/api/src/lib/csrf.test.ts
+++ b/apps/api/src/lib/csrf.test.ts
@@ -117,4 +117,15 @@ describe('checkCsrf', () => {
     );
     expect(r.ok).toBe(false);
   });
+
+  it('handles the array-form Origin header (duplicate Origin headers, takes the first)', () => {
+    // Node exposes duplicate headers as string[]. The implementation falls
+    // back to the first array entry — pin that semantic so a refactor that
+    // returns null for arrays (and thus skips Origin checking entirely)
+    // can't ship.
+    const req = {
+      headers: { origin: ['https://app.example.com', 'https://other.example.com'] },
+    } as unknown as IncomingMessage;
+    expect(checkCsrf(req, 'POST', 'https://app.example.com').ok).toBe(true);
+  });
 });

--- a/apps/api/src/lib/http.test.ts
+++ b/apps/api/src/lib/http.test.ts
@@ -1,0 +1,118 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import {
+  getClientIp,
+  respondCreated,
+  respondError,
+  respondNoContent,
+  respondNotFound,
+  respondRateLimited,
+} from './http.js';
+
+function reqWith(opts: {
+  forwarded?: string | string[] | undefined;
+  remoteAddress?: string | undefined;
+}): IncomingMessage {
+  const headers: Record<string, string | string[] | undefined> = {};
+  if (opts.forwarded !== undefined) headers['x-forwarded-for'] = opts.forwarded;
+  return {
+    headers,
+    socket: opts.remoteAddress === undefined ? {} : { remoteAddress: opts.remoteAddress },
+  } as unknown as IncomingMessage;
+}
+
+describe('getClientIp', () => {
+  it('returns the first hop from a single-IP X-Forwarded-For', () => {
+    expect(getClientIp(reqWith({ forwarded: '203.0.113.1' }))).toBe('203.0.113.1');
+  });
+
+  it('returns the first hop from a comma-separated X-Forwarded-For list', () => {
+    // The first entry is the original client; subsequent entries are proxies.
+    expect(getClientIp(reqWith({ forwarded: '203.0.113.1, 10.0.0.1, 10.0.0.2' }))).toBe('203.0.113.1');
+  });
+
+  it('trims whitespace around the first hop', () => {
+    expect(getClientIp(reqWith({ forwarded: '  203.0.113.1  ,  10.0.0.1' }))).toBe('203.0.113.1');
+  });
+
+  it('falls back to socket.remoteAddress when no X-Forwarded-For header is present', () => {
+    expect(getClientIp(reqWith({ remoteAddress: '198.51.100.7' }))).toBe('198.51.100.7');
+  });
+
+  it('returns "unknown" when neither X-Forwarded-For nor socket.remoteAddress is available', () => {
+    expect(getClientIp(reqWith({}))).toBe('unknown');
+  });
+
+  it('falls back to socket.remoteAddress when X-Forwarded-For is the array form (duplicate headers)', () => {
+    // Node exposes duplicate headers as string[]. The current impl only handles
+    // the string form; an array should fall through to the socket address rather
+    // than silently returning 'unknown' and bucketing every duplicate-header
+    // request into the same rate-limit bucket.
+    expect(getClientIp(reqWith({ forwarded: ['203.0.113.1', '203.0.113.2'], remoteAddress: '198.51.100.7' }))).toBe('198.51.100.7');
+  });
+});
+
+describe('respondCreated', () => {
+  it('returns a 201 with the data wrapped in an ok envelope', () => {
+    const r = respondCreated({ id: 'abc' });
+    expect(r.httpStatus).toBe(201);
+    expect(r.body).toEqual({ ok: true, data: { id: 'abc' } });
+    expect(r.headers).toBeUndefined();
+  });
+
+  it('attaches a Location header when one is provided', () => {
+    const r = respondCreated({ id: 'abc' }, '/v1/projects/abc');
+    expect(r.headers).toEqual({ Location: '/v1/projects/abc' });
+  });
+});
+
+describe('respondNoContent', () => {
+  it('returns a 204 with the data:null ok envelope (writeJson short-circuits the body)', () => {
+    const r = respondNoContent();
+    expect(r.httpStatus).toBe(204);
+    expect(r.body).toEqual({ ok: true, data: null });
+  });
+});
+
+describe('respondError', () => {
+  it('defaults to status 400 with the given code and message', () => {
+    const r = respondError('validation_error', 'bad input');
+    expect(r.httpStatus).toBe(400);
+    expect(r.body).toEqual({ ok: false, error: { code: 'validation_error', message: 'bad input' } });
+  });
+
+  it('honours an explicit status', () => {
+    const r = respondError('unauthenticated', 'no session', 401);
+    expect(r.httpStatus).toBe(401);
+  });
+
+  it('attaches details only when supplied (no spurious "details": undefined leaks)', () => {
+    const without = respondError('validation_error', 'bad');
+    if (without.body.ok) throw new Error('expected error envelope');
+    expect('details' in without.body.error).toBe(false);
+
+    const withDetails = respondError('validation_error', 'bad', 400, { field: 'email' });
+    if (withDetails.body.ok) throw new Error('expected error envelope');
+    expect(withDetails.body.error.details).toEqual({ field: 'email' });
+  });
+});
+
+describe('respondNotFound', () => {
+  it('returns a 404 with not_found code and the supplied message', () => {
+    const r = respondNotFound('Project xyz not found');
+    expect(r.httpStatus).toBe(404);
+    if (r.body.ok) throw new Error('expected error envelope');
+    expect(r.body.error.code).toBe('not_found');
+    expect(r.body.error.message).toBe('Project xyz not found');
+  });
+});
+
+describe('respondRateLimited', () => {
+  it('returns a 429 with rate_limited code and the Retry-After header', () => {
+    const r = respondRateLimited(120);
+    expect(r.httpStatus).toBe(429);
+    if (r.body.ok) throw new Error('expected error envelope');
+    expect(r.body.error.code).toBe('rate_limited');
+    expect(r.headers).toEqual({ 'Retry-After': '120' });
+  });
+});

--- a/apps/api/src/lib/logger.test.ts
+++ b/apps/api/src/lib/logger.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from './logger.js';
+
+describe('logger', () => {
+  let logs: string[];
+  let warns: string[];
+  let errors: string[];
+
+  beforeEach(() => {
+    logs = [];
+    warns = [];
+    errors = [];
+    vi.spyOn(console, 'log').mockImplementation((line: string) => { logs.push(line); });
+    vi.spyOn(console, 'warn').mockImplementation((line: string) => { warns.push(line); });
+    vi.spyOn(console, 'error').mockImplementation((line: string) => { errors.push(line); });
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('writes a JSON line on info() with ts, level, msg', () => {
+    logger.info('hello');
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]!) as { ts: string; level: string; msg: string };
+    expect(parsed.level).toBe('info');
+    expect(parsed.msg).toBe('hello');
+    expect(() => new Date(parsed.ts).toISOString()).not.toThrow();
+  });
+
+  it('routes warn() to console.warn and error() to console.error', () => {
+    logger.warn('w');
+    logger.error('e');
+    expect(warns).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('merges meta fields into the payload', () => {
+    logger.info('hello', { requestId: 'r-1', status: 200 });
+    const parsed = JSON.parse(logs[0]!) as Record<string, unknown>;
+    expect(parsed.requestId).toBe('r-1');
+    expect(parsed.status).toBe(200);
+  });
+
+  it('does NOT crash when meta contains a circular reference', () => {
+    // JSON.stringify throws on circular refs. The logger sits inside the
+    // request pipeline — a throw here would crash the response. The safe
+    // fallback emits a minimal envelope keyed off log_serialization_failed.
+    const meta: Record<string, unknown> = { name: 'x' };
+    meta.self = meta;
+    expect(() => logger.info('with-circular', meta)).not.toThrow();
+    expect(logs).toHaveLength(1);
+    const parsed = JSON.parse(logs[0]!) as Record<string, unknown>;
+    expect(parsed.error).toBe('log_serialization_failed');
+    expect(parsed.msg).toBe('with-circular');
+  });
+
+  it('does NOT crash when meta contains a BigInt (also unstringifiable by default)', () => {
+    expect(() => logger.warn('with-bigint', { count: BigInt(1) })).not.toThrow();
+    const parsed = JSON.parse(warns[0]!) as Record<string, unknown>;
+    expect(parsed.error).toBe('log_serialization_failed');
+  });
+});

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -1,5 +1,20 @@
 type Level = 'info' | 'warn' | 'error';
 
+function safeStringify(payload: unknown): string {
+  try {
+    return JSON.stringify(payload);
+  } catch {
+    // JSON.stringify throws on circular refs and BigInts. The logger sits
+    // inside the request pipeline — a crash here would take the response
+    // with it. Fall back to a minimal envelope so observability stays up
+    // even if a caller logged a self-referential object by accident.
+    const fallback = (payload && typeof payload === 'object' && 'msg' in payload)
+      ? { ts: new Date().toISOString(), level: 'error', msg: String((payload as { msg: unknown }).msg), error: 'log_serialization_failed' }
+      : { ts: new Date().toISOString(), level: 'error', msg: 'log_serialization_failed' };
+    return JSON.stringify(fallback);
+  }
+}
+
 function emit(level: Level, msg: string, meta?: Record<string, unknown>): void {
   const payload = {
     ts: new Date().toISOString(),
@@ -7,7 +22,7 @@ function emit(level: Level, msg: string, meta?: Record<string, unknown>): void {
     msg,
     ...(meta ?? {}),
   };
-  const line = JSON.stringify(payload);
+  const line = safeStringify(payload);
   if (level === 'error') console.error(line);
   else if (level === 'warn') console.warn(line);
   else console.log(line);

--- a/apps/api/src/lib/password.test.ts
+++ b/apps/api/src/lib/password.test.ts
@@ -22,4 +22,28 @@ describe('password helpers', () => {
     expect(await verifyPassword('anything', 'no-colon')).toBe(false);
     expect(await verifyPassword('anything', '')).toBe(false);
   });
+
+  it('rejects a stored hash with a wrong-length key (would otherwise crash timingSafeEqual)', async () => {
+    // KEY_LEN = 64 bytes = 128 hex chars. timingSafeEqual throws on mismatched
+    // buffer lengths, which would propagate as a 500 from a route. The impl
+    // pre-checks the hex length and returns false instead — pin that behaviour.
+    const truncated = 'aa'.repeat(16) + ':' + 'bb'.repeat(32); // 32-byte key
+    expect(await verifyPassword('anything', truncated)).toBe(false);
+  });
+
+  it('rejects a stored hash with non-hex characters (Buffer.from would silently truncate)', async () => {
+    // Buffer.from('zz', 'hex') yields an empty buffer. Pin that the helper
+    // catches and returns false rather than mis-comparing.
+    const bad = 'zzzz' + ':' + 'bb'.repeat(64);
+    expect(await verifyPassword('anything', bad)).toBe(false);
+  });
+
+  it('verifies a 1-character password (lower bound — no min enforced at this layer)', async () => {
+    // password.ts is the cryptographic layer — input length policy lives in
+    // the auth route's schema. Confirm the helper doesn't have its own
+    // hidden minimum that could surprise a caller.
+    const hash = await hashPassword('x');
+    expect(await verifyPassword('x', hash)).toBe(true);
+    expect(await verifyPassword('y', hash)).toBe(false);
+  });
 });

--- a/apps/api/src/lib/schema.test.ts
+++ b/apps/api/src/lib/schema.test.ts
@@ -96,4 +96,19 @@ describe('schema.object', () => {
     expect(Body.parse(null).ok).toBe(false);
     expect(Body.parse('x').ok).toBe(false);
   });
+
+  it('silently drops unknown fields (forward-compatible accept policy)', () => {
+    // The shape iterates declared keys only — anything extra in the input
+    // is intentionally not surfaced in errors and not carried into the
+    // parsed value. This is the "be liberal in what you accept" posture
+    // for client forward-compat: a v2 client that adds a new field can
+    // still talk to a v1 server. Pin it explicitly so a future strict-
+    // mode opt-in has to update this test, not silently break clients.
+    const r = Body.parse({ name: 'A', age: 1, extra: 'should-be-dropped', nested: { x: 1 } });
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.value).toEqual({ name: 'A', age: 1 });
+    expect('extra' in r.value).toBe(false);
+    expect('nested' in r.value).toBe(false);
+  });
 });

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -101,6 +101,27 @@ describe('dispatch — error envelopes', () => {
     const allow = res.headers.get('allow') ?? '';
     expect(allow).toContain('GET');
   });
+
+  it('rejects non-canonical HTTP methods with 405 method_not_allowed', async () => {
+    // The router only supports the seven methods declared in the HttpMethod
+    // type union. A method like LINK / UNLINK / PROPFIND must short-circuit
+    // before route matching with a 405, not silently fall through to a 404
+    // or worse, get past CSRF and reach a handler. We use a raw socket here
+    // because undici's fetch refuses some non-canonical methods at the
+    // client layer; we want to exercise the server's own check.
+    const url = new URL(harness.baseUrl);
+    const port = Number(url.port);
+    const { request } = await import('node:http');
+    const status: number = await new Promise((resolve, reject) => {
+      const r = request(
+        { host: url.hostname, port, path: '/health', method: 'PROPFIND' },
+        (res) => { res.resume(); resolve(res.statusCode ?? 0); },
+      );
+      r.on('error', reject);
+      r.end();
+    });
+    expect(status).toBe(405);
+  });
 });
 
 // ── CSRF protection ───────────────────────────────────────────────────────────

--- a/apps/api/src/providers/registry.test.ts
+++ b/apps/api/src/providers/registry.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { SUPPORTED_PROVIDERS, getProviderClient, isSupportedProvider } from './registry.js';
+import type { AIProvider } from '@webapp/types';
+import {
+  SUPPORTED_PROVIDERS,
+  getProviderClient,
+  isSupportedProvider,
+  verifyProviderKey,
+} from './registry.js';
 
 describe('providers/registry', () => {
   it('lists openai, anthropic and perplexity as supported', () => {
@@ -18,5 +24,24 @@ describe('providers/registry', () => {
     expect(getProviderClient('openai',     'k')).toBeDefined();
     expect(getProviderClient('anthropic',  'k')).toBeDefined();
     expect(getProviderClient('perplexity', 'k')).toBeDefined();
+  });
+
+  it('getProviderClient throws on an unknown provider — matches isSupportedProvider', () => {
+    // The string is forced through the AIProvider type to exercise the
+    // exhaustiveness fallthrough. If a new entry is added to the union
+    // without a switch arm, this test still passes — but isSupportedProvider
+    // would still report true and tip off the gap. Pin the fallback throw.
+    const bogus = 'bogus' as unknown as AIProvider;
+    expect(() => getProviderClient(bogus, 'k')).toThrow(/No provider client/);
+    expect(isSupportedProvider(bogus)).toBe(false);
+  });
+
+  it('verifyProviderKey returns "provider_error" for an unknown provider', async () => {
+    // Fallback path: a misconfigured provider should NOT crash the verify
+    // endpoint. It should resolve to the same 'provider_error' code that
+    // a real provider would return on a transient network blip, so the
+    // controller can handle both with one code path.
+    const bogus = 'bogus' as unknown as AIProvider;
+    await expect(verifyProviderKey(bogus, 'k')).resolves.toBe('provider_error');
   });
 });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -202,6 +202,34 @@ describe('POST /v1/auth/login', () => {
     expect(body.error.code).toBe('unauthenticated');
     await close();
   });
+
+  it('returns the same code AND the same message string for unknown email vs wrong password', async () => {
+    // The whole point of the unified 'Invalid email or password' string is to
+    // be impossible to distinguish from the caller's POV. If a future
+    // refactor adds a more helpful 'No account with that email' branch, this
+    // test will fail — forcing a re-look at the enumeration trade-off.
+
+    // Path A: email unknown.
+    const a = await startServer(makeDeps({ findUserByEmail: async () => null }));
+    const ra = await post(a.baseUrl, '/v1/auth/login', { email: 'ghost@example.com', password: 'anything' });
+    expect(ra.status).toBe(401);
+    const ba = (await ra.json()) as ApiResponse<never>;
+    if (ba.ok) throw new Error('expected error');
+    await a.close();
+
+    // Path B: email known, wrong password.
+    const b = await startServer(makeDeps({
+      findUserByEmail: async () => mockUser({ passwordHash: realHash }),
+    }));
+    const rb = await post(b.baseUrl, '/v1/auth/login', { email: 'test@example.com', password: 'wrongpassword' });
+    expect(rb.status).toBe(401);
+    const bb = (await rb.json()) as ApiResponse<never>;
+    if (bb.ok) throw new Error('expected error');
+    await b.close();
+
+    expect(ba.error.code).toBe(bb.error.code);
+    expect(ba.error.message).toBe(bb.error.message);
+  });
 });
 
 // ── Me ────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -282,6 +282,51 @@ describe('GET /v1/auth/me', () => {
     expect(calls).toEqual([]);
     await close();
   });
+
+  it('always returns the unauthenticated code on 401, regardless of which subcheck failed', async () => {
+    // Three distinct failure paths inside meController: no cookie, no
+    // matching session, session resolves to a now-deleted user. They MUST
+    // share the same error code so a caller cannot distinguish 'never
+    // logged in' from 'session was revoked' from 'account was deleted' —
+    // that distinction is an account-enumeration oracle.
+
+    // 1. No cookie
+    const noCookie = await startServer(makeDeps());
+    const r1 = await fetch(`${noCookie.baseUrl}/v1/auth/me`);
+    expect(r1.status).toBe(401);
+    const b1 = (await r1.json()) as ApiResponse<never>;
+    if (b1.ok) throw new Error('expected error');
+    await noCookie.close();
+
+    // 2. Cookie present, session unknown
+    const noSession = await startServer(makeDeps({
+      findSessionByTokenHash: async () => null,
+    }));
+    const r2 = await fetch(`${noSession.baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${'9'.repeat(64)}` },
+    });
+    expect(r2.status).toBe(401);
+    const b2 = (await r2.json()) as ApiResponse<never>;
+    if (b2.ok) throw new Error('expected error');
+    await noSession.close();
+
+    // 3. Cookie present, session valid, user gone
+    const noUser = await startServer(makeDeps({
+      findSessionByTokenHash: async () => mockSession(KNOWN_HASH),
+      findUserById:           async () => null,
+    }));
+    const r3 = await fetch(`${noUser.baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${KNOWN_TOKEN}` },
+    });
+    expect(r3.status).toBe(401);
+    const b3 = (await r3.json()) as ApiResponse<never>;
+    if (b3.ok) throw new Error('expected error');
+    await noUser.close();
+
+    expect(b1.error.code).toBe('unauthenticated');
+    expect(b2.error.code).toBe('unauthenticated');
+    expect(b3.error.code).toBe('unauthenticated');
+  });
 });
 
 // ── Alias: /v1/me → /v1/auth/me ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ten-commit batch focused on backend hardening + regression coverage for previously-untested helper modules. One real production fix (logger), nine regression-test commits that pin contracts so future refactors fail CI before they ship.

### Production fix
- **`logger` crash-proofing** — `JSON.stringify` throws on circular references or `BigInt` values. The logger sits inside the request pipeline, so a throw there would crash the response. Wrap the serialise call in a try/catch and emit a minimal `log_serialization_failed` envelope so observability stays up even when a caller logs a self-referential object.

### Coverage backfill (no behaviour change, locks contracts)
- `http.ts` helpers — `getClientIp` first-hop XFF parsing, comma-list trimming, socket fallback, 'unknown' sentinel + safe array-form behaviour. `respondCreated` / `respondNoContent` / `respondNotFound` / `respondError` / `respondRateLimited` envelope shapes + Retry-After/Location headers. (Was 0 tests on this file.)
- `password.verifyPassword` — wrong-key-length + non-hex stored hashes return false (no `timingSafeEqual` crash). 1-char password verifies (no hidden minimum at the crypto layer).
- `meController` — all three 401 paths (no cookie / unknown session / user gone) return identical `unauthenticated` code (no account-enumeration oracle).
- `loginController` — unknown-email and wrong-password paths return identical envelope (code AND message).
- `providers/registry` — `getProviderClient` throws on unknown provider, `verifyProviderKey` resolves to `provider_error` on unknown provider.
- `handleRequest` — non-canonical HTTP methods (PROPFIND) get 405 short-circuit before route matching.
- `csrf` — array-form Origin header takes the first entry (duplicate-header safety).
- `parseCookies` — `=` inside value (base64 / JWT) preserved; duplicate-name → last wins.
- `schema.object` — silently drops unknown fields (forward-compat accept policy pinned).

### Tests
- 432 backend tests pass (was 400). +32 new tests across 9 files.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 432/432 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)