### PR TITLE
Backend hardening batch 10: 404 parity matrix + messages contract pins

### DIFF
--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -239,6 +239,33 @@ describe('GET /v1/chat-windows/:id — user isolation', () => {
     expect(res.status).toBe(404);
     await close();
   });
+
+  it('cross-user 404 + non-existent 404 share the same code (no existence leak)', async () => {
+    // Mirror of the messages parity pin: an attacker who can probe
+    // chat-window IDs must not be able to tell 'belongs to another user'
+    // apart from 'does not exist'. Pin both responses share status +
+    // error code with a side-by-side compare.
+    const a = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => null,
+    }));
+    const ra = await get(a.baseUrl, '/v1/chat-windows/ghost-cw');
+    const ba = (await ra.json()) as ApiResponse<never>;
+    if (ba.ok) throw new Error('expected error');
+    await a.close();
+
+    const b = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async (_id, userId) => userId === USER_2.id ? mockChatWindow('ws-2') : null,
+    }));
+    const rb = await get(b.baseUrl, '/v1/chat-windows/user2-cw');
+    const bb = (await rb.json()) as ApiResponse<never>;
+    if (bb.ok) throw new Error('expected error');
+    await b.close();
+
+    expect(ra.status).toBe(rb.status);
+    expect(ba.error.code).toBe(bb.error.code);
+  });
 });
 
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -383,6 +383,12 @@ describe('POST /v1/messages — openai generation path', () => {
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('provider_not_configured');
     expect(body.error.message).toContain('openai');
+    // 412 is a setup/contract error — must ride the standard pipeline
+    // headers so an oncall can correlate via X-Request-Id and so the
+    // response is never cached.
+    expect(res.headers.get('x-request-id')).toBeTruthy();
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('x-frame-options')).toBe('DENY');
     await close();
   });
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -612,6 +612,35 @@ describe('GET /v1/messages/:id — user isolation', () => {
     expect(res.status).toBe(404);
     await close();
   });
+
+  it('cross-user 404 and non-existent 404 share the same error code (no existence leak)', async () => {
+    // Two paths return 404: 'message belongs to another user' and 'message
+    // does not exist'. The error code MUST be identical in both responses
+    // — otherwise an attacker can probe for the existence of any message
+    // ID by checking which 404 variant they receive. Pin the code parity.
+    const a = await startServer(makeDeps({
+      resolveUser:  async () => USER_1,
+      findMessage:  async () => null, // does-not-exist
+    }));
+    const ra = await get(a.baseUrl, '/v1/messages/ghost');
+    const ba = (await ra.json()) as ApiResponse<never>;
+    if (ba.ok) throw new Error('expected error');
+    await a.close();
+
+    const b = await startServer(makeDeps({
+      resolveUser:  async () => USER_1,
+      // Cross-user: repo returns null when looked up by USER_1 even though
+      // the row exists for USER_2.
+      findMessage:  async (_id, userId) => userId === USER_2.id ? mockMessage('cw-2') : null,
+    }));
+    const rb = await get(b.baseUrl, '/v1/messages/user2-msg');
+    const bb = (await rb.json()) as ApiResponse<never>;
+    if (bb.ok) throw new Error('expected error');
+    await b.close();
+
+    expect(ra.status).toBe(rb.status);
+    expect(ba.error.code).toBe(bb.error.code);
+  });
 });
 
 // ── Streaming ────────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -219,6 +219,31 @@ describe('POST /v1/messages — standard path', () => {
     expect(res.status).toBe(400);
     await close();
   });
+
+  it('role=system message persists as-is, no provider call attempted', async () => {
+    // The 'system' role is allowed by the schema (MESSAGE_ROLES) and travels
+    // the default persist-as-is path — no AI generation, no findChatWindow
+    // for provider lookup. Pin it: useful for callers that want to inject a
+    // system prompt or system note into the chat history without triggering
+    // a billed provider call.
+    let generateCalled = false;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      createMessage: async (chatWindowId, _userId, role, content) =>
+        mockMessage(chatWindowId, { id: 'sys-msg', role, content }),
+      generate: async () => { generateCalled = true; throw new Error('should not be called'); },
+    }));
+    const res = await post(baseUrl, '/v1/messages', {
+      chatWindowId: 'cw-1', role: 'system', content: 'Be terse.',
+    });
+    expect(res.status).toBe(201);
+    expect(generateCalled).toBe(false);
+    const body = (await res.json()) as ApiResponse<Message>;
+    if (!body.ok) throw new Error('expected ok');
+    expect(body.data.role).toBe('system');
+    expect(body.data.content).toBe('Be terse.');
+    await close();
+  });
 });
 
 // ── Create message — OpenAI generation path ───────────────────────────────────

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -610,6 +610,9 @@ describe('GET /v1/messages/:id — user isolation', () => {
     const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
     const res = await get(baseUrl, '/v1/messages/does-not-exist');
     expect(res.status).toBe(404);
+    // 404 must NOT be cached. A cached 404 would tell a legit caller that
+    // a message does not exist even after it has just been created.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -220,6 +220,23 @@ describe('POST /v1/messages — standard path', () => {
     await close();
   });
 
+  it('rejects content over 32_000 chars with invalid_body (schema cap)', async () => {
+    // Pin the upper-bound on content. Without this, a refactor that
+    // dropped max: 32_000 would let the controller forward arbitrarily-
+    // large prompts to the provider, blowing through the body-size
+    // limit (100KB) only when the body parser sees it — which would
+    // surface as 413 instead of the helpful 400 invalid_body.
+    const { baseUrl, close } = await startServer(makeDeps({ resolveUser: async () => USER_1 }));
+    const res = await post(baseUrl, '/v1/messages', {
+      chatWindowId: 'cw-1', role: 'user', content: 'A'.repeat(32_001),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ApiResponse<never>;
+    if (body.ok) throw new Error('expected error');
+    expect(body.error.code).toBe('invalid_body');
+    await close();
+  });
+
   it('role=system message persists as-is, no provider call attempted', async () => {
     // The 'system' role is allowed by the schema (MESSAGE_ROLES) and travels
     // the default persist-as-is path — no AI generation, no findChatWindow

--- a/apps/api/src/routes/projects-db.test.ts
+++ b/apps/api/src/routes/projects-db.test.ts
@@ -204,6 +204,32 @@ describe('GET /v1/projects/:id — user isolation', () => {
     expect(res.status).toBe(404);
     await close();
   });
+
+  it('cross-user 404 + non-existent 404 share the same code (no existence leak)', async () => {
+    // Mirror of messages-db / chat-windows-db / workspaces-db parity pins.
+    // Pin that both 404 paths return identical status + error code so an
+    // attacker probing project IDs cannot enumerate other users' projects.
+    const a = await startServer(makeDeps({
+      resolveUser: async () => USER_1,
+      findProject: async () => null,
+    }));
+    const ra = await get(a.baseUrl, '/v1/projects/ghost-proj');
+    const ba = (await ra.json()) as ApiResponse<never>;
+    if (ba.ok) throw new Error('expected error');
+    await a.close();
+
+    const b = await startServer(makeDeps({
+      resolveUser: async () => USER_1,
+      findProject: async (_id, userId) => userId === USER_2.id ? mockProject(USER_2.id) : null,
+    }));
+    const rb = await get(b.baseUrl, '/v1/projects/user2-proj');
+    const bb = (await rb.json()) as ApiResponse<never>;
+    if (bb.ok) throw new Error('expected error');
+    await b.close();
+
+    expect(ra.status).toBe(rb.status);
+    expect(ba.error.code).toBe(bb.error.code);
+  });
 });
 
 describe('PATCH /v1/projects/:id — authenticated', () => {

--- a/apps/api/src/routes/workspaces-db.test.ts
+++ b/apps/api/src/routes/workspaces-db.test.ts
@@ -226,6 +226,33 @@ describe('GET /v1/workspaces/:id — user isolation', () => {
     await close();
   });
 
+  it('cross-user 404 + non-existent 404 share the same code (no existence leak)', async () => {
+    // Mirror of the messages-db / chat-windows-db parity pins. Same
+    // threat model: an attacker who can probe workspace IDs must not
+    // be able to tell 'belongs to another user' apart from 'does not
+    // exist' via the response shape.
+    const a = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      findWorkspace: async () => null,
+    }));
+    const ra = await get(a.baseUrl, '/v1/workspaces/ghost-ws');
+    const ba = (await ra.json()) as ApiResponse<never>;
+    if (ba.ok) throw new Error('expected error');
+    await a.close();
+
+    const b = await startServer(makeDeps({
+      resolveUser:   async () => USER_1,
+      findWorkspace: async (_id, userId) => userId === USER_2.id ? mockWorkspace('proj-2') : null,
+    }));
+    const rb = await get(b.baseUrl, '/v1/workspaces/user2-ws');
+    const bb = (await rb.json()) as ApiResponse<never>;
+    if (bb.ok) throw new Error('expected error');
+    await b.close();
+
+    expect(ra.status).toBe(rb.status);
+    expect(ba.error.code).toBe(bb.error.code);
+  });
+
   it('populates windowIds from listWindowIds result', async () => {
     const ws = mockWorkspace('proj-1', { id: 'ws-with-windows' });
     const { baseUrl, close } = await startServer(makeDeps({


### PR DESCRIPTION
## Summary

Eight-commit regression-test batch. The headline is a **404-parity matrix** across all four resource types (messages, chat-windows, workspaces, projects) — every GET-by-id endpoint now has an explicit pin that the cross-user 404 and non-existent 404 paths produce indistinguishable response shapes. No more enumeration oracles via 4xx variant.

### 404 parity matrix (anti-enumeration)
- `GET /v1/messages/:id` — cross-user 404 ≡ non-existent 404 (status + code)
- `GET /v1/chat-windows/:id` — same parity pinned
- `GET /v1/workspaces/:id` — same parity pinned
- `GET /v1/projects/:id` — same parity pinned

### messages contract pins
- `role=system` POST persists as-is, no provider call attempted (allows system-prompt injection without billing).
- POST /v1/messages rejects content > 32_000 chars with invalid_body (schema cap pinned).
- 412 provider_not_configured rides `X-Request-Id`, `Cache-Control: no-store`, `X-Frame-Options` (standard pipeline parity).
- GET /v1/messages/:id 404 rides `Cache-Control: no-store` (CDN-cached 404 would lie to legit callers).

### Tests
- 495 backend tests pass (was 489). +6 new tests / parameterised assertions.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 495/495 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)