### PR TITLE
feat(web): productivity batch (sidebar filter, more chat shortcuts, export, grouped help)

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -15,6 +15,7 @@ const SHORTCUTS: Shortcut[] = [
   { keys: ['⌘', 'J'], description: 'Focus the composer of the active chat window (Ctrl+J on Linux/Win)' },
   { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
   { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
+  { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft of the active chat window (Ctrl+Shift+Backspace)' },
   { keys: ['Enter'], description: 'In Find: jump to next match' },
   { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
   { keys: ['Enter'], description: 'In composer: send message' },

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -17,6 +17,7 @@ const GROUPS: ShortcutGroup[] = [
     label: 'Global',
     items: [
       { keys: ['?'], description: 'Show this help' },
+      { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
       { keys: ['Esc'], description: 'Close menus, modals, search bar, this help' },
       { keys: ['⌘', 'K'], description: 'Open command palette — switch chat window by title (Ctrl+K on Linux/Win)' },
     ],
@@ -57,6 +58,11 @@ export function KeyboardShortcutsOverlay() {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
         if (isTypingTarget(e.target)) return;
+        e.preventDefault();
+        setOpen((v) => !v);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === '/') {
         e.preventDefault();
         setOpen((v) => !v);
         return;

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -16,6 +16,8 @@ const SHORTCUTS: Shortcut[] = [
   { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
   { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
   { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft of the active chat window (Ctrl+Shift+Backspace)' },
+  { keys: ['G'], description: 'Jump to the latest message in the active chat (when not typing)' },
+  { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
   { keys: ['Enter'], description: 'In Find: jump to next match' },
   { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
   { keys: ['Enter'], description: 'In composer: send message' },

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -14,6 +14,7 @@ const SHORTCUTS: Shortcut[] = [
   { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
   { keys: ['⌘', 'J'], description: 'Focus the composer of the active chat window (Ctrl+J on Linux/Win)' },
   { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
+  { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
   { keys: ['Enter'], description: 'In Find: jump to next match' },
   { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
   { keys: ['Enter'], description: 'In composer: send message' },

--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -7,20 +7,39 @@ interface Shortcut {
   description: string;
 }
 
-const SHORTCUTS: Shortcut[] = [
-  { keys: ['?'], description: 'Show this help' },
-  { keys: ['Esc'], description: 'Close menus, modals, search bar, this help' },
-  { keys: ['⌘', 'K'], description: 'Open command palette — switch chat window by title (Ctrl+K on Linux/Win)' },
-  { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
-  { keys: ['⌘', 'J'], description: 'Focus the composer of the active chat window (Ctrl+J on Linux/Win)' },
-  { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
-  { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
-  { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft of the active chat window (Ctrl+Shift+Backspace)' },
-  { keys: ['G'], description: 'Jump to the latest message in the active chat (when not typing)' },
-  { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
-  { keys: ['Enter'], description: 'In Find: jump to next match' },
-  { keys: ['Shift', 'Enter'], description: 'In Find: jump to previous match  ·  In composer: newline' },
-  { keys: ['Enter'], description: 'In composer: send message' },
+interface ShortcutGroup {
+  label: string;
+  items: Shortcut[];
+}
+
+const GROUPS: ShortcutGroup[] = [
+  {
+    label: 'Global',
+    items: [
+      { keys: ['?'], description: 'Show this help' },
+      { keys: ['Esc'], description: 'Close menus, modals, search bar, this help' },
+      { keys: ['⌘', 'K'], description: 'Open command palette — switch chat window by title (Ctrl+K on Linux/Win)' },
+    ],
+  },
+  {
+    label: 'Active chat window',
+    items: [
+      { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
+      { keys: ['⌘', 'J'], description: 'Focus the composer (Ctrl+J on Linux/Win)' },
+      { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
+      { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
+      { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft (Ctrl+Shift+Backspace)' },
+      { keys: ['G'], description: 'Jump to the latest message (when not typing)' },
+      { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
+    ],
+  },
+  {
+    label: 'Composer & search',
+    items: [
+      { keys: ['Enter'], description: 'In composer: send message  ·  In Find: jump to next match' },
+      { keys: ['Shift', 'Enter'], description: 'In composer: newline  ·  In Find: jump to previous match' },
+    ],
+  },
 ];
 
 function isTypingTarget(target: EventTarget | null): boolean {
@@ -80,18 +99,25 @@ export function KeyboardShortcutsOverlay() {
             ×
           </button>
         </div>
-        <ul style={listStyle}>
-          {SHORTCUTS.map((s, i) => (
-            <li key={i} style={rowStyle}>
-              <span style={keysCellStyle}>
-                {s.keys.map((k, j) => (
-                  <kbd key={j} style={kbdStyle}>{k}</kbd>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {GROUPS.map((g) => (
+            <div key={g.label}>
+              <div style={groupLabelStyle}>{g.label}</div>
+              <ul style={listStyle}>
+                {g.items.map((s, i) => (
+                  <li key={i} style={rowStyle}>
+                    <span style={keysCellStyle}>
+                      {s.keys.map((k, j) => (
+                        <kbd key={j} style={kbdStyle}>{k}</kbd>
+                      ))}
+                    </span>
+                    <span style={descStyle}>{s.description}</span>
+                  </li>
                 ))}
-              </span>
-              <span style={descStyle}>{s.description}</span>
-            </li>
+              </ul>
+            </div>
           ))}
-        </ul>
+        </div>
         <div style={footnoteStyle}>
           Press <kbd style={kbdStyle}>?</kbd> to toggle this list.
         </div>
@@ -184,4 +210,13 @@ const footnoteStyle: React.CSSProperties = {
   marginTop: 12,
   fontSize: '0.72rem',
   color: '#8a8a95',
+};
+
+
+const groupLabelStyle: React.CSSProperties = {
+  fontSize: '0.65rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: '#6a6a75',
+  marginBottom: 6,
 };

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -90,6 +90,7 @@ export function ChatWindow({
   const lastGAtRef = useRef<number>(0);
   const scrollSaveTimerRef = useRef<number | null>(null);
   const [scrolledAway, setScrolledAway] = useState(false);
+  const [exportLabel, setExportLabel] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   const updateStickiness = () => {
     const el = scrollRef.current;
@@ -115,6 +116,39 @@ export function ChatWindow({
     el.scrollTop = el.scrollHeight;
     stickyRef.current = true;
     setScrolledAway(false);
+  };
+
+  const exportConversation = async () => {
+    if (typeof window === 'undefined') return;
+    const md = messages
+      .filter((m) => (m.status ?? 'ok') === 'ok' && m.content.trim().length > 0)
+      .map((m) => {
+        const role = m.role === 'user' ? 'User' : m.role === 'assistant' ? 'Assistant' : m.role;
+        const stamp = m.createdAt ?? '';
+        const head = stamp ? `**${role}** · ${stamp}` : `**${role}**`;
+        return `${head}\n\n${m.content}`;
+      })
+      .join('\n\n---\n\n');
+    const header = `# ${title}\n\n_${provider} · ${model}_\n\n`;
+    const text = header + (md || '_(empty)_') + '\n';
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else if (typeof document !== 'undefined') {
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      setExportLabel('copied');
+    } catch {
+      setExportLabel('failed');
+    }
+    setTimeout(() => setExportLabel('idle'), 1800);
   };
 
   useLayoutEffect(() => {
@@ -356,6 +390,31 @@ export function ChatWindow({
           <ProviderBadge provider={provider} model={model} />
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              void exportConversation();
+            }}
+            aria-label="Copy conversation as Markdown"
+            title="Copy conversation as Markdown"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: exportLabel === 'copied' ? '#9aa6ff' : exportLabel === 'failed' ? '#ff8b8b' : '#8a8a95',
+              cursor: 'pointer',
+              fontSize: '0.7rem',
+              fontWeight: 500,
+              padding: '0.25rem 0.5rem',
+              borderRadius: 6,
+              lineHeight: 1,
+              fontFamily: 'inherit',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            {exportLabel === 'copied' ? 'Copied' : exportLabel === 'failed' ? 'Failed' : 'Export'}
+          </button>
           <button
             type="button"
             onClick={(e) => {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -204,11 +204,16 @@ export function ChatWindow({
         e.preventDefault();
         setTitleDraft(title);
         setEditing(true);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'w' || e.key === 'W') && onClose) {
+        e.preventDefault();
+        onClose(id);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, onRename, title]);
+  }, [active, onRename, onClose, title, id]);
 
   const commitRename = () => {
     const trimmed = titleDraft.trim();

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -87,6 +87,7 @@ export function ChatWindow({
 
   const scrollStorageKey = `wav.chat.scroll.${id}`;
   const restoredScrollRef = useRef(false);
+  const lastGAtRef = useRef<number>(0);
   const scrollSaveTimerRef = useRef<number | null>(null);
   const [scrolledAway, setScrolledAway] = useState(false);
 
@@ -215,6 +216,33 @@ export function ChatWindow({
         e.preventDefault();
         setDraft('');
         requestAnimationFrame(() => textareaRef.current?.focus());
+        return;
+      }
+      // Vim-style: G jumps to bottom; g g jumps to top. Only when not typing.
+      if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+        const target = e.target;
+        const typing = target instanceof HTMLElement
+          && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+        if (typing) return;
+        if (e.key === 'G' && e.shiftKey) {
+          e.preventDefault();
+          scrollToBottom();
+          return;
+        }
+        if (e.key === 'g' && !e.shiftKey) {
+          e.preventDefault();
+          if (lastGAtRef.current && Date.now() - lastGAtRef.current < 600) {
+            const el = scrollRef.current;
+            if (el) {
+              el.scrollTop = 0;
+              stickyRef.current = false;
+              setScrolledAway(true);
+            }
+            lastGAtRef.current = 0;
+          } else {
+            lastGAtRef.current = Date.now();
+          }
+        }
       }
     };
     window.addEventListener('keydown', onKey);

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -209,6 +209,12 @@ export function ChatWindow({
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'w' || e.key === 'W') && onClose) {
         e.preventDefault();
         onClose(id);
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'Backspace') {
+        e.preventDefault();
+        setDraft('');
+        requestAnimationFrame(() => textareaRef.current?.focus());
       }
     };
     window.addEventListener('keydown', onKey);

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -162,7 +162,21 @@ export function WorkspaceSidebar({
         }}
       >
         <NewWindowComposer onCreate={onCreate} />
-        <Button variant="ghost" onClick={onReset} style={{ flex: 1, fontSize: '0.78rem' }}>
+        <Button
+          variant="ghost"
+          title="Reset workspace view (close/reopen state)"
+          onClick={() => {
+            if (typeof window === 'undefined') {
+              onReset();
+              return;
+            }
+            const ok = window.confirm(
+              'Reset the workspace view? This reopens every closed window and discards local close/reopen state. Server data is unchanged.',
+            );
+            if (ok) onReset();
+          }}
+          style={{ flex: 1, fontSize: '0.78rem' }}
+        >
           Reset
         </Button>
       </div>

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -48,6 +48,19 @@ export function WorkspaceSidebar({
   onReset,
 }: WorkspaceSidebarProps) {
   const total = visibleWindows.length + closedWindows.length;
+  const [windowFilter, setWindowFilter] = useState('');
+  const filterEnabled = total >= 5;
+  const lowerFilter = windowFilter.trim().toLowerCase();
+  const matchesFilter = (w: ChatWindow): boolean => {
+    if (!lowerFilter) return true;
+    return (
+      w.title.toLowerCase().includes(lowerFilter) ||
+      w.model.toLowerCase().includes(lowerFilter) ||
+      w.provider.toLowerCase().includes(lowerFilter)
+    );
+  };
+  const filteredVisible = filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows;
+  const filteredClosed = filterEnabled ? closedWindows.filter(matchesFilter) : closedWindows;
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
 
   return (
@@ -87,11 +100,25 @@ export function WorkspaceSidebar({
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '0.5rem' }}>
-        <SectionLabel>Open · {visibleWindows.length}</SectionLabel>
-        {visibleWindows.length === 0 ? (
-          <EmptyHint>No windows open</EmptyHint>
+        {filterEnabled ? (
+          <div style={{ padding: '0 0.05rem 0.5rem' }}>
+            <input
+              type="text"
+              value={windowFilter}
+              onChange={(e) => setWindowFilter(e.target.value)}
+              placeholder="Filter windows…"
+              aria-label="Filter chat windows"
+              style={filterInputStyle}
+            />
+          </div>
+        ) : null}
+        <SectionLabel>
+          Open · {filterEnabled && lowerFilter ? `${filteredVisible.length}/${visibleWindows.length}` : visibleWindows.length}
+        </SectionLabel>
+        {filteredVisible.length === 0 ? (
+          <EmptyHint>{lowerFilter ? 'No matches' : 'No windows open'}</EmptyHint>
         ) : (
-          visibleWindows.map((w) => (
+          filteredVisible.map((w) => (
             <WindowRow
               key={w.id}
               window={w}
@@ -104,10 +131,12 @@ export function WorkspaceSidebar({
           ))
         )}
 
-        {closedWindows.length > 0 ? (
+        {filteredClosed.length > 0 ? (
           <>
-            <SectionLabel>Closed · {closedWindows.length}</SectionLabel>
-            {closedWindows.map((w) => (
+            <SectionLabel>
+              Closed · {filterEnabled && lowerFilter ? `${filteredClosed.length}/${closedWindows.length}` : closedWindows.length}
+            </SectionLabel>
+            {filteredClosed.map((w) => (
               <WindowRow
                 key={w.id}
                 window={w}
@@ -738,3 +767,15 @@ function formatRelative(iso: string | null | undefined): string | null {
   const yr = Math.floor(day / 365);
   return `${yr}y`;
 }
+
+const filterInputStyle: React.CSSProperties = {
+  width: '100%',
+  background: '#0f0f13',
+  border: '1px solid #2a2a30',
+  borderRadius: 6,
+  padding: '0.35rem 0.55rem',
+  color: '#f5f5f5',
+  fontSize: '0.78rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -632,6 +632,12 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
       role="button"
       tabIndex={0}
       onClick={onClick}
+      onAuxClick={(e) => {
+        if (e.button === 1) {
+          e.preventDefault();
+          onAction();
+        }
+      }}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();


### PR DESCRIPTION
Continuation of the chat/workspace productivity work after #144 (Cmd-K palette + Cmd-E rename). This branch is **stacked on `feat/web-command-palette`** (PR #144) — merge that first; this rebases trivially onto main once it lands.

## What
- **Sidebar window filter** — auto-shown when total ≥ 5. Substring match on title / model / provider. Section labels become `<filtered>/<total>` while filtering.
- **Cmd / Ctrl + Shift + W** — close the active chat window (avoids the Cmd+W browser collision; matches "close pane" in editors).
- **Cmd / Ctrl + Shift + Backspace** — clear the composer draft of the active chat window, then refocus.
- **Vim-style g / G** — when not typing: `G` jumps to the latest message, `gg` jumps to the top. Keystrokes consumed only on the active window.
- **Export chat as Markdown** — new "Export" pill in the chat header copies the entire conversation to clipboard with provider/model header + ISO-stamped role blocks. Inline label flips Copied / Failed for ~1.8s.
- **Cmd / Ctrl + /** — toggles the shortcuts overlay even while the user is typing in an input/textarea (the modifier signals intent; `?` keeps its no-typing guard).
- **Sidebar Reset confirm** — Reset button now asks confirmation; clarifies that server data is unchanged.
- **Grouped shortcuts overlay** — list reorganized into Global / Active chat window / Composer & search sections.
- **Middle-click sidebar row** — invokes the row's action (close on open rows, reopen on closed rows).

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx` — Shift+W, Shift+Backspace, g/G, Export
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx` — filter input, Reset confirm, middle-click
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx` — Cmd+/ + grouping + new entries

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)