### PR TITLE
Backend hardening batch 9: signup/login order-of-operations + cookie shape + algorithm pins

### DIFF
--- a/apps/api/src/lib/cookie.test.ts
+++ b/apps/api/src/lib/cookie.test.ts
@@ -109,4 +109,22 @@ describe('clearCookieHeader', () => {
   it('emits Secure when secure=true', () => {
     expect(clearCookieHeader('sid', true)).toContain('Secure');
   });
+
+  it('NO Domain attribute (matches serializeSetCookie so the browser actually clears)', () => {
+    // Browsers only delete a cookie when the clearing Set-Cookie matches
+    // the original on (name, Path, Domain). serializeSetCookie omits
+    // Domain → clearCookieHeader must omit it too. Pin the symmetry so
+    // a future addition of Domain= to one but not the other doesn't
+    // produce 'cookie won't go away on logout' bugs.
+    const cookie = clearCookieHeader('sid', true);
+    expect(cookie).not.toMatch(/\bDomain=/i);
+  });
+
+  it('Path matches the issuing serializeSetCookie (so the clear actually targets the same cookie)', () => {
+    // Browsers also key on Path. clearCookieHeader hard-codes Path=/ ;
+    // serializeSetCookie reads Path from SESSION_COOKIE_OPTIONS. Pin the
+    // observable equivalence: both produce 'Path=/' so the clear works.
+    expect(clearCookieHeader('sid', false)).toContain('Path=/');
+    expect(serializeSetCookie('sid', 'v', false)).toContain('Path=/');
+  });
 });

--- a/apps/api/src/lib/cookie.test.ts
+++ b/apps/api/src/lib/cookie.test.ts
@@ -78,6 +78,22 @@ describe('serializeSetCookie', () => {
     // raw "; " would terminate the cookie attribute list — the encoded form is safe.
     expect(cookie).toContain(encodeURIComponent('a; b=c'));
   });
+
+  it('does NOT emit a Domain attribute (host-only cookie semantics)', () => {
+    // Without Domain= the cookie is bound to the exact host that issued
+    // it — no leakage to subdomains. A future addition of Domain=
+    // (e.g. ".example.com") would broaden the attack surface to every
+    // subdomain. Pin the absence so that change has to update the test.
+    const cookie = serializeSetCookie('sid', 'v', true);
+    expect(cookie).not.toMatch(/\bDomain=/i);
+  });
+
+  it('escapes "=" inside cookie value via URL-encoding (no premature attribute split)', () => {
+    // A token-like value with an internal "=" must not be interpreted as
+    // an attribute boundary. encodeURIComponent maps "=" to "%3D".
+    const cookie = serializeSetCookie('sid', 'a=b', false);
+    expect(cookie.startsWith('sid=a%3Db;')).toBe(true);
+  });
 });
 
 describe('clearCookieHeader', () => {

--- a/apps/api/src/lib/session-token.test.ts
+++ b/apps/api/src/lib/session-token.test.ts
@@ -22,6 +22,20 @@ describe('session token helpers', () => {
     expect(hashSessionToken(token)).not.toBe(token);
   });
 
+  it('hashes "abc" to the standard SHA-256 vector (algorithm-stability pin)', () => {
+    // Pin the algorithm choice with a published RFC 6234 / FIPS 180-4 test
+    // vector. A refactor that swapped to BLAKE2 / SHA-3 / a different digest
+    // length would break the cookie ↔ stored-hash roundtrip silently for
+    // every existing session in the DB. This test fails the moment the
+    // digest changes.
+    expect(hashSessionToken('abc'))
+      .toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('hash is exactly 64 hex chars (SHA-256 output length)', () => {
+    expect(hashSessionToken('any-input')).toMatch(/^[0-9a-f]{64}$/);
+  });
+
   it('session expiry is roughly SESSION_EXPIRY_MS in the future', () => {
     const before = Date.now();
     const expiresAt = sessionExpiresAt();

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -278,6 +278,18 @@ describe('POST /v1/auth/signup', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('signup 201 does not emit a Location header (auth response is data + Set-Cookie, not a redirect target)', async () => {
+    // POST /v1/auth/signup returns 201 with the SafeUser body in the
+    // response — there's no canonical resource URL to point at. A
+    // refactor that switched to respondCreated would attach a Location
+    // header, which clients might follow as a 302 once it ships in
+    // some HTTP libraries. Pin the absence so that change has to update
+    // the test deliberately.
+    const res = await post(base, '/v1/auth/signup', { email: 'noloc@example.com', password: 'password123' });
+    expect(res.status).toBe(201);
+    expect(res.headers.get('location')).toBeNull();
+  });
+
   it('signup that crashes during createUser does not emit Set-Cookie (no half-grant)', async () => {
     // The throw becomes a 500 via handleRequest's catch. The 500 envelope
     // is built by writeJson with no extra headers, so Set-Cookie cannot

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -727,6 +727,24 @@ describe('GET /v1/auth/me', () => {
     await close();
   });
 
+  it('ignores Authorization Bearer header — only cookie auth is supported', async () => {
+    // We are cookie-auth only. A client that sends a Bearer token in
+    // Authorization is either confused (wrong API) or attempting a
+    // confusion attack. /me must NOT honour the Authorization header
+    // and must NOT call the session repo for it. Pin both: the
+    // response is 401, and no session lookup is triggered.
+    let lookupCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      findSessionByTokenHash: async () => { lookupCalls++; return null; },
+    }));
+    const res = await fetch(`${baseUrl}/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${'a'.repeat(64)}` },
+    });
+    expect(res.status).toBe(401);
+    expect(lookupCalls).toBe(0);
+    await close();
+  });
+
   it('rejects whitespace-only session cookie without touching the session repo', async () => {
     // Probe with a whitespace-only token: must short-circuit before any DB
     // lookup and return the same envelope as a missing cookie. Otherwise an

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -278,6 +278,22 @@ describe('POST /v1/auth/signup', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('409 conflict fires BEFORE createUser (no orphan user row on duplicate-email path)', async () => {
+    // Order-of-operations pin: a duplicate-email probe must NOT trigger
+    // createUser. Otherwise a unique-constraint violation would surface as
+    // a 500 instead of a clean 409, AND we'd be wasting a row insert
+    // attempt + the password hash that came before it.
+    let createCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => mockUser(),
+      createUser:      async () => { createCalls++; return mockUser(); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/signup', { email: 'dupe@example.com', password: 'password123' });
+    expect(res.status).toBe(409);
+    expect(createCalls).toBe(0);
+    await close();
+  });
+
   it('returns 409 for duplicate email', async () => {
     const { baseUrl, close: c } = await startServer(
       makeDeps({ findUserByEmail: async () => mockUser() }),

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -457,6 +457,28 @@ describe('POST /v1/auth/login', () => {
     await close();
   });
 
+  it('500 from createSession crash emits no Set-Cookie + does not reset the rate-limit bucket', async () => {
+    // A login that authenticated correctly but crashed mid-session-create
+    // must NOT ship a cookie (no DB-backed session means a 'logged in'
+    // indicator that fails immediately). Also: the rate-limit reset only
+    // fires AFTER createSession succeeds, so a half-failure must keep the
+    // bucket counted — otherwise an attacker who can crash createSession
+    // (e.g. via a transient DB hiccup) gets to retry without paying the
+    // brute-force tax.
+    const okHash = await hashPassword('rightpw');
+    let resetCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      findUserByEmail: async () => mockUser({ passwordHash: okHash }),
+      createSession:   async () => { throw new Error('session-create-boom'); },
+      resetRateLimit:  () => { resetCalls++; },
+    }));
+    const res = await post(baseUrl, '/v1/auth/login', { email: 'test@example.com', password: 'rightpw' });
+    expect(res.status).toBe(500);
+    expect(res.headers.get('set-cookie')).toBeNull();
+    expect(resetCalls).toBe(0);
+    await close();
+  });
+
   it('returns the same code AND the same message string for unknown email vs wrong password', async () => {
     // The whole point of the unified 'Invalid email or password' string is to
     // be impossible to distinguish from the caller's POV. If a future

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -278,6 +278,21 @@ describe('POST /v1/auth/signup', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('signup that crashes during createUser does not emit Set-Cookie (no half-grant)', async () => {
+    // The throw becomes a 500 via handleRequest's catch. The 500 envelope
+    // is built by writeJson with no extra headers, so Set-Cookie cannot
+    // ride that response. Pin it so a future refactor that pre-built
+    // cookieHeader before calling createUser cannot accidentally ship a
+    // cookie with no matching DB row behind it.
+    const { baseUrl, close } = await startServer(makeDeps({
+      createUser: async () => { throw new Error('crash'); },
+    }));
+    const res = await post(baseUrl, '/v1/auth/signup', { email: 'half@example.com', password: 'password123' });
+    expect(res.status).toBe(500);
+    expect(res.headers.get('set-cookie')).toBeNull();
+    await close();
+  });
+
   it('createSession is called only AFTER createUser succeeds (no orphan session)', async () => {
     // Pin: if createUser throws, createSession must not have been called.
     // Otherwise a partial-failure could leave a session row pointing at a

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -278,6 +278,27 @@ describe('POST /v1/auth/signup', () => {
     expect(body.error.code).toBe('invalid_body');
   });
 
+  it('createSession is called only AFTER createUser succeeds (no orphan session)', async () => {
+    // Pin: if createUser throws, createSession must not have been called.
+    // Otherwise a partial-failure could leave a session row pointing at a
+    // user_id that was never persisted — a foreign-key violation in
+    // production, and a real-userId-spoof oracle in dev where FKs are
+    // off. Pin the call ordering with a spy.
+    let createSessionCalls = 0;
+    const { baseUrl, close } = await startServer(makeDeps({
+      createUser:    async () => { throw new Error('user-create-boom'); },
+      createSession: async (h, userId, expiresAt) => {
+        createSessionCalls++;
+        return { id: h, userId, expiresAt, createdAt: new Date() };
+      },
+    }));
+    const res = await post(baseUrl, '/v1/auth/signup', { email: 'orphan@example.com', password: 'password123' });
+    // The route's catch-all in handleRequest converts the throw to a 500.
+    expect(res.status).toBe(500);
+    expect(createSessionCalls).toBe(0);
+    await close();
+  });
+
   it('409 conflict fires BEFORE createUser (no orphan user row on duplicate-email path)', async () => {
     // Order-of-operations pin: a duplicate-email probe must NOT trigger
     // createUser. Otherwise a unique-constraint violation would surface as


### PR DESCRIPTION
## Summary

Nine-commit regression-test batch covering auth/session order-of-operations, cookie-attribute symmetry, and crypto-algorithm choice. Pure additive tests — no production code changes.

### Order-of-operations pins
- Signup 409 conflict fires BEFORE createUser — no orphan user-row attempts.
- Signup createSession fires only AFTER createUser succeeds — no orphan session pointing at a non-existent user_id.
- Signup createUser crash → 500 + no Set-Cookie — no half-grant where the client thinks it's logged in but the server has no session row.
- Login createSession crash → 500 + no Set-Cookie + rate-limit bucket not reset — closing the brute-force-tax bypass via transient DB hiccup.

### Auth contract pins
- /me ignores Authorization Bearer header (cookie-auth only) — pin no-Bearer-support before someone adds it silently.
- Signup 201 emits no Location header — pin the response stays "data + Set-Cookie", not a redirect target.

### Crypto algorithm pin
- hashSessionToken pinned against the SHA-256('abc') RFC 6234 vector. A swap to BLAKE2/SHA-3 would silently invalidate every existing session in the DB; this test fails the moment the digest changes.

### Cookie shape symmetry
- serializeSetCookie has NO Domain attribute (host-only).
- A token value containing '=' is URL-encoded to '%3D' (no premature attribute split).
- clearCookieHeader matches serializeSetCookie on (Domain absent, Path=/) so logout actually clears the cookie the browser sees.

### Tests
- 489 backend tests pass (was 477). +12 new tests.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 489/489 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)