### PR TITLE
Backend hardening batch 6: requireUser rollout (24 sites) + stream observability

### DIFF
--- a/apps/api/src/controllers/chat-windows-db.controller.ts
+++ b/apps/api/src/controllers/chat-windows-db.controller.ts
@@ -12,6 +12,7 @@ import {
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ChatWindowPatch } from '../db/chat-windows.repo.js';
 import * as chatWindowsRepo from '../db/chat-windows.repo.js';
@@ -92,13 +93,13 @@ export async function listChatWindowsDbController(
   ctx: RequestContext,
   deps: ChatWindowsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const workspaceId = ctx.url.searchParams.get('workspaceId') ?? '';
   if (!workspaceId) return respondError('validation_error', 'Query param workspaceId is required');
 
-  const rows = await deps.listChatWindows(workspaceId, user.id);
+  const rows = await deps.listChatWindows(workspaceId, auth.user.id);
   if (rows === null) return respondNotFound(`Workspace ${workspaceId} not found`);
   return respond(rows.map(toChatWindow));
 }
@@ -107,8 +108,8 @@ export async function createChatWindowDbController(
   ctx: RequestContext,
   deps: ChatWindowsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, CreateChatWindowDbBody);
   if (!body.ok) return body.result;
@@ -123,7 +124,7 @@ export async function createChatWindowDbController(
 
   const row = await deps.createChatWindow(
     body.value.workspaceId,
-    user.id,
+    auth.user.id,
     body.value.title,
     body.value.provider,
     body.value.model,
@@ -137,11 +138,11 @@ export async function getChatWindowDbController(
   ctx: RequestContext,
   deps: ChatWindowsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.findChatWindow(id, user.id);
+  const row = await deps.findChatWindow(id, auth.user.id);
   return row ? respond(toChatWindow(row)) : respondNotFound(`ChatWindow ${id} not found`);
 }
 
@@ -149,14 +150,14 @@ export async function patchChatWindowDbController(
   ctx: RequestContext,
   deps: ChatWindowsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, PatchChatWindowDbBody);
   if (!body.ok) return body.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.updateChatWindow(id, user.id, body.value);
+  const row = await deps.updateChatWindow(id, auth.user.id, body.value);
   return row ? respond(toChatWindow(row)) : respondNotFound(`ChatWindow ${id} not found`);
 }
 
@@ -164,10 +165,10 @@ export async function deleteChatWindowDbController(
   ctx: RequestContext,
   deps: ChatWindowsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const deleted = await deps.deleteChatWindow(id, user.id);
+  const deleted = await deps.deleteChatWindow(id, auth.user.id);
   return deleted ? respondNoContent() : respondNotFound(`ChatWindow ${id} not found`);
 }

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -12,6 +12,7 @@ import {
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import { captureException } from '../lib/sentry.js';
 import { env } from '../config/env.js';
@@ -137,8 +138,9 @@ export async function listMessagesDbController(
   ctx: RequestContext,
   deps: MessagesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
+  const user = auth.user;
 
   const chatWindowId = ctx.url.searchParams.get('chatWindowId') ?? '';
   if (!chatWindowId) return respondError('validation_error', 'Query param chatWindowId is required');
@@ -152,8 +154,9 @@ export async function createMessageDbController(
   ctx: RequestContext,
   deps: MessagesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
+  const user = auth.user;
 
   const body = await parseJsonBody(ctx, CreateMessageDbBody);
   if (!body.ok) return body.result;
@@ -241,8 +244,9 @@ export async function getMessageDbController(
   ctx: RequestContext,
   deps: MessagesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
+  const user = auth.user;
 
   const id = ctx.params['id'] ?? '';
   const row = await deps.findMessage(id, user.id);
@@ -259,8 +263,9 @@ export async function streamMessageDbController(
   ctx: RequestContext,
   deps: MessagesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
+  const user = auth.user;
 
   const body = await parseJsonBody(ctx, CreateMessageDbBody);
   if (!body.ok) return body.result;

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -413,5 +413,13 @@ export async function streamMessageDbController(
   });
   res.write('data: [DONE]\n\n');
   res.end();
+  logger.info('stream completed', {
+    requestId:        ctx.requestId,
+    provider:         cw.provider,
+    model,
+    promptTokens:     usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    latencyMs,
+  });
   return respondStreamed(200);
 }

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -15,6 +15,7 @@ import { s } from '../lib/schema.js';
 import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import { captureException } from '../lib/sentry.js';
+import { logger } from '../lib/logger.js';
 import { env } from '../config/env.js';
 import type { Db, AssistantMessageMetadata } from '../db/messages.repo.js';
 import * as messagesRepo from '../db/messages.repo.js';
@@ -362,6 +363,13 @@ export async function streamMessageDbController(
     // throw happens because we asked the upstream to stop. Don't ship an
     // 'error' SSE event (the client is gone anyway) and don't capture it.
     if (aborted) {
+      logger.info('stream cancelled by client disconnect', {
+        requestId: ctx.requestId,
+        provider: cw.provider,
+        model: cw.model,
+        partialBytes: assistantContent.length,
+        durationMs: Date.now() - startedAt,
+      });
       try { res.end(); } catch { /* socket already closed */ }
       return respondStreamed(499);
     }

--- a/apps/api/src/controllers/projects-db.controller.ts
+++ b/apps/api/src/controllers/projects-db.controller.ts
@@ -5,7 +5,6 @@ import {
   parseJsonBody,
   respond,
   respondCreated,
-  respondError,
   respondNoContent,
   respondNotFound,
   type InternalResult,

--- a/apps/api/src/controllers/projects-db.controller.ts
+++ b/apps/api/src/controllers/projects-db.controller.ts
@@ -12,6 +12,7 @@ import {
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ProjectPatch } from '../db/projects.repo.js';
 import * as projectsRepo from '../db/projects.repo.js';
@@ -84,10 +85,10 @@ export async function listProjectsDbController(
   ctx: RequestContext,
   deps: ProjectsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
-  const rows = await deps.listProjects(user.id);
+  const rows = await deps.listProjects(auth.user.id);
   return respond(rows.map(toProject));
 }
 
@@ -95,13 +96,13 @@ export async function createProjectDbController(
   ctx: RequestContext,
   deps: ProjectsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, CreateProjectDbBody);
   if (!body.ok) return body.result;
 
-  const row = await deps.createProject(user.id, body.value.name, body.value.description ?? undefined);
+  const row = await deps.createProject(auth.user.id, body.value.name, body.value.description ?? undefined);
   const project = toProject(row);
   return respondCreated(project, getProjectPath(project.id));
 }
@@ -110,11 +111,11 @@ export async function getProjectDbController(
   ctx: RequestContext,
   deps: ProjectsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.findProject(id, user.id);
+  const row = await deps.findProject(id, auth.user.id);
   return row ? respond(toProject(row)) : respondNotFound(`Project ${id} not found`);
 }
 
@@ -122,14 +123,14 @@ export async function patchProjectDbController(
   ctx: RequestContext,
   deps: ProjectsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, PatchProjectDbBody);
   if (!body.ok) return body.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.updateProject(id, user.id, body.value);
+  const row = await deps.updateProject(id, auth.user.id, body.value);
   return row ? respond(toProject(row)) : respondNotFound(`Project ${id} not found`);
 }
 
@@ -137,10 +138,10 @@ export async function deleteProjectDbController(
   ctx: RequestContext,
   deps: ProjectsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const deleted = await deps.deleteProject(id, user.id);
+  const deleted = await deps.deleteProject(id, auth.user.id);
   return deleted ? respondNoContent() : respondNotFound(`Project ${id} not found`);
 }

--- a/apps/api/src/controllers/provider-connections.controller.ts
+++ b/apps/api/src/controllers/provider-connections.controller.ts
@@ -10,6 +10,7 @@ import {
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, ProviderConnectionMeta } from '../db/provider-connections.repo.js';
 import * as providerRepo from '../db/provider-connections.repo.js';
@@ -80,9 +81,9 @@ export async function listConnectionsController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
-  const list = await deps.listConnections(user.id);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
+  const list = await deps.listConnections(auth.user.id);
   return respond(list.map(toResponse));
 }
 
@@ -90,11 +91,11 @@ export async function getConnectionController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
-  const meta = await deps.findConnection(user.id, provider);
+  const meta = await deps.findConnection(auth.user.id, provider);
   return meta ? respond(toResponse(meta)) : respondNotFound(`No connection for provider '${provider}'`);
 }
 
@@ -102,8 +103,8 @@ export async function upsertConnectionController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
   if (!ENABLED_PROVIDERS.has(provider)) {
@@ -119,7 +120,7 @@ export async function upsertConnectionController(
   if (verifyResult === 'provider_error') {
     return respondError('provider_error', 'Could not reach the provider to validate the key — try again later', 502);
   }
-  const meta = await deps.upsertConnection(user.id, provider, apiKey);
+  const meta = await deps.upsertConnection(auth.user.id, provider, apiKey);
   return respond(toResponse(meta));
 }
 
@@ -127,11 +128,11 @@ export async function deleteConnectionController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
   const provider = parseProvider(ctx.params['provider'] ?? '');
   if (!provider) return respondError('validation_error', 'Unknown provider', 400);
-  await deps.deleteConnection(user.id, provider);
+  await deps.deleteConnection(auth.user.id, provider);
   return respond(null);
 }
 
@@ -139,13 +140,13 @@ export async function testConnectionController(
   ctx: RequestContext,
   deps: ProviderConnectionsDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const connectionId = ctx.params['id'] ?? '';
   if (!connectionId) return respondError('validation_error', 'Missing connection id', 400);
 
-  const record = await deps.getDecryptedKeyById(user.id, connectionId);
+  const record = await deps.getDecryptedKeyById(auth.user.id, connectionId);
   if (!record) return respondNotFound(`No connection found with id '${connectionId}'`);
 
   const rl = deps.checkRateLimit(connectionId);

--- a/apps/api/src/controllers/workspaces-db.controller.ts
+++ b/apps/api/src/controllers/workspaces-db.controller.ts
@@ -12,6 +12,7 @@ import {
   type RequestContext,
 } from '../lib/http.js';
 import { s } from '../lib/schema.js';
+import { requireUser } from '../lib/auth-helper.js';
 import { resolveCurrentUser } from '../lib/resolve-user.js';
 import type { Db, WorkspacePatch } from '../db/workspaces.repo.js';
 import * as workspacesRepo from '../db/workspaces.repo.js';
@@ -94,13 +95,13 @@ export async function listWorkspacesDbController(
   ctx: RequestContext,
   deps: WorkspacesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const projectId = ctx.url.searchParams.get('projectId') ?? '';
   if (!projectId) return respondError('validation_error', 'Query param projectId is required');
 
-  const rows = await deps.listWorkspaces(projectId, user.id);
+  const rows = await deps.listWorkspaces(projectId, auth.user.id);
   if (rows === null) return respondNotFound(`Project ${projectId} not found`);
   const windowRows = await deps.listWindowIds(rows.map((r) => r.id));
   const windowMap = buildWindowMap(windowRows);
@@ -111,13 +112,13 @@ export async function createWorkspaceDbController(
   ctx: RequestContext,
   deps: WorkspacesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, CreateWorkspaceDbBody);
   if (!body.ok) return body.result;
 
-  const row = await deps.createWorkspace(body.value.projectId, user.id, body.value.name);
+  const row = await deps.createWorkspace(body.value.projectId, auth.user.id, body.value.name);
   if (row === null) return respondNotFound(`Project ${body.value.projectId} not found`);
   return respondCreated(toWorkspace(row, []), getWorkspacePath(row.id));
 }
@@ -126,11 +127,11 @@ export async function getWorkspaceDbController(
   ctx: RequestContext,
   deps: WorkspacesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.findWorkspace(id, user.id);
+  const row = await deps.findWorkspace(id, auth.user.id);
   if (!row) return respondNotFound(`Workspace ${id} not found`);
   const windowRows = await deps.listWindowIds([row.id]);
   return respond(toWorkspace(row, windowRows.map((cw) => cw.id)));
@@ -140,14 +141,14 @@ export async function patchWorkspaceDbController(
   ctx: RequestContext,
   deps: WorkspacesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const body = await parseJsonBody(ctx, PatchWorkspaceDbBody);
   if (!body.ok) return body.result;
 
   const id = ctx.params['id'] ?? '';
-  const row = await deps.updateWorkspace(id, user.id, body.value);
+  const row = await deps.updateWorkspace(id, auth.user.id, body.value);
   if (!row) return respondNotFound(`Workspace ${id} not found`);
   const windowRows = await deps.listWindowIds([row.id]);
   return respond(toWorkspace(row, windowRows.map((cw) => cw.id)));
@@ -157,10 +158,10 @@ export async function deleteWorkspaceDbController(
   ctx: RequestContext,
   deps: WorkspacesDeps,
 ): Promise<InternalResult> {
-  const user = await deps.resolveUser(ctx.req);
-  if (!user) return respondError('unauthenticated', 'Not authenticated', 401);
+  const auth = await requireUser(ctx.req, deps.resolveUser);
+  if (!auth.ok) return auth.result;
 
   const id = ctx.params['id'] ?? '';
-  const deleted = await deps.deleteWorkspace(id, user.id);
+  const deleted = await deps.deleteWorkspace(id, auth.user.id);
   return deleted ? respondNoContent() : respondNotFound(`Workspace ${id} not found`);
 }

--- a/apps/api/src/lib/auth-helper.test.ts
+++ b/apps/api/src/lib/auth-helper.test.ts
@@ -42,4 +42,26 @@ describe('requireUser', () => {
       requireUser(fakeReq, async () => { throw new Error('db down'); }),
     ).rejects.toThrow('db down');
   });
+
+  it('emits a 401 result with NO headers attached (no Set-Cookie, no Allow leakage)', async () => {
+    // The 401 response from requireUser is built via respondError('unauthenticated', ...).
+    // It must not carry a headers object — a refactor that decided to attach
+    // Set-Cookie or Allow on unauth would leak information (e.g. Allow could
+    // tell an unauthenticated probe which methods exist on the route, and a
+    // Set-Cookie clear is the responsibility of the explicit logout path).
+    const r = await requireUser(fakeReq, async () => null);
+    if (r.ok) throw new Error('expected fail');
+    expect(r.result.headers).toBeUndefined();
+    expect(r.result.streamed).toBeUndefined();
+  });
+
+  it('returns a 400-default-overridden 401 status (not the respondError default)', async () => {
+    // respondError defaults to 400. The helper passes 401 explicitly. Pin
+    // that explicit override so a refactor that drops the 401 argument and
+    // accidentally falls back to 400 fails CI.
+    const r = await requireUser(fakeReq, async () => null);
+    if (r.ok) throw new Error('expected fail');
+    expect(r.result.httpStatus).toBe(401);
+    expect(r.result.httpStatus).not.toBe(400);
+  });
 });

--- a/apps/api/src/lib/auth-helper.test.ts
+++ b/apps/api/src/lib/auth-helper.test.ts
@@ -64,4 +64,14 @@ describe('requireUser', () => {
     expect(r.result.httpStatus).toBe(401);
     expect(r.result.httpStatus).not.toBe(400);
   });
+
+  it('401 envelope carries no details field (no information leak via the body)', async () => {
+    // The 401 envelope must be the minimum: { code, message } only. A
+    // future refactor that piped extra context (originating ip, why-401,
+    // etc.) into details would leak diagnostic info to anonymous callers.
+    const r = await requireUser(fakeReq, async () => null);
+    if (r.ok) throw new Error('expected fail');
+    if (r.result.body.ok) throw new Error('expected error envelope');
+    expect('details' in r.result.body.error).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Ten-commit batch. Two themes:

1. **Complete `requireUser` rollout** across all DB-mode authenticated controllers — 24 call sites migrated across 5 controllers. The helper was introduced as opt-in in batch 5 (#143) with one proof-of-use; this batch finishes the migration so the 401 unauth envelope is now produced from a single helper call site instead of 26 inline copies.
2. **Stream observability** — structured info logs on both `/v1/messages/stream` lifecycle terminals (client-disconnect cancel + clean completion). Purely additive, no SSE event change, no client-visible behaviour change.

### Migrations
- `provider-connections.controller.ts` — 5 sites
- `chat-windows-db.controller.ts` — 5 sites
- `workspaces-db.controller.ts` — 5 sites
- `projects-db.controller.ts` — 5 sites + dropped now-unused `respondError` import
- `messages-db.controller.ts` — 4 sites (kept `const user = auth.user` rebinding to minimise diff in the streaming/AI flow)

Total: **24 sites**. The only remaining inline `if (!user)` site is in `auth.controller.ts:meController` and uses a different message ('User not found') for the user-deleted branch — not a candidate.

### Helper hardening (regression coverage)
- 401 result has no `headers` (no Set-Cookie, no Allow-leakage)
- 401 envelope has no `details` field (no information leak)
- Status is explicitly 401, not the respondError 400 default

### Stream observability
- `stream cancelled by client disconnect` — emitted on the abort path with provider/model/partialBytes/durationMs.
- `stream completed` — emitted on the success path with provider/model/promptTokens/completionTokens/latencyMs.

### Tests
- 454 backend tests pass (was 451). +3 new helper tests.
- All existing route tests still pass (unchanged behaviour).
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 454/454 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)