### PR TITLE
Backend hardening batch 5: requireUser helper + auth/stream/health regression coverage

### DIFF
--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -56,6 +56,24 @@ describe('GET /v1/health/deep', () => {
     const details = body.error.details as { db: DbStatus; dbLatencyMs: number | null };
     expect(details.db).toBe('down');
     expect(details.dbLatencyMs).toBe(4_999);
+    // 503 from the deep health probe must NOT be cached. A CDN that
+    // briefly cached a 503 would extend the downtime window for every
+    // subsequent client. Pin no-store on this path explicitly because
+    // health responses are an obvious caching candidate for a misconfigured
+    // proxy.
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+    await close();
+  });
+
+  it('returns 200 with cache-control: no-store on the healthy path too', async () => {
+    // Same logic — health checks are a poll target, not a content endpoint.
+    // Even the success response must not be cacheable; otherwise a stale
+    // 'ok' would mask a real outage to anyone behind the cache.
+    const { baseUrl, close } = await startServer(makeDeps('ok'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 });

--- a/apps/api/src/controllers/state-db.controller.ts
+++ b/apps/api/src/controllers/state-db.controller.ts
@@ -3,10 +3,10 @@ import { inArray } from 'drizzle-orm';
 import type { AIProvider, AppState, ChatWindow, Message, Project, Workspace } from '@webapp/types';
 import {
   respond,
-  respondError,
   type InternalResult,
   type RequestContext,
 } from '../lib/http.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db as ProjectsDb } from '../db/projects.repo.js';
 import { listProjectsByUserId } from '../db/projects.repo.js';
@@ -142,9 +142,9 @@ export async function stateDbController(
   ctx: RequestContext,
   deps: StateDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
-  const state = await deps.loadState(user.id);
+  const state = await deps.loadState(auth.user.id);
   return respond(state);
 }

--- a/apps/api/src/lib/auth-helper.test.ts
+++ b/apps/api/src/lib/auth-helper.test.ts
@@ -1,0 +1,45 @@
+import type { IncomingMessage } from 'node:http';
+import { describe, expect, it } from 'vitest';
+import { requireUser } from './auth-helper.js';
+
+const fakeReq = {} as unknown as IncomingMessage;
+
+describe('requireUser', () => {
+  it('returns ok: true with the resolved user when the resolver yields one', async () => {
+    const r = await requireUser(fakeReq, async () => ({ id: 'user-1' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.user.id).toBe('user-1');
+  });
+
+  it('preserves extra user fields beyond id (the helper is generic over the user shape)', async () => {
+    const r = await requireUser(fakeReq, async () => ({ id: 'user-1', email: 'a@b.com' }));
+    if (!r.ok) throw new Error('expected ok');
+    expect(r.user.email).toBe('a@b.com');
+  });
+
+  it('returns ok: false with a 401 result when the resolver yields null', async () => {
+    const r = await requireUser(fakeReq, async () => null);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected fail');
+    expect(r.result.httpStatus).toBe(401);
+    if (r.result.body.ok) throw new Error('expected error envelope');
+    expect(r.result.body.error.code).toBe('unauthenticated');
+    expect(r.result.body.error.message).toBe('Not authenticated');
+  });
+
+  it('forwards the request object to the resolver verbatim', async () => {
+    let received: IncomingMessage | undefined;
+    await requireUser(fakeReq, async (req) => { received = req; return null; });
+    expect(received).toBe(fakeReq);
+  });
+
+  it('lets resolver-thrown errors propagate (no silent auth-as-anonymous masking)', async () => {
+    // Same contract as resolveCurrentUser: a DB outage in the resolver must
+    // surface as a 5xx via handleRequest's catch, not as a 401 that hides
+    // infrastructure failures behind "logged out" traffic.
+    await expect(
+      requireUser(fakeReq, async () => { throw new Error('db down'); }),
+    ).rejects.toThrow('db down');
+  });
+});

--- a/apps/api/src/lib/auth-helper.ts
+++ b/apps/api/src/lib/auth-helper.ts
@@ -1,0 +1,34 @@
+import type { IncomingMessage } from 'node:http';
+import { respondError, type InternalResult } from './http.js';
+
+type UserResolver = (req: IncomingMessage) => Promise<{ id: string } | null>;
+
+/**
+ * Resolves the authenticated user via the supplied resolver, or returns the
+ * standard 401 InternalResult if no user is present.
+ *
+ * Every authenticated controller currently repeats:
+ *
+ *   const user = await deps.resolveUser(ctx.req);
+ *   if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+ *
+ * This helper centralises that boilerplate so the 401 envelope (code +
+ * message + status) stays identical across routes. Controllers that opt in
+ * call:
+ *
+ *   const auth = await requireUser(ctx.req, deps.resolveUser);
+ *   if (!auth.ok) return auth.result;
+ *   const user = auth.user;
+ */
+export async function requireUser<U extends { id: string }>(
+  req: IncomingMessage,
+  resolver: (req: IncomingMessage) => Promise<U | null>,
+): Promise<{ ok: true; user: U } | { ok: false; result: InternalResult }> {
+  const user = await resolver(req);
+  if (!user) {
+    return { ok: false, result: respondError('unauthenticated', 'Not authenticated', 401) };
+  }
+  return { ok: true, user };
+}
+
+export type { UserResolver };

--- a/apps/api/src/lib/http.test.ts
+++ b/apps/api/src/lib/http.test.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage } from 'node:http';
 import { describe, expect, it } from 'vitest';
 import {
+  fail,
   getClientIp,
+  isHttpMethod,
+  isRecord,
+  ok,
   respondCreated,
   respondError,
   respondNoContent,
@@ -114,5 +118,60 @@ describe('respondRateLimited', () => {
     if (r.body.ok) throw new Error('expected error envelope');
     expect(r.body.error.code).toBe('rate_limited');
     expect(r.headers).toEqual({ 'Retry-After': '120' });
+  });
+});
+
+describe('envelope invariants — ok() / fail()', () => {
+  it('ok() never carries an error field', () => {
+    const env = ok({ x: 1 });
+    expect(env.ok).toBe(true);
+    expect('error' in env).toBe(false);
+  });
+
+  it('fail() never carries a data field', () => {
+    const env = fail('validation_error', 'bad');
+    expect(env.ok).toBe(false);
+    expect('data' in env).toBe(false);
+  });
+
+  it('fail() omits details when not supplied (no spurious details: undefined in JSON)', () => {
+    const env = fail('validation_error', 'bad');
+    if (env.ok) throw new Error('expected error envelope');
+    expect('details' in env.error).toBe(false);
+    // Round-trip through JSON to confirm: a stray undefined would either
+    // crash JSON.stringify (no — JSON drops undefined) or appear as
+    // a missing key. Accept either, but pin the *parsed* shape.
+    const parsed = JSON.parse(JSON.stringify(env));
+    expect(parsed.error).not.toHaveProperty('details');
+  });
+});
+
+describe('isHttpMethod', () => {
+  it('accepts the seven canonical methods', () => {
+    for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']) {
+      expect(isHttpMethod(m)).toBe(true);
+    }
+  });
+
+  it('rejects non-canonical or undefined methods', () => {
+    expect(isHttpMethod(undefined)).toBe(false);
+    expect(isHttpMethod('TRACE')).toBe(false);
+    expect(isHttpMethod('PROPFIND')).toBe(false);
+    expect(isHttpMethod('get')).toBe(false); // case-sensitive
+  });
+});
+
+describe('isRecord', () => {
+  it('accepts plain objects', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it('rejects null, arrays, primitives', () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord([])).toBe(false);
+    expect(isRecord('s')).toBe(false);
+    expect(isRecord(1)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
   });
 });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -420,6 +420,28 @@ describe('POST /v1/auth/logout', () => {
     await close();
   });
 
+  it('is idempotent — calling logout twice with the same cookie is a 200 each time', async () => {
+    // The frontend may double-fire logout (button + tab-close handler), and
+    // a second call after the session is already gone must not error. The
+    // controller deletes the session by token-hash, which is naturally
+    // idempotent — pin it with a regression test so a future refactor that
+    // returns 401 on already-deleted sessions can't ship without failing CI.
+    const { baseUrl, close } = await startServer(makeDeps({
+      deleteSession: async () => { /* idempotent: succeed both times */ },
+    }));
+    const cookie = `${SESSION_COOKIE_NAME}=${'1'.repeat(64)}`;
+    const r1 = await post(baseUrl, '/v1/auth/logout', {}, { Cookie: cookie });
+    const r2 = await post(baseUrl, '/v1/auth/logout', {}, { Cookie: cookie });
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    // Both responses must clear the cookie too — second logout is not a
+    // no-op from the cookie POV; it should still emit Max-Age=0 so a stale
+    // browser cookie can't survive the second call.
+    expect(getSetCookie(r1)).toContain('Max-Age=0');
+    expect(getSetCookie(r2)).toContain('Max-Age=0');
+    await close();
+  });
+
   it('returns 401 on /me after logout', async () => {
     const KNOWN_TOKEN2 = 'd'.repeat(64);
     const KNOWN_HASH2  = hashSessionToken(KNOWN_TOKEN2);

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -297,6 +297,47 @@ describe('GET /v1/auth/me', () => {
     await close();
   });
 
+  it('expired-session cleanup is fire-and-forget (response does not wait for the delete)', async () => {
+    // The opportunistic delete must not add latency to the 401 — the user is
+    // bouncing through an unauth response and shouldn't be slowed down by
+    // hygiene work. Use a deleteSession that never resolves and assert the
+    // 401 still returns within a tight budget.
+    const EXPIRED_TOKEN = '7'.repeat(64);
+    const EXPIRED_HASH  = hashSessionToken(EXPIRED_TOKEN);
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async (h) => h === EXPIRED_HASH
+        ? { id: h, userId: 'user-1', expiresAt: new Date(Date.now() - 60_000), createdAt: new Date() }
+        : null,
+      deleteSession: () => new Promise<void>(() => { /* never resolves */ }),
+    }));
+    const startedAt = Date.now();
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${EXPIRED_TOKEN}` },
+    });
+    expect(res.status).toBe(401);
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    await close();
+  });
+
+  it('expired-session cleanup swallows delete errors (no crash on hygiene failure)', async () => {
+    // The catch in meController is .catch(() => {}). A throwing delete must
+    // not affect the response or surface as an unhandled rejection that
+    // could crash the process.
+    const EXPIRED_TOKEN = '8'.repeat(64);
+    const EXPIRED_HASH  = hashSessionToken(EXPIRED_TOKEN);
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async (h) => h === EXPIRED_HASH
+        ? { id: h, userId: 'user-1', expiresAt: new Date(Date.now() - 60_000), createdAt: new Date() }
+        : null,
+      deleteSession: async () => { throw new Error('db down on cleanup'); },
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${EXPIRED_TOKEN}` },
+    });
+    expect(res.status).toBe(401);
+    await close();
+  });
+
   it('does NOT call deleteSession when token simply does not match', async () => {
     const calls: string[] = [];
     const { baseUrl, close } = await startServer(makeDeps({

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -602,6 +602,13 @@ describe('POST /v1/messages/stream — authenticated', () => {
     const res = await post(baseUrl, '/v1/messages/stream', { chatWindowId: 'cw-1', role: 'user', content: 'hello' });
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type') ?? '').toMatch(/text\/event-stream/);
+    // Ride-headers regression: SSE-critical hints must reach the client so
+    // proxies don't buffer the stream. Pin them on the success path so a
+    // future writeHead refactor can't quietly strip them.
+    expect(res.headers.get('cache-control') ?? '').toMatch(/no-store/);
+    expect(res.headers.get('cache-control') ?? '').toMatch(/no-transform/);
+    expect(res.headers.get('x-accel-buffering')).toBe('no');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
 
     const events = await readSseEvents(res);
     // Two deltas + final done payload + literal [DONE].

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -390,6 +390,13 @@ describe('POST /v1/messages — openai generation path', () => {
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('provider_error');
     expect(body.error.message).toMatch(/timed out/i);
+    // 502 from a provider timeout still rides the standard pipeline —
+    // X-Request-Id must be present so an oncall can correlate logs and
+    // the upstream provider request that hung. Pin it explicitly because
+    // the provider-error path is a narrow code branch that's easy to
+    // accidentally bypass with a bare res.end().
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -104,6 +104,21 @@ describe('POST /v1/projects', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('accepts application/json with charset=utf-8 (RFC 8259 normative)', async () => {
+    // The content-type check uses substring includes('application/json') so
+    // a Content-Type with parameters must still pass. Pin it because a
+    // future tightening to strict equality would break clients that use
+    // fetch() defaults (which often append the charset).
+    const res = await fetch(`${harness.baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ name: 'with-charset' }),
+    });
+    // Either 201 (success) or 401 (auth not configured here) is fine — the
+    // critical regression is that this is NOT 415 unsupported_media_type.
+    expect(res.status).not.toBe(415);
+  });
+
   it('returns 400 invalid_body for a JSON array body (not an object)', async () => {
     // Same path: object schema rejects arrays. Caller must not be able to
     // sneak past validation by sending [{...}] hoping the array-form is

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -88,6 +88,37 @@ describe('POST /v1/projects', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('returns 400 invalid_body for an explicit null JSON body', async () => {
+    // The schema is s.object(...); s.object rejects null with the
+    // 'must be a JSON object' error. Make sure the controller surfaces
+    // that as a 400 invalid_body, not a 500 from a destructure later.
+    const res = await fetch(`${harness.baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'null',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<unknown>;
+    expect(body.ok).toBe(false);
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('invalid_body');
+  });
+
+  it('returns 400 invalid_body for a JSON array body (not an object)', async () => {
+    // Same path: object schema rejects arrays. Caller must not be able to
+    // sneak past validation by sending [{...}] hoping the array-form is
+    // ignored.
+    const res = await fetch(`${harness.baseUrl}/v1/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([{ name: 'A' }]),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<unknown>;
+    if (body.ok) throw new Error('expected error envelope');
+    expect(body.error.code).toBe('invalid_body');
+  });
+
   it('returns 400 for invalid JSON body', async () => {
     const res = await fetch(`${harness.baseUrl}/v1/projects`, {
       method: 'POST',


### PR DESCRIPTION
## Summary

Ten-commit batch. The headline is a small new helper (`requireUser`) that centralises the 401 boilerplate repeated across 26 controller call sites. Adopted in one controller as a proof-of-use; the other 25 stay as-is and can migrate at their own pace. Rest of the batch is regression coverage that pins contracts so future refactors fail CI before they ship.

### New helper + adoption (small refactor, no contract change)
- **`requireUser(req, resolver)`** — returns `{ ok: true; user }` or `{ ok: false; result: 401 }`. Generic over the user shape. Intentionally lets resolver errors propagate (no silent auth-as-anonymous masking).
- **Adopted in `state-db.controller.ts`** — single call site, lowest-risk migration. Tests still green; unauth envelope byte-identical.

### Regression coverage (pure tests, no behaviour change)
- SSE response rides `Cache-Control: no-store, no-transform`, `X-Accel-Buffering: no`, `X-Request-Id` — proxy-bypass hints for streaming.
- Logout is idempotent (double-fire = 200 + Max-Age=0 twice).
- `meController` expired-session cleanup is fire-and-forget (hung delete < 500ms response) AND error-swallowing (throwing delete doesn't crash).
- Provider-timeout 502 still rides `X-Request-Id` + `Cache-Control: no-store` — observability parity across all provider failure modes.
- `ok()` / `fail()` envelope invariants: ok never has `error`, fail never has `data`, fail omits `details` cleanly.
- `isHttpMethod` rejects TRACE/PROPFIND/lowercase. `isRecord` rejects null/array/primitive.
- POST `/v1/projects` rejects explicit `null` + array body with 400 `invalid_body` (no destructure crash).
- `/v1/health/deep` emits `cache-control: no-store` on both 200 and 503 — health probes are cache footguns.
- `application/json; charset=utf-8` is accepted (RFC 8259 normative) — substring-includes check pinned.

### Tests
- 451 backend tests pass (was 432). +19 new tests across 6 files.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 451/451 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)