### PR TITLE
feat(web): sidebar activity dot + composer templates + workspaces in Cmd-K

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -30,6 +30,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
       { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
       { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft (Ctrl+Shift+Backspace)' },
+      { keys: ['⌘', 'Shift', 'T'], description: 'Open the prompt template menu in the active composer (Ctrl+Shift+T)' },
       { keys: ['G'], description: 'Jump to the latest message (when not typing)' },
       { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
     ],

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -265,6 +265,11 @@ export function ChatWindow({
         onClose(id);
         return;
       }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 't' || e.key === 'T')) {
+        e.preventDefault();
+        setTemplatesOpen((v) => !v);
+        return;
+      }
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'Backspace') {
         e.preventDefault();
         setDraft('');

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -93,6 +93,7 @@ export function ChatWindow({
   const [scrolledAway, setScrolledAway] = useState(false);
   const [exportLabel, setExportLabel] = useState<'idle' | 'copied' | 'failed'>('idle');
   const toast = useToast();
+  const [templatesOpen, setTemplatesOpen] = useState(false);
   const pinStorageKey = `wav.chat.pinned.${id}`;
   const [pinned, setPinned] = useState<boolean>(() => readBoolFlag(pinStorageKey));
   const pinInitRef = useRef(false);
@@ -983,6 +984,26 @@ export function ChatWindow({
             lineHeight: 1.4,
           }}
         />
+        {!pending ? (
+          <TemplateMenu
+            open={templatesOpen}
+            onToggle={() => setTemplatesOpen((v) => !v)}
+            onClose={() => setTemplatesOpen(false)}
+            onPick={(prefix) => {
+              setTemplatesOpen(false);
+              setDraft((prev) => {
+                const sep = prev.length === 0 || prev.endsWith(' ') || prev.endsWith('\n') ? '' : ' ';
+                return `${prev}${sep}${prefix}`;
+              });
+              requestAnimationFrame(() => {
+                const ta = textareaRef.current;
+                if (!ta) return;
+                ta.focus();
+                ta.selectionStart = ta.selectionEnd = ta.value.length;
+              });
+            }}
+          />
+        ) : null}
         {pending && onCancel ? (
           <button
             type="button"
@@ -1679,4 +1700,106 @@ function writeScrollTop(key: string, value: number): void {
   } catch {
     // ignore
   }
+}
+
+
+interface TemplateMenuProps {
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onPick: (prefix: string) => void;
+}
+
+const TEMPLATES: Array<{ label: string; prefix: string }> = [
+  { label: 'Summarize', prefix: 'Summarize the following:\n' },
+  { label: 'Critique', prefix: 'Critique this and point out the weakest assumptions:\n' },
+  { label: 'Translate', prefix: 'Translate to French:\n' },
+  { label: 'Explain like 5', prefix: 'Explain like I am five:\n' },
+  { label: 'Code review', prefix: 'Code review — list bugs, smells, missing edge cases:\n' },
+  { label: 'Continue', prefix: 'Continue from where you left off.' },
+];
+
+function TemplateMenu({ open, onToggle, onClose, onPick }: TemplateMenuProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+  return (
+    <div style={{ position: 'relative', alignSelf: 'stretch' }} onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Insert template"
+        title="Insert prompt template"
+        style={{
+          background: 'transparent',
+          color: '#cfcfd6',
+          border: '1px solid #2a2a30',
+          borderRadius: 8,
+          padding: '0 0.7rem',
+          fontSize: '0.8rem',
+          cursor: 'pointer',
+          fontFamily: 'inherit',
+          height: '100%',
+        }}
+      >
+        T
+      </button>
+      {open ? (
+        <>
+          <button
+            aria-label="Close templates"
+            onClick={onClose}
+            style={{ position: 'fixed', inset: 0, background: 'transparent', border: 'none', cursor: 'default', zIndex: 20 }}
+          />
+          <div
+            role="menu"
+            style={{
+              position: 'absolute',
+              bottom: 'calc(100% + 6px)',
+              right: 0,
+              minWidth: 220,
+              background: '#161620',
+              border: '1px solid #2a2a30',
+              borderRadius: 8,
+              padding: 4,
+              zIndex: 30,
+              boxShadow: '0 10px 28px rgba(0,0,0,0.45)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 2,
+            }}
+          >
+            {TEMPLATES.map((t) => (
+              <button
+                key={t.label}
+                role="menuitem"
+                type="button"
+                onClick={() => onPick(t.prefix)}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  textAlign: 'left',
+                  padding: '0.4rem 0.55rem',
+                  borderRadius: 4,
+                  color: '#e8e8ef',
+                  fontSize: '0.82rem',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -506,6 +506,22 @@ export function ChatWindow({
             </span>
           )}
           <ProviderBadge provider={provider} model={model} />
+          {pending ? (
+            <span
+              role="status"
+              aria-live="polite"
+              style={{
+                marginTop: 4,
+                alignSelf: 'flex-start',
+                fontSize: '0.62rem',
+                color: '#9aa6ff',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+              }}
+            >
+              Generating…
+            </span>
+          ) : null}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           <button

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -90,6 +90,15 @@ export function Workspace({
     stream: true,
   });
 
+  const lastActivityByWindow: Record<string, string | undefined> = {};
+  const pendingByWindow: Record<string, boolean> = {};
+  for (const w of [...state.visibleWindows, ...state.closedWindows]) {
+    const list = chat.getMessages(w.id);
+    const last = list[list.length - 1];
+    lastActivityByWindow[w.id] = last?.createdAt;
+    pendingByWindow[w.id] = chat.isPending(w.id);
+  }
+
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
       <WorkspaceSidebar
@@ -100,6 +109,8 @@ export function Workspace({
         visibleWindows={state.visibleWindows}
         closedWindows={state.closedWindows}
         activeId={state.activeId}
+        lastActivityByWindow={lastActivityByWindow}
+        pendingByWindow={pendingByWindow}
         onFocus={state.focus}
         onClose={state.close}
         onReopen={state.reopen}

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -137,6 +137,9 @@ export function Workspace({
         onCreate={state.createWindow}
       />
       <WorkspaceCommandPalette
+        projectId={projectId}
+        workspaces={workspaces}
+        activeWorkspaceId={activeWorkspace.id}
         visibleWindows={state.visibleWindows}
         closedWindows={state.closedWindows}
         activeId={state.activeId}

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -1,7 +1,8 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
-import type { ChatWindow } from '@webapp/types';
+import type { ChatWindow, Workspace } from '@webapp/types';
 
 interface PaletteWindow {
   window: ChatWindow;
@@ -9,6 +10,9 @@ interface PaletteWindow {
 }
 
 interface WorkspaceCommandPaletteProps {
+  projectId: string;
+  workspaces: Workspace[];
+  activeWorkspaceId: string;
   visibleWindows: ChatWindow[];
   closedWindows: ChatWindow[];
   activeId: string | null;
@@ -25,6 +29,9 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 export function WorkspaceCommandPalette({
+  projectId,
+  workspaces,
+  activeWorkspaceId,
   visibleWindows,
   closedWindows,
   activeId,
@@ -51,6 +58,12 @@ export function WorkspaceCommandPalette({
       return t.includes(q) || it.window.model.toLowerCase().includes(q);
     });
   }, [items, query]);
+
+  const filteredWorkspaces = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return workspaces;
+    return workspaces.filter((w) => w.name.toLowerCase().includes(q));
+  }, [workspaces, query]);
 
   useEffect(() => {
     setHover(0);
@@ -135,10 +148,43 @@ export function WorkspaceCommandPalette({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={onInputKeyDown}
-          placeholder="Type a window title or model…"
-          aria-label="Filter chat windows"
+          placeholder="Type a window title, model, or workspace…"
+          aria-label="Filter chat windows or workspaces"
           style={inputStyle}
         />
+        {filteredWorkspaces.length > 1 ? (
+          <div>
+            <div style={sectionLabelStyle}>Workspaces</div>
+            <ul role="list" style={listStyle}>
+              {filteredWorkspaces.map((w) => {
+                const active = w.id === activeWorkspaceId;
+                return (
+                  <li key={w.id} style={{ listStyle: 'none' }}>
+                    <Link
+                      href={`/project/${projectId}?workspace=${w.id}`}
+                      onClick={() => {
+                        setOpen(false);
+                        setQuery('');
+                      }}
+                      style={{
+                        ...rowStyle,
+                        textDecoration: 'none',
+                        color: active ? '#9aa6ff' : '#cfcfd6',
+                        background: active ? '#1c1c28' : 'transparent',
+                      }}
+                    >
+                      <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {w.name}
+                      </span>
+                      {active ? <span style={activeBadgeStyle}>active</span> : null}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+            <div style={sectionLabelStyle}>Chat windows</div>
+          </div>
+        ) : null}
         <ul role="listbox" aria-label="Chat windows" style={listStyle}>
           {filtered.length === 0 ? (
             <li style={emptyStyle}>No matches.</li>
@@ -314,4 +360,13 @@ const pinnedBadgeStyle: React.CSSProperties = {
   background: '#1c1f12',
   border: '1px solid #6b5a2a',
   color: '#f0c14b',
+};
+
+
+const sectionLabelStyle: React.CSSProperties = {
+  fontSize: '0.62rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: '#6a6a75',
+  padding: '0.5rem 0.55rem 0.25rem',
 };

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -20,6 +20,8 @@ interface WorkspaceSidebarProps {
   visibleWindows: ChatWindow[];
   closedWindows: ChatWindow[];
   activeId: string | null;
+  lastActivityByWindow?: Record<string, string | undefined>;
+  pendingByWindow?: Record<string, boolean>;
   onFocus: (id: string) => void;
   onClose: (id: string) => void;
   onReopen: (id: string) => void;
@@ -41,6 +43,8 @@ export function WorkspaceSidebar({
   visibleWindows,
   closedWindows,
   activeId,
+  lastActivityByWindow,
+  pendingByWindow,
   onFocus,
   onClose,
   onReopen,
@@ -170,6 +174,8 @@ export function WorkspaceSidebar({
               window={w}
               active={activeId === w.id}
               pinned={pinnedSet.has(w.id)}
+              lastActivity={lastActivityByWindow?.[w.id]}
+              pending={pendingByWindow?.[w.id]}
               onClick={() => onFocus(w.id)}
               onAction={() => onClose(w.id)}
               actionLabel="×"
@@ -189,6 +195,7 @@ export function WorkspaceSidebar({
                 window={w}
                 active={false}
                 muted
+                lastActivity={lastActivityByWindow?.[w.id]}
                 onClick={() => onReopen(w.id)}
                 onAction={() => onReopen(w.id)}
                 actionLabel="↺"
@@ -651,14 +658,16 @@ interface WindowRowProps {
   active: boolean;
   muted?: boolean;
   pinned?: boolean;
+  lastActivity?: string;
+  pending?: boolean;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
-  const stamp = formatRelative(window.updatedAt ?? window.createdAt);
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+  const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (!active) return;
@@ -792,14 +801,30 @@ function WindowRow({ window, active, muted, pinned, onClick, onAction, actionLab
           >
             {window.provider} · {window.model}
           </span>
+          {pending ? (
+            <span
+              aria-label="Reply in progress"
+              title="Reply in progress"
+              style={{
+                marginLeft: 'auto',
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: '#9aa6ff',
+                animation: 'chat-blink 1s steps(2, end) infinite',
+                flexShrink: 0,
+                marginRight: stamp ? 4 : 0,
+              }}
+            />
+          ) : null}
           {stamp ? (
             <span
               style={{
-                marginLeft: 'auto',
+                marginLeft: pending ? 0 : 'auto',
                 color: '#6a6a75',
                 flexShrink: 0,
               }}
-              title={window.updatedAt ?? window.createdAt}
+              title={lastActivity ?? window.updatedAt ?? window.createdAt}
             >
               {stamp}
             </span>


### PR DESCRIPTION
Continuation of the workspace/chat productivity work.

## What
- **Sidebar live activity** — Workspace now derives `lastActivityByWindow` (last message createdAt) and `pendingByWindow` (in-flight reply) from `chat.getMessages` / `chat.isPending` and threads them to the sidebar. WindowRow uses `lastActivity` for its small relative timestamp and renders an accent pulsing dot when a reply is in progress. Pure live data plumbing — no backend, no API change.
- **Composer template button (T)** — small "T" button next to Send opens a popover with built-in prompt prefixes (Summarize, Critique, Translate, Explain like 5, Code review, Continue). Clicking inserts the prefix at the end of the draft and refocuses the textarea. Esc / backdrop close.
- **Cmd / Ctrl + Shift + T** — keyboard shortcut to toggle the same popover from the active window. Help overlay updated.
- **Cmd-K palette gets a Workspaces section** — when the project has more than one workspace, the palette shows a "Workspaces" list above the chat-windows list. Each row is a `next/link` to `?workspace=<id>` (soft client-side nav). Filtered by the same query input. Active workspace gets the existing accent badge. Hidden for single-workspace projects.
- **'Generating…' tag in chat header** — accent uppercase tag under the title's provider badge while the chat is pending. `role="status"` + `aria-live="polite"` for AT users.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)