### PR TITLE
feat(web): jump-to-unread + Alt+↑/↓ window cycle + Cmd-K preselect unread

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -20,6 +20,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
       { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft' },
       { keys: ['⌘', 'K'], description: 'Open command palette — switch chat window by title (Ctrl+K on Linux/Win)' },
+      { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
     ],
   },
   {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -237,6 +237,42 @@ export function ChatWindow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messagesSignature]);
 
+  // Jump-to-first-unread: when this window becomes active, find the first
+  // assistant message strictly newer than the previous lastSeen and flash it.
+  const lastSeenAtRef = useRef<number>(typeof Date !== 'undefined' ? Date.now() : 0);
+  const wasActiveRef = useRef<boolean>(active);
+  useEffect(() => {
+    if (active && !wasActiveRef.current) {
+      const seenAt = lastSeenAtRef.current;
+      let firstUnread: { id: string; createdAt: string } | null = null;
+      for (const m of messages) {
+        if (m.role !== 'assistant') continue;
+        if ((m.status ?? 'ok') !== 'ok') continue;
+        const t = Date.parse(m.createdAt);
+        if (Number.isNaN(t)) continue;
+        if (t > seenAt) {
+          firstUnread = { id: m.id, createdAt: m.createdAt };
+          break;
+        }
+      }
+      if (firstUnread) {
+        const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(firstUnread.id)}`);
+        if (el && 'scrollIntoView' in el) {
+          (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'auto' });
+        }
+        stickyRef.current = false;
+        setFlashedMsgId(firstUnread.id);
+        const handle = setTimeout(() => setFlashedMsgId(null), 1500);
+        wasActiveRef.current = true;
+        lastSeenAtRef.current = Date.now();
+        return () => clearTimeout(handle);
+      }
+    }
+    if (active) lastSeenAtRef.current = Date.now();
+    wasActiveRef.current = active;
+    return undefined;
+  }, [active, messagesSignature]);
+
   useEffect(() => {
     if (!active) return;
     const onKey = (e: globalThis.KeyboardEvent) => {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -271,6 +271,7 @@ export function ChatWindow({
     if (active) lastSeenAtRef.current = Date.now();
     wasActiveRef.current = active;
     return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, messagesSignature]);
 
   useEffect(() => {

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -115,6 +115,28 @@ export function Workspace({
     lastSeenRef.current[state.activeId] = Date.now();
   }, [state.activeId, activeLastActivity]);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!e.altKey || e.metaKey || e.ctrlKey || e.shiftKey) return;
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const target = e.target;
+      const typing = target instanceof HTMLElement
+        && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+      if (typing) return;
+      const ids = state.visibleWindows.map((w) => w.id);
+      if (ids.length === 0) return;
+      e.preventDefault();
+      const idx = state.activeId ? ids.indexOf(state.activeId) : -1;
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
+      const nextIdx = idx < 0 ? 0 : (idx + dir + ids.length) % ids.length;
+      const target2 = ids[nextIdx];
+      if (target2) state.focus(target2);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [state.visibleWindows, state.activeId, state.focus]);
+
   const unreadByWindow: Record<string, boolean> = {};
   for (const w of [...state.visibleWindows, ...state.closedWindows]) {
     const ts = lastAssistantByWindow[w.id];

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -115,6 +115,9 @@ export function Workspace({
     lastSeenRef.current[state.activeId] = Date.now();
   }, [state.activeId, activeLastActivity]);
 
+  const visibleWindowsForKey = state.visibleWindows;
+  const activeIdForKey = state.activeId;
+  const focusForKey = state.focus;
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onKey = (e: KeyboardEvent) => {
@@ -124,18 +127,18 @@ export function Workspace({
       const typing = target instanceof HTMLElement
         && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
       if (typing) return;
-      const ids = state.visibleWindows.map((w) => w.id);
+      const ids = visibleWindowsForKey.map((w) => w.id);
       if (ids.length === 0) return;
       e.preventDefault();
-      const idx = state.activeId ? ids.indexOf(state.activeId) : -1;
+      const idx = activeIdForKey ? ids.indexOf(activeIdForKey) : -1;
       const dir = e.key === 'ArrowDown' ? 1 : -1;
       const nextIdx = idx < 0 ? 0 : (idx + dir + ids.length) % ids.length;
       const target2 = ids[nextIdx];
-      if (target2) state.focus(target2);
+      if (target2) focusForKey(target2);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [state.visibleWindows, state.activeId, state.focus]);
+  }, [visibleWindowsForKey, activeIdForKey, focusForKey]);
 
   const unreadByWindow: Record<string, boolean> = {};
   for (const w of [...state.visibleWindows, ...state.closedWindows]) {

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -68,8 +68,17 @@ export function WorkspaceCommandPalette({
   }, [workspaces, query]);
 
   useEffect(() => {
-    setHover(0);
-  }, [query, open]);
+    if (!open) {
+      setHover(0);
+      return;
+    }
+    if (query) {
+      setHover(0);
+      return;
+    }
+    const idx = filtered.findIndex((it) => unreadByWindow?.[it.window.id]);
+    setHover(idx >= 0 ? idx : 0);
+  }, [query, open, filtered, unreadByWindow]);
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
Three small attention/navigation features that build on the unread tracking from #152.

## What
- **Jump to first unread on activation** — when a chat window flips active=false → active=true, ChatWindow scrolls the first ok-status assistant message strictly newer than its previous lastSeen into view and flashes it for ~1.5s (reuses the existing flash highlight from copy-link anchors). Falls back to the existing sticky-bottom behaviour when no unread message exists.
- **Alt + ↑ / ↓ cycles active chat window** — when the user is not typing into an input/textarea, Alt+↑ and Alt+↓ cycle through the visible (open) windows in workspace order. Wraps at both ends. Help overlay updated.
- **Cmd-K palette preselects first unread row** — opening the palette with no query lands the highlighted row on the first window flagged unread (instead of always the first one). Typing a query resets the highlight to the top of the filtered list, as before.

## Files changed
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)