### PR TITLE
feat(web): unread indicators + user templates + tab title hints

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -1740,15 +1740,81 @@ const TEMPLATES: Array<{ label: string; prefix: string }> = [
   { label: 'Continue', prefix: 'Continue from where you left off.' },
 ];
 
+interface UserTemplate {
+  id: string;
+  label: string;
+  prefix: string;
+}
+
+const USER_TEMPLATES_KEY = 'wav.templates';
+
+function readUserTemplates(): UserTemplate[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(USER_TEMPLATES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (t): t is UserTemplate =>
+          t && typeof t.id === 'string' && typeof t.label === 'string' && typeof t.prefix === 'string',
+      )
+      .slice(0, 50);
+  } catch {
+    return [];
+  }
+}
+
+function writeUserTemplates(items: UserTemplate[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(USER_TEMPLATES_KEY, JSON.stringify(items));
+    window.dispatchEvent(new Event('wav:templates-changed'));
+  } catch {
+    // ignore quota
+  }
+}
+
 function TemplateMenu({ open, onToggle, onClose, onPick }: TemplateMenuProps) {
+  const [userTemplates, setUserTemplates] = useState<UserTemplate[]>(() => readUserTemplates());
+  const [adding, setAdding] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newPrefix, setNewPrefix] = useState('');
   useEffect(() => {
     if (!open) return;
     const onKey = (e: globalThis.KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
+    const onChange = () => setUserTemplates(readUserTemplates());
     window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
+    window.addEventListener('wav:templates-changed', onChange);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('wav:templates-changed', onChange);
+    };
   }, [open, onClose]);
+  const onSaveNew = () => {
+    const label = newLabel.trim();
+    const prefix = newPrefix.trim();
+    if (!label || !prefix) return;
+    const next: UserTemplate = {
+      id: `t-${Date.now()}-${Math.floor(Math.random() * 1e6)}`,
+      label,
+      prefix,
+    };
+    const updated = [next, ...userTemplates].slice(0, 50);
+    setUserTemplates(updated);
+    writeUserTemplates(updated);
+    setNewLabel('');
+    setNewPrefix('');
+    setAdding(false);
+  };
+  const onDelete = (id: string) => {
+    const updated = userTemplates.filter((t) => t.id !== id);
+    setUserTemplates(updated);
+    writeUserTemplates(updated);
+  };
   return (
     <div style={{ position: 'relative', alignSelf: 'stretch' }} onClick={(e) => e.stopPropagation()}>
       <button
@@ -1785,7 +1851,8 @@ function TemplateMenu({ open, onToggle, onClose, onPick }: TemplateMenuProps) {
               position: 'absolute',
               bottom: 'calc(100% + 6px)',
               right: 0,
-              minWidth: 220,
+              minWidth: 260,
+              maxWidth: 320,
               background: '#161620',
               border: '1px solid #2a2a30',
               borderRadius: 8,
@@ -1797,6 +1864,60 @@ function TemplateMenu({ open, onToggle, onClose, onPick }: TemplateMenuProps) {
               gap: 2,
             }}
           >
+            {userTemplates.length > 0 ? (
+              <>
+                <div style={tplSectionStyle}>Yours</div>
+                {userTemplates.map((t) => (
+                  <div
+                    key={t.id}
+                    style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+                  >
+                    <button
+                      role="menuitem"
+                      type="button"
+                      onClick={() => onPick(t.prefix)}
+                      title={t.prefix}
+                      style={{
+                        flex: 1,
+                        background: 'transparent',
+                        border: 'none',
+                        textAlign: 'left',
+                        padding: '0.4rem 0.55rem',
+                        borderRadius: 4,
+                        color: '#e8e8ef',
+                        fontSize: '0.82rem',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {t.label}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(t.id)}
+                      aria-label={`Delete template ${t.label}`}
+                      title={`Delete template ${t.label}`}
+                      style={{
+                        background: 'transparent',
+                        border: 'none',
+                        color: '#8a8a95',
+                        cursor: 'pointer',
+                        fontSize: '0.85rem',
+                        padding: '0 6px',
+                        borderRadius: 4,
+                        fontFamily: 'inherit',
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </>
+            ) : null}
+            <div style={tplSectionStyle}>Built-in</div>
             {TEMPLATES.map((t) => (
               <button
                 key={t.label}
@@ -1818,9 +1939,99 @@ function TemplateMenu({ open, onToggle, onClose, onPick }: TemplateMenuProps) {
                 {t.label}
               </button>
             ))}
+            <div style={{ height: 1, background: '#1d1d22', margin: '4px 0' }} />
+            {adding ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '0.3rem 0.5rem 0.5rem' }}>
+                <input
+                  autoFocus
+                  value={newLabel}
+                  onChange={(e) => setNewLabel(e.target.value)}
+                  placeholder="Label"
+                  aria-label="New template label"
+                  style={tplInputStyle}
+                />
+                <textarea
+                  value={newPrefix}
+                  onChange={(e) => setNewPrefix(e.target.value)}
+                  placeholder="Prefix to insert at the end of the draft"
+                  aria-label="New template prefix"
+                  rows={3}
+                  style={{ ...tplInputStyle, resize: 'vertical', minHeight: 60, lineHeight: 1.4 }}
+                />
+                <div style={{ display: 'flex', gap: 6, justifyContent: 'flex-end' }}>
+                  <button type="button" onClick={() => { setAdding(false); setNewLabel(''); setNewPrefix(''); }} style={tplGhostBtnStyle}>
+                    Cancel
+                  </button>
+                  <button type="button" onClick={onSaveNew} disabled={!newLabel.trim() || !newPrefix.trim()} style={tplPrimaryBtnStyle}>
+                    Save
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setAdding(true)}
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  textAlign: 'left',
+                  padding: '0.4rem 0.55rem',
+                  borderRadius: 4,
+                  color: '#9aa6ff',
+                  fontSize: '0.78rem',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                + New template
+              </button>
+            )}
           </div>
         </>
       ) : null}
     </div>
   );
 }
+
+const tplSectionStyle: React.CSSProperties = {
+  fontSize: '0.62rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: '#6a6a75',
+  padding: '0.4rem 0.55rem 0.2rem',
+};
+
+const tplInputStyle: React.CSSProperties = {
+  width: '100%',
+  background: '#0f0f13',
+  border: '1px solid #2a2a30',
+  borderRadius: 4,
+  padding: '0.35rem 0.5rem',
+  color: '#f5f5f5',
+  fontSize: '0.78rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};
+
+const tplGhostBtnStyle: React.CSSProperties = {
+  background: 'transparent',
+  color: '#cfcfd6',
+  border: '1px solid #2a2a30',
+  borderRadius: 4,
+  padding: '2px 8px',
+  fontSize: '0.72rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+};
+
+const tplPrimaryBtnStyle: React.CSSProperties = {
+  background: '#f5f5f5',
+  color: '#0b0b0d',
+  border: 'none',
+  borderRadius: 4,
+  padding: '2px 10px',
+  fontSize: '0.72rem',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontWeight: 600,
+};

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -109,10 +109,11 @@ export function Workspace({
     }
     initSeenRef.current = true;
   }
+  const activeLastActivity = state.activeId ? lastActivityByWindow[state.activeId] : undefined;
   useEffect(() => {
     if (!state.activeId) return;
     lastSeenRef.current[state.activeId] = Date.now();
-  }, [state.activeId, lastActivityByWindow[state.activeId ?? '']]);
+  }, [state.activeId, activeLastActivity]);
 
   const unreadByWindow: Record<string, boolean> = {};
   for (const w of [...state.visibleWindows, ...state.closedWindows]) {

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -130,6 +130,7 @@ export function Workspace({
     unreadByWindow[w.id] = seenAt == null ? true : messageTime > seenAt;
   }
   const totalUnread = Object.values(unreadByWindow).filter(Boolean).length;
+  const anyPending = Object.values(pendingByWindow).some(Boolean);
 
   const previousTitleRef = useRef<string | null>(null);
   useEffect(() => {
@@ -141,8 +142,9 @@ export function Workspace({
   useEffect(() => {
     if (typeof document === 'undefined') return;
     const base = `${projectName} · ${activeWorkspace.name} — AI Workspace V1`;
-    document.title = totalUnread > 0 ? `(${totalUnread}) ${base}` : base;
-  }, [totalUnread, projectName, activeWorkspace.name]);
+    const prefix = totalUnread > 0 ? `(${totalUnread}) ` : anyPending ? '… ' : '';
+    document.title = `${prefix}${base}`;
+  }, [totalUnread, anyPending, projectName, activeWorkspace.name]);
   useEffect(() => {
     return () => {
       if (typeof document === 'undefined') return;

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -31,14 +31,6 @@ export function Workspace({
 }: WorkspaceProps) {
   const toast = useToast();
   const router = useRouter();
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    const previous = document.title;
-    document.title = `${projectName} · ${activeWorkspace.name} — AI Workspace V1`;
-    return () => {
-      document.title = previous;
-    };
-  }, [projectName, activeWorkspace.name]);
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const initialWindowParam = searchParams?.get('window') ?? null;
@@ -92,12 +84,71 @@ export function Workspace({
 
   const lastActivityByWindow: Record<string, string | undefined> = {};
   const pendingByWindow: Record<string, boolean> = {};
+  const lastAssistantByWindow: Record<string, string | undefined> = {};
   for (const w of [...state.visibleWindows, ...state.closedWindows]) {
     const list = chat.getMessages(w.id);
     const last = list[list.length - 1];
     lastActivityByWindow[w.id] = last?.createdAt;
     pendingByWindow[w.id] = chat.isPending(w.id);
+    for (let i = list.length - 1; i >= 0; i -= 1) {
+      const m = list[i];
+      if (!m) continue;
+      if (m.role === 'assistant' && (m.status ?? 'ok') === 'ok') {
+        lastAssistantByWindow[w.id] = m.createdAt;
+        break;
+      }
+    }
   }
+
+  const lastSeenRef = useRef<Record<string, number>>({});
+  const initSeenRef = useRef(false);
+  if (!initSeenRef.current) {
+    const now = Date.now();
+    for (const w of [...state.visibleWindows, ...state.closedWindows]) {
+      lastSeenRef.current[w.id] = now;
+    }
+    initSeenRef.current = true;
+  }
+  useEffect(() => {
+    if (!state.activeId) return;
+    lastSeenRef.current[state.activeId] = Date.now();
+  }, [state.activeId, lastActivityByWindow[state.activeId ?? '']]);
+
+  const unreadByWindow: Record<string, boolean> = {};
+  for (const w of [...state.visibleWindows, ...state.closedWindows]) {
+    const ts = lastAssistantByWindow[w.id];
+    const seenAt = lastSeenRef.current[w.id];
+    if (!ts || w.id === state.activeId) {
+      unreadByWindow[w.id] = false;
+      continue;
+    }
+    const messageTime = Date.parse(ts);
+    if (Number.isNaN(messageTime)) {
+      unreadByWindow[w.id] = false;
+      continue;
+    }
+    unreadByWindow[w.id] = seenAt == null ? true : messageTime > seenAt;
+  }
+  const totalUnread = Object.values(unreadByWindow).filter(Boolean).length;
+
+  const previousTitleRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    if (previousTitleRef.current == null) {
+      previousTitleRef.current = document.title;
+    }
+  }, []);
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const base = `${projectName} · ${activeWorkspace.name} — AI Workspace V1`;
+    document.title = totalUnread > 0 ? `(${totalUnread}) ${base}` : base;
+  }, [totalUnread, projectName, activeWorkspace.name]);
+  useEffect(() => {
+    return () => {
+      if (typeof document === 'undefined') return;
+      if (previousTitleRef.current != null) document.title = previousTitleRef.current;
+    };
+  }, []);
 
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
@@ -111,6 +162,7 @@ export function Workspace({
         activeId={state.activeId}
         lastActivityByWindow={lastActivityByWindow}
         pendingByWindow={pendingByWindow}
+        unreadByWindow={unreadByWindow}
         onFocus={state.focus}
         onClose={state.close}
         onReopen={state.reopen}
@@ -143,6 +195,7 @@ export function Workspace({
         visibleWindows={state.visibleWindows}
         closedWindows={state.closedWindows}
         activeId={state.activeId}
+        unreadByWindow={unreadByWindow}
         onFocus={state.focus}
         onReopen={state.reopen}
       />

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -16,6 +16,7 @@ interface WorkspaceCommandPaletteProps {
   visibleWindows: ChatWindow[];
   closedWindows: ChatWindow[];
   activeId: string | null;
+  unreadByWindow?: Record<string, boolean>;
   onFocus: (id: string) => void;
   onReopen: (id: string) => void;
 }
@@ -35,6 +36,7 @@ export function WorkspaceCommandPalette({
   visibleWindows,
   closedWindows,
   activeId,
+  unreadByWindow,
   onFocus,
   onReopen,
 }: WorkspaceCommandPaletteProps) {
@@ -211,6 +213,7 @@ export function WorkspaceCommandPalette({
                   <span style={metaStyle}>
                     {it.window.provider} · {it.window.model}
                   </span>
+                  {unreadByWindow?.[it.window.id] ? <span style={unreadBadgeStyle}>unread</span> : null}
                   {pinnedSet.has(it.window.id) ? <span style={pinnedBadgeStyle}>pinned</span> : null}
                   {!it.open ? <span style={badgeStyle}>closed</span> : null}
                   {isActive ? <span style={activeBadgeStyle}>active</span> : null}
@@ -369,4 +372,12 @@ const sectionLabelStyle: React.CSSProperties = {
   letterSpacing: '0.06em',
   color: '#6a6a75',
   padding: '0.5rem 0.55rem 0.25rem',
+};
+
+
+const unreadBadgeStyle: React.CSSProperties = {
+  ...badgeStyle,
+  background: '#15203b',
+  border: '1px solid #3a3f6b',
+  color: '#9aa6ff',
 };

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -22,6 +22,7 @@ interface WorkspaceSidebarProps {
   activeId: string | null;
   lastActivityByWindow?: Record<string, string | undefined>;
   pendingByWindow?: Record<string, boolean>;
+  unreadByWindow?: Record<string, boolean>;
   onFocus: (id: string) => void;
   onClose: (id: string) => void;
   onReopen: (id: string) => void;
@@ -45,6 +46,7 @@ export function WorkspaceSidebar({
   activeId,
   lastActivityByWindow,
   pendingByWindow,
+  unreadByWindow,
   onFocus,
   onClose,
   onReopen,
@@ -176,6 +178,7 @@ export function WorkspaceSidebar({
               pinned={pinnedSet.has(w.id)}
               lastActivity={lastActivityByWindow?.[w.id]}
               pending={pendingByWindow?.[w.id]}
+              unread={unreadByWindow?.[w.id]}
               onClick={() => onFocus(w.id)}
               onAction={() => onClose(w.id)}
               actionLabel="×"
@@ -196,6 +199,7 @@ export function WorkspaceSidebar({
                 active={false}
                 muted
                 lastActivity={lastActivityByWindow?.[w.id]}
+                unread={unreadByWindow?.[w.id]}
                 onClick={() => onReopen(w.id)}
                 onAction={() => onReopen(w.id)}
                 actionLabel="↺"
@@ -660,13 +664,14 @@ interface WindowRowProps {
   pinned?: boolean;
   lastActivity?: string;
   pending?: boolean;
+  unread?: boolean;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, lastActivity, pending, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -740,6 +745,20 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, onCli
             overflow: 'hidden',
           }}
         >
+          {unread ? (
+            <span
+              aria-label="Unread reply"
+              title="New reply since you last viewed this window"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                background: '#9aa6ff',
+                boxShadow: '0 0 0 2px rgba(79,107,255,0.25)',
+                flexShrink: 0,
+              }}
+            />
+          ) : null}
           {pinned ? (
             <span
               aria-hidden


### PR DESCRIPTION
Three cohesive themes around attention/awareness in the workspace.

## What
- **Unread indicators for inactive windows** — Workspace now tracks per-window "last seen" timestamps via a ref. A window becomes unread when it has at least one ok-status assistant message whose `createdAt` is later than the user's last visit, and it's not the currently active window.
  - Sidebar `WindowRow` shows a small accent dot before the title with title="New reply since you last viewed this window".
  - Cmd-K palette rows get an `unread` pill.
  - Initial mount seeds last-seen for every window with `Date.now()` so pre-existing messages don't show up unread on load.
- **Tab title attention** — `document.title` prefixes:
  - `(<n>) ` when at least one window is unread
  - else `… ` when at least one window is generating
  - else just the project + workspace base
  - Original tab title is restored on Workspace unmount (via a ref capturing the pre-mount title).
- **User-defined composer templates** — TemplateMenu popover gains a "Yours" section:
  - "+ New template" inline form: label + multiline prefix; Save / Cancel.
  - per-item × button to delete.
  - persisted under `wav.templates` in `localStorage` (max 50 entries, schema-validated reads, quota-safe writes).
  - dispatches `wav:templates-changed` on every write so other open popovers can refresh.

## Files changed
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`
- `apps/web/src/features/chat/ChatWindow.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)