### PR TITLE
feat(web): unread counts + Mark all read + Cmd-. stop

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -32,6 +32,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
       { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft (Ctrl+Shift+Backspace)' },
       { keys: ['⌘', 'Shift', 'T'], description: 'Open the prompt template menu in the active composer (Ctrl+Shift+T)' },
+      { keys: ['⌘', '.'], description: 'Stop the in-flight reply in the active chat window (Ctrl+. on Linux/Win)' },
       { keys: ['G'], description: 'Jump to the latest message (when not typing)' },
       { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
     ],

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -339,10 +339,14 @@ export function ChatWindow({
           }
         }
       }
+      if ((e.metaKey || e.ctrlKey) && e.key === '.' && pending && onCancel) {
+        e.preventDefault();
+        onCancel(id);
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, onRename, onClose, title, id]);
+  }, [active, onRename, onClose, onCancel, pending, title, id]);
 
   const commitRename = () => {
     const trimmed = titleDraft.trim();

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -265,6 +265,7 @@ export function Workspace({
         closedWindows={state.closedWindows}
         activeId={state.activeId}
         unreadByWindow={unreadByWindow}
+        unreadCountByWindow={unreadCountByWindow}
         onFocus={state.focus}
         onReopen={state.reopen}
       />

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -2,7 +2,7 @@
 
 import type { ChatWindow, Workspace as WorkspaceType } from '@webapp/types';
 import type { MockMessage } from '@/lib/data';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useWorkspaceState } from '@/features/workspace/useWorkspaceState';
 import { useChatSessions } from '@/features/chat/useChatSessions';
@@ -141,22 +141,54 @@ export function Workspace({
   }, [visibleWindowsForKey, activeIdForKey, focusForKey]);
 
   const unreadByWindow: Record<string, boolean> = {};
+  const unreadCountByWindow: Record<string, number> = {};
   for (const w of [...state.visibleWindows, ...state.closedWindows]) {
     const ts = lastAssistantByWindow[w.id];
     const seenAt = lastSeenRef.current[w.id];
     if (!ts || w.id === state.activeId) {
       unreadByWindow[w.id] = false;
+      unreadCountByWindow[w.id] = 0;
       continue;
     }
     const messageTime = Date.parse(ts);
     if (Number.isNaN(messageTime)) {
       unreadByWindow[w.id] = false;
+      unreadCountByWindow[w.id] = 0;
       continue;
     }
-    unreadByWindow[w.id] = seenAt == null ? true : messageTime > seenAt;
+    const isUnread = seenAt == null ? true : messageTime > seenAt;
+    unreadByWindow[w.id] = isUnread;
+    if (!isUnread) {
+      unreadCountByWindow[w.id] = 0;
+      continue;
+    }
+    let count = 0;
+    const list = chat.getMessages(w.id);
+    for (const m of list) {
+      if (m.role !== 'assistant') continue;
+      if ((m.status ?? 'ok') !== 'ok') continue;
+      const t = Date.parse(m.createdAt);
+      if (Number.isNaN(t)) continue;
+      if (seenAt == null || t > seenAt) count += 1;
+    }
+    unreadCountByWindow[w.id] = count;
   }
   const totalUnread = Object.values(unreadByWindow).filter(Boolean).length;
+  const totalUnreadMessages = Object.values(unreadCountByWindow).reduce((a, b) => a + b, 0);
   const anyPending = Object.values(pendingByWindow).some(Boolean);
+
+  const [, forceTick] = useState(0);
+  const markAsReadById = (id: string) => {
+    lastSeenRef.current[id] = Date.now();
+    forceTick((n: number) => n + 1);
+  };
+  const markAllAsRead = () => {
+    const now = Date.now();
+    for (const id of Object.keys(unreadByWindow)) {
+      if (unreadByWindow[id]) lastSeenRef.current[id] = now;
+    }
+    forceTick((n: number) => n + 1);
+  };
 
   const previousTitleRef = useRef<string | null>(null);
   useEffect(() => {
@@ -168,9 +200,16 @@ export function Workspace({
   useEffect(() => {
     if (typeof document === 'undefined') return;
     const base = `${projectName} · ${activeWorkspace.name} — AI Workspace V1`;
-    const prefix = totalUnread > 0 ? `(${totalUnread}) ` : anyPending ? '… ' : '';
+    const prefix =
+      totalUnreadMessages > 0
+        ? `(${totalUnreadMessages}) `
+        : totalUnread > 0
+          ? `(${totalUnread}) `
+          : anyPending
+            ? '… '
+            : '';
     document.title = `${prefix}${base}`;
-  }, [totalUnread, anyPending, projectName, activeWorkspace.name]);
+  }, [totalUnread, totalUnreadMessages, anyPending, projectName, activeWorkspace.name]);
   useEffect(() => {
     return () => {
       if (typeof document === 'undefined') return;

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -178,10 +178,6 @@ export function Workspace({
   const anyPending = Object.values(pendingByWindow).some(Boolean);
 
   const [, forceTick] = useState(0);
-  const markAsReadById = (id: string) => {
-    lastSeenRef.current[id] = Date.now();
-    forceTick((n: number) => n + 1);
-  };
   const markAllAsRead = () => {
     const now = Date.now();
     for (const id of Object.keys(unreadByWindow)) {

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -230,6 +230,8 @@ export function Workspace({
         lastActivityByWindow={lastActivityByWindow}
         pendingByWindow={pendingByWindow}
         unreadByWindow={unreadByWindow}
+        unreadCountByWindow={unreadCountByWindow}
+        onMarkAllAsRead={totalUnread > 0 ? markAllAsRead : undefined}
         onFocus={state.focus}
         onClose={state.close}
         onReopen={state.reopen}

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -17,6 +17,7 @@ interface WorkspaceCommandPaletteProps {
   closedWindows: ChatWindow[];
   activeId: string | null;
   unreadByWindow?: Record<string, boolean>;
+  unreadCountByWindow?: Record<string, number>;
   onFocus: (id: string) => void;
   onReopen: (id: string) => void;
 }
@@ -37,6 +38,7 @@ export function WorkspaceCommandPalette({
   closedWindows,
   activeId,
   unreadByWindow,
+  unreadCountByWindow,
   onFocus,
   onReopen,
 }: WorkspaceCommandPaletteProps) {
@@ -222,7 +224,15 @@ export function WorkspaceCommandPalette({
                   <span style={metaStyle}>
                     {it.window.provider} · {it.window.model}
                   </span>
-                  {unreadByWindow?.[it.window.id] ? <span style={unreadBadgeStyle}>unread</span> : null}
+                  {unreadByWindow?.[it.window.id]
+                    ? (
+                      <span style={unreadBadgeStyle}>
+                        {(unreadCountByWindow?.[it.window.id] ?? 0) > 1
+                          ? `+${unreadCountByWindow?.[it.window.id]} unread`
+                          : 'unread'}
+                      </span>
+                    )
+                    : null}
                   {pinnedSet.has(it.window.id) ? <span style={pinnedBadgeStyle}>pinned</span> : null}
                   {!it.open ? <span style={badgeStyle}>closed</span> : null}
                   {isActive ? <span style={activeBadgeStyle}>active</span> : null}

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -23,6 +23,8 @@ interface WorkspaceSidebarProps {
   lastActivityByWindow?: Record<string, string | undefined>;
   pendingByWindow?: Record<string, boolean>;
   unreadByWindow?: Record<string, boolean>;
+  unreadCountByWindow?: Record<string, number>;
+  onMarkAllAsRead?: () => void;
   onFocus: (id: string) => void;
   onClose: (id: string) => void;
   onReopen: (id: string) => void;
@@ -47,6 +49,8 @@ export function WorkspaceSidebar({
   lastActivityByWindow,
   pendingByWindow,
   unreadByWindow,
+  unreadCountByWindow,
+  onMarkAllAsRead,
   onFocus,
   onClose,
   onReopen,
@@ -164,9 +168,32 @@ export function WorkspaceSidebar({
             </button>
           </div>
         ) : null}
-        <SectionLabel>
-          Open · {filterEnabled && lowerFilter ? `${filteredVisible.length}/${visibleWindows.length}` : visibleWindows.length}
-        </SectionLabel>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <SectionLabel>
+            Open · {filterEnabled && lowerFilter ? `${filteredVisible.length}/${visibleWindows.length}` : visibleWindows.length}
+          </SectionLabel>
+          {onMarkAllAsRead ? (
+            <button
+              type="button"
+              onClick={onMarkAllAsRead}
+              aria-label="Mark all unread windows as read"
+              title="Mark all unread windows as read"
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: '#9aa6ff',
+                cursor: 'pointer',
+                fontSize: '0.62rem',
+                fontFamily: 'inherit',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                padding: '0 0.25rem',
+              }}
+            >
+              Mark all read
+            </button>
+          ) : null}
+        </div>
         {filteredVisible.length === 0 ? (
           <EmptyHint>{lowerFilter ? 'No matches' : 'No windows open'}</EmptyHint>
         ) : (
@@ -179,6 +206,7 @@ export function WorkspaceSidebar({
               lastActivity={lastActivityByWindow?.[w.id]}
               pending={pendingByWindow?.[w.id]}
               unread={unreadByWindow?.[w.id]}
+              unreadCount={unreadCountByWindow?.[w.id]}
               onClick={() => onFocus(w.id)}
               onAction={() => onClose(w.id)}
               actionLabel="×"
@@ -200,6 +228,7 @@ export function WorkspaceSidebar({
                 muted
                 lastActivity={lastActivityByWindow?.[w.id]}
                 unread={unreadByWindow?.[w.id]}
+                unreadCount={unreadCountByWindow?.[w.id]}
                 onClick={() => onReopen(w.id)}
                 onAction={() => onReopen(w.id)}
                 actionLabel="↺"
@@ -665,13 +694,14 @@ interface WindowRowProps {
   lastActivity?: string;
   pending?: boolean;
   unread?: boolean;
+  unreadCount?: number;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -746,18 +776,40 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, unrea
           }}
         >
           {unread ? (
-            <span
-              aria-label="Unread reply"
-              title="New reply since you last viewed this window"
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: '#9aa6ff',
-                boxShadow: '0 0 0 2px rgba(79,107,255,0.25)',
-                flexShrink: 0,
-              }}
-            />
+            unreadCount && unreadCount > 1 ? (
+              <span
+                aria-label={`${unreadCount} unread replies`}
+                title={`${unreadCount} new replies since you last viewed this window`}
+                style={{
+                  fontSize: '0.6rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.04em',
+                  padding: '0 5px',
+                  height: 14,
+                  lineHeight: '14px',
+                  borderRadius: 7,
+                  background: '#15203b',
+                  border: '1px solid #3a3f6b',
+                  color: '#9aa6ff',
+                  flexShrink: 0,
+                }}
+              >
+                +{unreadCount}
+              </span>
+            ) : (
+              <span
+                aria-label="Unread reply"
+                title="New reply since you last viewed this window"
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: '#9aa6ff',
+                  boxShadow: '0 0 0 2px rgba(79,107,255,0.25)',
+                  flexShrink: 0,
+                }}
+              />
+            )
           ) : null}
           {pinned ? (
             <span


### PR DESCRIPTION
Builds on the unread tracking from #152/#154 with concrete affordances.

## What
- **Per-window unread count** — `unreadCountByWindow` derived in Workspace (number of ok-status assistant messages strictly newer than lastSeen). Used in:
  - `document.title` prefix: `(<n>) ` based on total unread *messages* (falls back to window-count, then to "… " when generating).
  - sidebar `WindowRow`: shows a "+N" pill instead of a single dot when count > 1.
  - Cmd-K palette: `unread` pill becomes `+N unread` when count > 1.
- **Mark all read** — Workspace exposes `markAllAsRead()` that bumps `lastSeen` for every currently-unread window. Sidebar shows a small "Mark all read" link next to the "Open · N" header when there's at least one unread.
- **Cmd / Ctrl + .** — keyboard shortcut for the Stop generating button. Listener attached only on the active window, fires only when `pending && onCancel`. Help overlay updated.

## Files changed
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceSidebar.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)