### PR TITLE
feat(web): scroll-position memory + sidebar auto-scroll + click-empty-to-focus + ↓ Latest

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -88,12 +88,15 @@ export function ChatWindow({
   const scrollStorageKey = `wav.chat.scroll.${id}`;
   const restoredScrollRef = useRef(false);
   const scrollSaveTimerRef = useRef<number | null>(null);
+  const [scrolledAway, setScrolledAway] = useState(false);
 
   const updateStickiness = () => {
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop;
-    stickyRef.current = distanceFromBottom < 64;
+    const sticky = distanceFromBottom < 64;
+    stickyRef.current = sticky;
+    setScrolledAway(!sticky);
     if (restoredScrollRef.current) {
       if (scrollSaveTimerRef.current != null) {
         window.clearTimeout(scrollSaveTimerRef.current);
@@ -103,6 +106,14 @@ export function ChatWindow({
         writeScrollTop(scrollStorageKey, top);
       }, 200);
     }
+  };
+
+  const scrollToBottom = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    stickyRef.current = true;
+    setScrolledAway(false);
   };
 
   useLayoutEffect(() => {
@@ -596,6 +607,43 @@ export function ChatWindow({
           ))
         )}
       </div>
+
+      {scrolledAway && !lowerQuery && messages.length > 0 ? (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            padding: '0.25rem 0',
+            background: 'transparent',
+            pointerEvents: 'none',
+            marginTop: -28,
+          }}
+        >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              scrollToBottom();
+            }}
+            aria-label="Scroll to latest message"
+            title="Scroll to latest message"
+            style={{
+              pointerEvents: 'auto',
+              background: '#1b1b23',
+              border: '1px solid #2a2a30',
+              color: '#e8e8ef',
+              borderRadius: 999,
+              padding: '0.3rem 0.7rem',
+              fontSize: '0.72rem',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              boxShadow: '0 4px 12px rgba(0,0,0,0.4)',
+            }}
+          >
+            ↓ Latest
+          </button>
+        </div>
+      ) : null}
 
       <form
         onSubmit={(e) => {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -85,18 +85,44 @@ export function ChatWindow({
     .map((m) => `${m.id}:${m.content.length}:${m.status ?? 'ok'}`)
     .join('|');
 
+  const scrollStorageKey = `wav.chat.scroll.${id}`;
+  const restoredScrollRef = useRef(false);
+  const scrollSaveTimerRef = useRef<number | null>(null);
+
   const updateStickiness = () => {
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop;
     stickyRef.current = distanceFromBottom < 64;
+    if (restoredScrollRef.current) {
+      if (scrollSaveTimerRef.current != null) {
+        window.clearTimeout(scrollSaveTimerRef.current);
+      }
+      const top = el.scrollTop;
+      scrollSaveTimerRef.current = window.setTimeout(() => {
+        writeScrollTop(scrollStorageKey, top);
+      }, 200);
+    }
   };
 
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
+    if (!restoredScrollRef.current) {
+      const stored = readScrollTop(scrollStorageKey);
+      if (stored != null) {
+        const max = el.scrollHeight - el.clientHeight;
+        el.scrollTop = Math.min(stored, max);
+        const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop;
+        stickyRef.current = distanceFromBottom < 64;
+      } else if (stickyRef.current) {
+        el.scrollTop = el.scrollHeight;
+      }
+      restoredScrollRef.current = true;
+      return;
+    }
     if (stickyRef.current) el.scrollTop = el.scrollHeight;
-  }, [messagesSignature]);
+  }, [messagesSignature, scrollStorageKey]);
 
   useLayoutEffect(() => {
     const ta = textareaRef.current;
@@ -1158,5 +1184,27 @@ function writeSearchQuery(key: string, value: string): void {
     else window.sessionStorage.removeItem(key);
   } catch {
     // sessionStorage unavailable / quota; ignore
+  }
+}
+
+function readScrollTop(key: string): number | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeScrollTop(key: string, value: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (value > 0) window.sessionStorage.setItem(key, String(Math.round(value)));
+    else window.sessionStorage.removeItem(key);
+  } catch {
+    // ignore
   }
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -531,6 +531,11 @@ export function ChatWindow({
       <div
         ref={scrollRef}
         onScroll={updateStickiness}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            textareaRef.current?.focus();
+          }
+        }}
         role="log"
         aria-live="polite"
         aria-relevant="additions text"

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import type { AIProvider, ChatWindow, Workspace } from '@webapp/types';
 import type { WindowPreset } from '@/lib/data';
 import { Button } from '@/components/Button';
@@ -568,8 +568,24 @@ interface WindowRowProps {
 
 function WindowRow({ window, active, muted, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(window.updatedAt ?? window.createdAt);
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!active) return;
+    const el = rowRef.current;
+    if (!el || typeof el.scrollIntoView !== 'function') return;
+    const rect = el.getBoundingClientRect();
+    const parent = el.parentElement;
+    if (!parent) return;
+    const parentRect = parent.getBoundingClientRect();
+    const above = rect.top < parentRect.top;
+    const below = rect.bottom > parentRect.bottom;
+    if (above || below) {
+      el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [active]);
   return (
     <div
+      ref={rowRef}
       role="button"
       tabIndex={0}
       onClick={onClick}


### PR DESCRIPTION
Polish around the in-window scroll surface.

## What
- **Per-window scroll memory** — each ChatWindow stores its scroll position under `wav.chat.scroll.<windowId>` in `sessionStorage`. On mount, the stored offset is restored (or sticky-bottom default kicks in). On scroll, the new position is saved on a 200ms debounce. Stickiness recomputes from the restored offset so a user who'd scrolled up keeps their view even when streaming tokens arrive.
- **Sidebar auto-scroll** — when the active window changes, the corresponding `WindowRow` checks if it's outside the visible scroll area and calls `scrollIntoView({ block: 'nearest', behavior: 'smooth' })`. No-op when already visible.
- **Click empty area to focus composer** — clicking the residual whitespace under the message list (when messages don't fill it) now focuses the textarea. Only fires when the click target is the container itself, not a bubble child.
- **↓ Latest pill** — when the user has scrolled up (and search is not active), a small pill appears above the composer. Click returns to the bottom and re-engages stickiness so future streaming tokens follow.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)