### PR TITLE
Backend hardening batch 11: complete Cache-Control: no-store matrix on user-scoped GETs

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -542,6 +542,14 @@ describe('GET /v1/auth/me', () => {
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe(USER.id);
     expect('passwordHash' in body.data).toBe(false);
+    // CRITICAL: /me carries per-user identity. A cached /me at a shared
+    // proxy/CDN would return user A's identity to user B on the next cache
+    // hit — instant identity confusion. Pin Cache-Control: no-store
+    // explicitly on the success path; the fact that handleRequest
+    // currently inherits it from writeJson is not enough — a future
+    // explicit caching directive on this route would silently leak.
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
     await close();
   });
 
@@ -798,6 +806,10 @@ describe('GET /v1/me (alias of /v1/auth/me)', () => {
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe(USER.id);
     expect('passwordHash' in body.data).toBe(false);
+    // Same caching catastrophe applies to the alias path — pin no-store
+    // explicitly so a refactor that special-cases the alias for caching
+    // can't ship without failing CI.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -223,6 +223,7 @@ describe('GET /v1/chat-windows/:id — user isolation', () => {
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe('own-cw');
     expect(body.data.provider).toBe('openai');
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/chat-windows-db.test.ts
+++ b/apps/api/src/routes/chat-windows-db.test.ts
@@ -147,6 +147,9 @@ describe('GET /v1/chat-windows — authenticated', () => {
     expect(body.data).toHaveLength(2);
     expect(body.data.map((c) => c.id)).toEqual(['cw-1', 'cw-2']);
     expect(body.data.every((c) => c.provider !== undefined && c.model !== undefined)).toBe(true);
+    // Per-user data must not be cached. Same caching catastrophe as
+    // /me, /v1/state and /v1/projects — pin no-store explicitly.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 });

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -164,6 +164,10 @@ describe('GET /v1/messages — authenticated', () => {
     if (!body.ok) throw new Error('expected ok');
     expect(body.data).toHaveLength(2);
     expect(body.data.map((m) => m.id)).toEqual(['msg-1', 'msg-2']);
+    // Per-user data — must not be cached. Messages are the highest-
+    // sensitivity surface of the API: a cached chat history broadcast
+    // would leak personal conversations across users.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 });

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -597,6 +597,7 @@ describe('GET /v1/messages/:id — user isolation', () => {
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe('own-msg');
     expect(body.data.role).toBe('user');
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/projects-db.test.ts
+++ b/apps/api/src/routes/projects-db.test.ts
@@ -124,6 +124,10 @@ describe('GET /v1/projects — authenticated', () => {
     expect(body.data).toHaveLength(2);
     expect(body.data.map((p) => p.id)).toEqual(['p1', 'p2']);
     expect(body.data.every((p) => !('userId' in p))).toBe(true);
+    // Per-user list: must not be cached at a shared proxy. Same blast
+    // radius as /me — a cached projects list would broadcast user A's
+    // project names to user B on the next cache hit.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/projects-db.test.ts
+++ b/apps/api/src/routes/projects-db.test.ts
@@ -188,6 +188,9 @@ describe('GET /v1/projects/:id — user isolation', () => {
     const body = (await res.json()) as ApiResponse<Project>;
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe('own-proj');
+    // Per-user data — no shared-cache caching. Same logic as the list
+    // endpoints; pin no-store on every user-scoped GET-by-id too.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/state-db.test.ts
+++ b/apps/api/src/routes/state-db.test.ts
@@ -96,6 +96,14 @@ describe('GET /v1/state — authenticated returns user graph', () => {
     expect(body.data.messages).toHaveLength(1);
     expect(body.data.projects[0]!.id).toBe('p1');
     expect(body.data.workspaces[0]!.windowIds).toEqual(['cw1']);
+    // CRITICAL: /v1/state ships the FULL per-user entity graph
+    // (projects + workspaces + chat windows + messages). A cached
+    // response at a shared proxy would broadcast one user's entire
+    // workspace to whoever hits the cache next. Pin no-store
+    // explicitly — this is the single highest-blast-radius caching
+    // bug the system can have.
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('x-request-id')).toBeTruthy();
     await close();
   });
 });

--- a/apps/api/src/routes/workspaces-db.test.ts
+++ b/apps/api/src/routes/workspaces-db.test.ts
@@ -209,6 +209,7 @@ describe('GET /v1/workspaces/:id — user isolation', () => {
     const body = (await res.json()) as ApiResponse<Workspace>;
     if (!body.ok) throw new Error('expected ok');
     expect(body.data.id).toBe('own-ws');
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/workspaces-db.test.ts
+++ b/apps/api/src/routes/workspaces-db.test.ts
@@ -143,6 +143,9 @@ describe('GET /v1/workspaces — authenticated', () => {
     expect(body.data).toHaveLength(2);
     expect(body.data.map((w) => w.id)).toEqual(['ws-1', 'ws-2']);
     expect(body.data.every((w) => Array.isArray(w.windowIds))).toBe(true);
+    // Per-user data — must not be cached. Same caching catastrophe as
+    // the other list endpoints; pin no-store explicitly.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 });


### PR DESCRIPTION
## Summary

Four-commit regression batch completing the **Cache-Control: no-store matrix** on every user-scoped GET success path. The middleware already inherits no-store globally via writeJson, but a future explicit caching directive on any of these routes would silently override it. Pinning the assertion on the success path prevents that class of regression from shipping.

### Coverage matrix
**Identity:**
- `GET /v1/auth/me` 200
- `GET /v1/me` alias 200

**Full graph:**
- `GET /v1/state` 200 (highest-blast-radius — projects + workspaces + chat-windows + messages)

**By-id (4):**
- `GET /v1/projects/:id`
- `GET /v1/workspaces/:id`
- `GET /v1/chat-windows/:id`
- `GET /v1/messages/:id`

**By-parent list (4):**
- `GET /v1/projects`
- `GET /v1/workspaces?projectId=…`
- `GET /v1/chat-windows?workspaceId=…`
- `GET /v1/messages?chatWindowId=…`

**11 user-scoped endpoints**, all now with explicit Cache-Control: no-store assertions on the 200 success path.

### Why it matters
Every endpoint above returns per-user data. A cached response at a shared proxy/CDN would return user A's data to user B on the next cache hit — the highest-impact caching bug a multi-tenant API can ship. The pins make that change have to update tests deliberately.

### Tests
- 495 backend tests pass (no count change — pins added to existing success-path tests).
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 495/495 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)