### PR TITLE
feat(web): pin chat windows + toast feedback for chat actions

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -404,8 +404,10 @@ export function ChatWindow({
   const toggleStar = (msgId: string) => {
     setStarredIds((prev) => {
       const next = new Set(prev);
+      const willStar = !next.has(msgId);
       if (next.has(msgId)) next.delete(msgId);
       else next.add(msgId);
+      toast.push('info', willStar ? 'Message starred' : 'Message unstarred');
       return next;
     });
   };

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -949,7 +949,13 @@ export function ChatWindow({
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onComposerKeyDown}
           onFocus={() => onFocus?.(id)}
-          placeholder={pending ? 'Waiting for reply…' : 'Send a message…  (Shift+Enter for newline)'}
+          placeholder={
+            pending
+              ? 'Waiting for reply…'
+              : userPromptHistory.length > 0 && draft.length === 0
+                ? 'Send a message…  (Shift+Enter newline · ↑ history)'
+                : 'Send a message…  (Shift+Enter for newline)'
+          }
           aria-label={`Message ${title}`}
           disabled={pending}
           style={{

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import type { AIProvider } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
+import { useToast } from '@/components/ToastHost';
 
 interface ChatWindowProps {
   id: string;
@@ -91,6 +92,7 @@ export function ChatWindow({
   const scrollSaveTimerRef = useRef<number | null>(null);
   const [scrolledAway, setScrolledAway] = useState(false);
   const [exportLabel, setExportLabel] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const toast = useToast();
 
   const updateStickiness = () => {
     const el = scrollRef.current;
@@ -145,8 +147,10 @@ export function ChatWindow({
         document.body.removeChild(ta);
       }
       setExportLabel('copied');
+      toast.push('success', `${title} — conversation copied as Markdown`);
     } catch {
       setExportLabel('failed');
+      toast.push('error', `${title} — could not copy conversation`);
     }
     setTimeout(() => setExportLabel('idle'), 1800);
   };

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -93,6 +93,14 @@ export function ChatWindow({
   const [scrolledAway, setScrolledAway] = useState(false);
   const [exportLabel, setExportLabel] = useState<'idle' | 'copied' | 'failed'>('idle');
   const toast = useToast();
+  const pinStorageKey = `wav.chat.pinned.${id}`;
+  const [pinned, setPinned] = useState<boolean>(() => readBoolFlag(pinStorageKey));
+  useEffect(() => {
+    writeBoolFlag(pinStorageKey, pinned);
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('wav:pin-changed', { detail: { id, pinned } }));
+    }
+  }, [pinStorageKey, pinned, id]);
 
   const updateStickiness = () => {
     const el = scrollRef.current;
@@ -490,6 +498,32 @@ export function ChatWindow({
           <ProviderBadge provider={provider} model={model} />
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setPinned((v) => !v);
+            }}
+            aria-label={pinned ? 'Unpin chat window' : 'Pin chat window'}
+            aria-pressed={pinned}
+            title={pinned ? 'Unpin (kept first in sidebar)' : 'Pin (keep first in sidebar)'}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: pinned ? '#f0c14b' : '#8a8a95',
+              cursor: 'pointer',
+              fontSize: '0.7rem',
+              fontWeight: 500,
+              padding: '0.25rem 0.5rem',
+              borderRadius: 6,
+              lineHeight: 1,
+              fontFamily: 'inherit',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            {pinned ? 'Pinned' : 'Pin'}
+          </button>
           <button
             type="button"
             onClick={(e) => {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -95,12 +95,18 @@ export function ChatWindow({
   const toast = useToast();
   const pinStorageKey = `wav.chat.pinned.${id}`;
   const [pinned, setPinned] = useState<boolean>(() => readBoolFlag(pinStorageKey));
+  const pinInitRef = useRef(false);
   useEffect(() => {
     writeBoolFlag(pinStorageKey, pinned);
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('wav:pin-changed', { detail: { id, pinned } }));
     }
-  }, [pinStorageKey, pinned, id]);
+    if (!pinInitRef.current) {
+      pinInitRef.current = true;
+      return;
+    }
+    toast.push('info', pinned ? `${title} pinned` : `${title} unpinned`);
+  }, [pinStorageKey, pinned, id, title, toast]);
 
   const updateStickiness = () => {
     const el = scrollRef.current;

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -387,6 +387,7 @@ export function ChatWindow({
       ta.focus();
       ta.selectionStart = ta.selectionEnd = ta.value.length;
     });
+    toast.push('info', `Quoted into ${title}`);
   };
 
   const starredStorageKey = `wav.chat.starred.${id}`;

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -32,6 +32,7 @@ export function WorkspaceCommandPalette({
   onReopen,
 }: WorkspaceCommandPaletteProps) {
   const [open, setOpen] = useState(false);
+  const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinned());
   const [query, setQuery] = useState('');
   const [hover, setHover] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -54,6 +55,14 @@ export function WorkspaceCommandPalette({
   useEffect(() => {
     setHover(0);
   }, [query, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setPinnedSet(readPinned());
+    const onChange = () => setPinnedSet(readPinned());
+    window.addEventListener('wav:pin-changed', onChange);
+    return () => window.removeEventListener('wav:pin-changed', onChange);
+  }, [open]);
 
   useEffect(() => {
     const onKey = (e: globalThis.KeyboardEvent) => {
@@ -156,6 +165,7 @@ export function WorkspaceCommandPalette({
                   <span style={metaStyle}>
                     {it.window.provider} · {it.window.model}
                   </span>
+                  {pinnedSet.has(it.window.id) ? <span style={pinnedBadgeStyle}>pinned</span> : null}
                   {!it.open ? <span style={badgeStyle}>closed</span> : null}
                   {isActive ? <span style={activeBadgeStyle}>active</span> : null}
                 </li>
@@ -278,4 +288,30 @@ const footerStyle: React.CSSProperties = {
   paddingTop: 4,
   borderTop: '1px solid #1d1d22',
   marginTop: 4,
+};
+
+
+function readPinned(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  const out = new Set<string>();
+  try {
+    for (let i = 0; i < window.sessionStorage.length; i += 1) {
+      const key = window.sessionStorage.key(i);
+      if (!key || !key.startsWith('wav.chat.pinned.')) continue;
+      const v = window.sessionStorage.getItem(key);
+      if (v === '1' || v === 'true') {
+        out.add(key.slice('wav.chat.pinned.'.length));
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return out;
+}
+
+const pinnedBadgeStyle: React.CSSProperties = {
+  ...badgeStyle,
+  background: '#1c1f12',
+  border: '1px solid #6b5a2a',
+  color: '#f0c14b',
 };

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -60,6 +60,10 @@ export function WorkspaceSidebar({
     );
   };
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinnedSet());
+  const [onlyPinned, setOnlyPinned] = useState(false);
+  useEffect(() => {
+    if (onlyPinned && pinnedSet.size === 0) setOnlyPinned(false);
+  }, [onlyPinned, pinnedSet.size]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onChange = () => setPinnedSet(readPinnedSet());
@@ -72,9 +76,12 @@ export function WorkspaceSidebar({
     return pb - pa;
   };
   const filteredVisible = (filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows)
+    .filter((w) => (onlyPinned ? pinnedSet.has(w.id) : true))
     .slice()
     .sort(sortPinnedFirst);
-  const filteredClosed = filterEnabled ? closedWindows.filter(matchesFilter) : closedWindows;
+  const filteredClosed = (filterEnabled ? closedWindows.filter(matchesFilter) : closedWindows).filter(
+    (w) => (onlyPinned ? pinnedSet.has(w.id) : true),
+  );
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
 
   return (
@@ -124,6 +131,31 @@ export function WorkspaceSidebar({
               aria-label="Filter chat windows"
               style={filterInputStyle}
             />
+          </div>
+        ) : null}
+        {pinnedSet.size > 0 ? (
+          <div style={{ padding: '0 0.05rem 0.5rem' }}>
+            <button
+              type="button"
+              onClick={() => setOnlyPinned((v) => !v)}
+              aria-pressed={onlyPinned}
+              aria-label={onlyPinned ? 'Show all windows' : 'Show only pinned windows'}
+              title={onlyPinned ? 'Show all windows' : `Show only pinned windows (${pinnedSet.size})`}
+              style={{
+                width: '100%',
+                background: onlyPinned ? '#1c1c28' : 'transparent',
+                color: onlyPinned ? '#f0c14b' : '#cfcfd6',
+                border: `1px solid ${onlyPinned ? '#3a3f6b' : '#24242c'}`,
+                borderRadius: 6,
+                padding: '0.3rem 0.55rem',
+                fontSize: '0.72rem',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                textAlign: 'left',
+              }}
+            >
+              {onlyPinned ? `Pinned only (${pinnedSet.size})` : `Show pinned only (${pinnedSet.size})`}
+            </button>
           </div>
         ) : null}
         <SectionLabel>

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -59,7 +59,21 @@ export function WorkspaceSidebar({
       w.provider.toLowerCase().includes(lowerFilter)
     );
   };
-  const filteredVisible = filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows;
+  const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinnedSet());
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onChange = () => setPinnedSet(readPinnedSet());
+    window.addEventListener('wav:pin-changed', onChange);
+    return () => window.removeEventListener('wav:pin-changed', onChange);
+  }, []);
+  const sortPinnedFirst = (a: ChatWindow, b: ChatWindow): number => {
+    const pa = pinnedSet.has(a.id) ? 1 : 0;
+    const pb = pinnedSet.has(b.id) ? 1 : 0;
+    return pb - pa;
+  };
+  const filteredVisible = (filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows)
+    .slice()
+    .sort(sortPinnedFirst);
   const filteredClosed = filterEnabled ? closedWindows.filter(matchesFilter) : closedWindows;
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
 
@@ -123,6 +137,7 @@ export function WorkspaceSidebar({
               key={w.id}
               window={w}
               active={activeId === w.id}
+              pinned={pinnedSet.has(w.id)}
               onClick={() => onFocus(w.id)}
               onAction={() => onClose(w.id)}
               actionLabel="×"
@@ -603,13 +618,14 @@ interface WindowRowProps {
   window: ChatWindow;
   active: boolean;
   muted?: boolean;
+  pinned?: boolean;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+function WindowRow({ window, active, muted, pinned, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -683,6 +699,21 @@ function WindowRow({ window, active, muted, onClick, onAction, actionLabel, acti
             overflow: 'hidden',
           }}
         >
+          {pinned ? (
+            <span
+              aria-hidden
+              title="Pinned"
+              style={{
+                fontSize: '0.6rem',
+                color: '#f0c14b',
+                fontWeight: 700,
+                letterSpacing: '0.05em',
+                flexShrink: 0,
+              }}
+            >
+              PIN
+            </span>
+          ) : null}
           <span
             style={{
               overflow: 'hidden',
@@ -799,3 +830,21 @@ const filterInputStyle: React.CSSProperties = {
   fontFamily: 'inherit',
   outline: 'none',
 };
+
+function readPinnedSet(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  const out = new Set<string>();
+  try {
+    for (let i = 0; i < window.sessionStorage.length; i += 1) {
+      const key = window.sessionStorage.key(i);
+      if (!key || !key.startsWith('wav.chat.pinned.')) continue;
+      const v = window.sessionStorage.getItem(key);
+      if (v === '1' || v === 'true') {
+        out.add(key.slice('wav.chat.pinned.'.length));
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return out;
+}


### PR DESCRIPTION
Continuation of the workspace/chat productivity work. Two cohesive themes:

## A. Pin chat windows (per-tab)
- **Header pin toggle** — new "Pin" pill in the chat window header. Toggles `wav.chat.pinned.<windowId>` in `sessionStorage`. Accent color when pinned.
- **Custom event** — every toggle dispatches `wav:pin-changed` so other surfaces can react without prop plumbing.
- **Sidebar** — listens to the event, sorts the Open list pinned-first, shows a small accent `PIN` tag before pinned titles.
- **"Show pinned only" chip** — small toggle under the window filter, visible when ≥1 window is pinned. Filters both Open and Closed lists. Auto-clears when the pinned set drops back to zero.
- **Cmd-K palette** — pinned windows get a small accent `pinned` badge alongside the existing active/closed badges.

## B. Toast feedback for productivity actions
- **Export** — toast confirms `<title> — conversation copied as Markdown` (plus the existing inline Copied label).
- **Quote** — toast `Quoted into <title>` so the user knows the bubble landed in the composer.
- **Pin / Unpin** — toast `<title> pinned` / `<title> unpinned`. Initial mount suppressed via a ref so it doesn't fire on rehydration.
- **Star / Unstar** — toast `Message starred` / `Message unstarred`.

## C. Composer placeholder hint
- When the composer is empty and the chat has prior user prompts, the placeholder now reads `Send a message…  (Shift+Enter newline · ↑ history)` so the existing `↑` history shortcut is discoverable.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)