### PR TITLE
Backend hardening batch 7: /me + auth semantic hardening + enumeration-resistance regressions

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -161,7 +161,10 @@ export async function logoutController(ctx: RequestContext, deps: AuthDeps): Pro
   const cookies = parseCookies(ctx.req.headers.cookie);
   const token   = cookies[SESSION_COOKIE_NAME];
 
-  if (token) {
+  // Same trim-empty short-circuit as meController: a whitespace-only cookie
+  // is a probe / clearing artefact, not a real session — don't waste a
+  // session-by-hash lookup on it.
+  if (token && token.trim().length > 0) {
     await deps.deleteSession(hashSessionToken(token));
   }
 

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -173,27 +173,37 @@ export async function logoutController(ctx: RequestContext, deps: AuthDeps): Pro
   };
 }
 
+// All 401 paths from /v1/auth/me share this single envelope so a caller can
+// not distinguish 'no cookie' / 'session unknown' / 'session expired' /
+// 'user deleted' from the response message — that distinction is an
+// account-enumeration oracle. Test pin: see auth.test.ts ("always returns the
+// unauthenticated code on 401"). The error code is already uniform; this
+// unifies the human-readable message too.
+const ME_UNAUTH = respondError('unauthenticated', 'Not authenticated', 401);
+
 export async function meController(ctx: RequestContext, deps: AuthDeps): Promise<InternalResult> {
   const cookies = parseCookies(ctx.req.headers.cookie);
   const token   = cookies[SESSION_COOKIE_NAME];
 
-  if (!token) return respondError('unauthenticated', 'Not authenticated', 401);
+  // Reject empty AND whitespace-only token values without ever touching the
+  // session repo. A trimmed-empty cookie is either a clearing artefact or a
+  // probe — both should short-circuit identically to a missing cookie.
+  if (!token || token.trim().length === 0) return ME_UNAUTH;
 
   const tokenHash = hashSessionToken(token);
   const session = await deps.findSessionByTokenHash(tokenHash);
-  if (!session) {
-    return respondError('unauthenticated', 'Session expired or invalid', 401);
-  }
+  if (!session) return ME_UNAUTH;
+
   if (session.expiresAt <= new Date()) {
     // Opportunistic cleanup — the matching row is now strictly stale, no
     // value keeping it in the DB. Fire-and-forget so we don't add latency
     // to the response, and swallow errors (best-effort hygiene).
     deps.deleteSession(tokenHash).catch(() => { /* ignore */ });
-    return respondError('unauthenticated', 'Session expired or invalid', 401);
+    return ME_UNAUTH;
   }
 
   const user = await deps.findUserById(session.userId);
-  if (!user) return respondError('unauthenticated', 'User not found', 401);
+  if (!user) return ME_UNAUTH;
 
   return respond(toSafeUser(user));
 }

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -155,6 +155,13 @@ describe('POST /v1/auth/signup', () => {
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('conflict');
+    // 409 must not be cacheable either — a cached 409 would falsely tell a
+    // legit signup attempt that their email is taken even after the
+    // conflicting account was deleted upstream.
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    // 409 must NOT emit a Set-Cookie either — there's no session to grant
+    // when the signup failed.
+    expect(res.headers.get('set-cookie')).toBeNull();
     await c();
   });
 });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -113,6 +113,12 @@ describe('POST /v1/auth/signup', () => {
     const maxAgeMatch = cookie?.match(/Max-Age=(\d+)/);
     expect(maxAgeMatch).not.toBeNull();
     expect(Number(maxAgeMatch?.[1])).toBeGreaterThan(0);
+    // CRITICAL: a successful signup ships a Set-Cookie with the session
+    // token. If this response gets cached by a CDN, every cache HIT below
+    // hands the same session cookie to a different user. Cache-Control:
+    // no-store is the only thing keeping that catastrophe from being one
+    // misconfigured CDN away.
+    expect(res.headers.get('cache-control')).toBe('no-store');
   });
 
   it('normalises email to lowercase', async () => {
@@ -177,6 +183,10 @@ describe('POST /v1/auth/login', () => {
     const cookie = getSetCookie(res);
     expect(cookie).toBeTruthy();
     expect(cookie).toContain(`${SESSION_COOKIE_NAME}=`);
+    // Same caching catastrophe as signup: a 200 with Set-Cookie that hits a
+    // shared cache would broadcast one user's session to everyone. Pin
+    // Cache-Control: no-store on the success path explicitly.
+    expect(res.headers.get('cache-control')).toBe('no-store');
 
     await close();
   });

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -403,6 +403,23 @@ describe('GET /v1/auth/me', () => {
     expect(b3.error.message).toBe('Not authenticated');
   });
 
+  it('401 from /me does not emit a Set-Cookie header (no surprise session clear)', async () => {
+    // /me is a read endpoint. A 401 should not mutate the caller's cookie
+    // jar — only the explicit /logout path is allowed to emit Set-Cookie
+    // for the session cookie. Pin this so a refactor that defensively
+    // 'cleans up' a stale cookie on /me 401 doesn't accidentally log out
+    // a legit user whose session got invalidated server-side.
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async () => null,
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=${'a'.repeat(64)}` },
+    });
+    expect(res.status).toBe(401);
+    expect(res.headers.get('set-cookie')).toBeNull();
+    await close();
+  });
+
   it('rejects whitespace-only session cookie without touching the session repo', async () => {
     // Probe with a whitespace-only token: must short-circuit before any DB
     // lookup and return the same envelope as a missing cookie. Otherwise an

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -649,6 +649,24 @@ describe('rate limiting — login', () => {
     await close();
   });
 
+  it('rejects whitespace-only email with 400 invalid_body (schema trims and enforces min:1)', async () => {
+    // The login schema trims the email field — pin that whitespace-only
+    // input rejects with invalid_body, not 401, and never reaches the
+    // user repo. Otherwise an attacker could probe whether the system
+    // accepts 'empty' emails as a backdoor (it won't, but pin it).
+    let lookupCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => { lookupCalls++; return null; },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: '   ', password: 'anything' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('invalid_body');
+    expect(lookupCalls).toBe(0);
+    await close();
+  });
+
   it('rate-limit gate fires BEFORE the user lookup (no enumeration via timing)', async () => {
     // Pin the order of operations: when the bucket is full, login must
     // short-circuit BEFORE calling findUserByEmail. Otherwise a probe

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -395,6 +395,32 @@ describe('GET /v1/auth/me', () => {
     expect(b1.error.code).toBe('unauthenticated');
     expect(b2.error.code).toBe('unauthenticated');
     expect(b3.error.code).toBe('unauthenticated');
+    // The human-readable message is also unified across all paths so a
+    // sophisticated probe can't distinguish 'session expired' from 'user
+    // deleted' from 'no cookie' via the message string. Pin all three.
+    expect(b1.error.message).toBe('Not authenticated');
+    expect(b2.error.message).toBe('Not authenticated');
+    expect(b3.error.message).toBe('Not authenticated');
+  });
+
+  it('rejects whitespace-only session cookie without touching the session repo', async () => {
+    // Probe with a whitespace-only token: must short-circuit before any DB
+    // lookup and return the same envelope as a missing cookie. Otherwise an
+    // attacker could measure the timing difference between 'no cookie' and
+    // 'cookie that ends up calling the repo'.
+    let lookupCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async () => { lookupCalls++; return null; },
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Cookie: `${SESSION_COOKIE_NAME}=   ` },
+    });
+    expect(res.status).toBe(401);
+    expect(lookupCalls).toBe(0);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.message).toBe('Not authenticated');
+    await close();
   });
 });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -618,6 +618,21 @@ describe('rate limiting — signup', () => {
     expect(res.status).toBe(201);
     await close();
   });
+
+  it('rate-limit gate fires BEFORE the user-lookup / hash work on signup', async () => {
+    // Mirror of the login gate-ordering test: a full bucket must short-
+    // circuit BEFORE findUserByEmail so an attacker can't enumerate emails
+    // by timing the difference between rate-limited-existing-user and
+    // rate-limited-fresh-email.
+    let userLookups = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      checkRateLimit:  () => ({ ok: false, retryAfterSecs: 60 }),
+      findUserByEmail: async () => { userLookups++; return null; },
+    }));
+    await post(baseUrl, '/v1/auth/signup', { email: 'a@b.com', password: 'password123' });
+    expect(userLookups).toBe(0);
+    await close();
+  });
 });
 
 describe('rate limiting — login', () => {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -487,6 +487,21 @@ describe('POST /v1/auth/logout', () => {
     await close();
   });
 
+  it('does not call deleteSession when the cookie value is whitespace-only', async () => {
+    // Same probe-resistance logic as meController: a whitespace-only token
+    // must not reach the session repo. The cookie is still cleared on the
+    // way out (Max-Age=0) so a subsequent normal logout still works.
+    let deleteCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      deleteSession: async () => { deleteCalls++; },
+    }));
+    const res = await post(baseUrl, '/v1/auth/logout', {}, { Cookie: `${SESSION_COOKIE_NAME}=  ` });
+    expect(res.status).toBe(200);
+    expect(deleteCalls).toBe(0);
+    expect(getSetCookie(res)).toContain('Max-Age=0');
+    await close();
+  });
+
   it('is idempotent — calling logout twice with the same cookie is a 200 each time', async () => {
     // The frontend may double-fire logout (button + tab-close handler), and
     // a second call after the session is already gone must not error. The

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -634,6 +634,22 @@ describe('rate limiting — login', () => {
     await close();
   });
 
+  it('rate-limit gate fires BEFORE the user lookup (no enumeration via timing)', async () => {
+    // Pin the order of operations: when the bucket is full, login must
+    // short-circuit BEFORE calling findUserByEmail. Otherwise a probe
+    // could measure the response time difference between an existing-
+    // user-but-rate-limited path and a non-existing-user-rate-limited
+    // path, which is an account-enumeration oracle.
+    let userLookups = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      checkRateLimit:  () => ({ ok: false, retryAfterSecs: 60 }),
+      findUserByEmail: async () => { userLookups++; return null; },
+    }));
+    await post(baseUrl, '/v1/auth/login', { email: 'a@b.com', password: 'whatever' });
+    expect(userLookups).toBe(0);
+    await close();
+  });
+
   it('resets the bucket after a successful login (legit user is not penalised)', async () => {
     const realHash = await hashPassword('validpassword');
     const resetCalls: string[] = [];


### PR DESCRIPTION
## Summary

Eight-commit batch focused on `/v1/auth/me` + auth-flow semantic hardening. Two production fixes (unified 401 message + whitespace-token short-circuit on /me and /logout); six regression tests pinning order-of-operations and caching/cookie contracts that could otherwise silently regress and turn into account-enumeration oracles or session-leak vectors.

### Production fixes
- **Unified /me 401 envelope** — collapses four distinct messages ('Not authenticated', 'Session expired or invalid' x2, 'User not found') into a single `Not authenticated`. The error code was already uniform; the message strings were a probe oracle that distinguished 'session row exists but stale' from 'cookie matches no session' from 'no cookie at all'.
- **Whitespace-only cookie short-circuit** on /me + /logout — a trimmed-empty cookie is either a clearing artefact or a probe; both should match the no-cookie path exactly so the lookup latency doesn't differentiate.

### Regression coverage
- /me 401 emits no Set-Cookie (read endpoint never mutates the cookie jar).
- Signup 201 + login 200 ride `Cache-Control: no-store` (CDN caching of a Set-Cookie response = session broadcast).
- Signup 409 conflict rides `no-store` + emits no Set-Cookie.
- Login rate-limit gate fires BEFORE user lookup (no enumeration-via-timing on rate-limited responses).
- Signup rate-limit gate fires BEFORE user lookup (mirror).
- Login rejects whitespace-only email via schema trim + min:1.

### Tests
- 460 backend tests pass (was 454). +6 new tests + amended assertions on existing 401-uniformity test.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 460/460 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)