### PR TITLE
Backend hardening batch 12: complete Cache-Control: no-store matrix on 4xx error envelopes

### DIFF
--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -94,6 +94,17 @@ describe('dispatch — error envelopes', () => {
     expect(notFound.headers.get('cache-control')).toBe('no-store');
   });
 
+  it('emits Cache-Control: no-store on 405 method-not-allowed', async () => {
+    // A cached 405 would falsely report 'method not allowed' even after
+    // a deploy that added the missing handler. Pin the no-store on the
+    // handleRequest 405 short-circuit (which uses writeJson under the
+    // hood, but a future direct res.writeHead(405) refactor could skip
+    // it).
+    const res = await fetch(`${harness.baseUrl}/health`, { method: 'DELETE' });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
   it('emits Allow header on 405 listing the methods the path actually supports', async () => {
     // /health is a GET-only route; a DELETE must surface Allow: GET (RFC 7231).
     const res = await fetch(`${harness.baseUrl}/health`, { method: 'DELETE' });
@@ -158,6 +169,7 @@ describe('CSRF protection — explicit origin', () => {
     expect(res.headers.get('x-frame-options')).toBe('DENY');
     expect(res.headers.get('x-content-type-options')).toBe('nosniff');
     expect(res.headers.get('x-request-id')).toBeTruthy();
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -591,6 +591,10 @@ describe('GET /v1/auth/me', () => {
     const body = (await res.json()) as ApiResponse<never>;
     if (body.ok) throw new Error('expected error');
     expect(body.error.code).toBe('unauthenticated');
+    // 401 must ride no-store. A cached 401 would tell a freshly-logged-in
+    // user 'you're not logged in' for the duration of the cache TTL —
+    // worst-possible UX for the auth flow. Pin explicitly.
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 
@@ -600,6 +604,7 @@ describe('GET /v1/auth/me', () => {
       headers: { Cookie: `${SESSION_COOKIE_NAME}=${'b'.repeat(64)}` },
     });
     expect(res.status).toBe(401);
+    expect(res.headers.get('cache-control')).toBe('no-store');
     await close();
   });
 

--- a/apps/api/src/routes/projects.test.ts
+++ b/apps/api/src/routes/projects.test.ts
@@ -158,6 +158,10 @@ describe('POST /v1/projects', () => {
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('unsupported_media_type');
+    // Even pipeline-level transport errors must ride no-store. A cached
+    // 415 would lock a client into 'unsupported' even after the wrong
+    // content-type was fixed in the deploy that follows.
+    expect(res.headers.get('cache-control')).toBe('no-store');
   });
 
   it('returns 413 for oversized body', async () => {
@@ -172,6 +176,9 @@ describe('POST /v1/projects', () => {
     expect(body.ok).toBe(false);
     if (body.ok) throw new Error('expected error envelope');
     expect(body.error.code).toBe('payload_too_large');
+    // Same logic as 415: a cached 413 would block a legit smaller-payload
+    // retry from the same caller. Pin no-store explicitly.
+    expect(res.headers.get('cache-control')).toBe('no-store');
   });
 
   it('invalid_body envelope carries a fields list with the offending paths', async () => {


### PR DESCRIPTION
## Summary

Three-commit batch finishing the **Cache-Control: no-store coverage matrix**. Batch 11 covered every user-scoped 200 success path; this batch covers the 4xx error envelopes that could equally cause confusion if cached at a shared proxy.

### Why error responses also need no-store
- Cached **401** would tell a freshly-logged-in user 'you are not logged in' for the cache TTL — worst-possible UX in the auth flow.
- Cached **403** CSRF rejection becomes a permanent block for every legit caller behind the cache.
- Cached **405** would falsely report 'method not allowed' even after a deploy added the missing handler.
- Cached **413/415** would lock callers into 'oversized' / 'unsupported media type' even after the bad request was fixed in a follow-up retry.

### Coverage added
- `405 method_not_allowed` (handle-request) → no-store
- `403 csrf_error` (handle-request) → no-store
- `415 unsupported_media_type` (projects POST) → no-store
- `413 payload_too_large` (projects POST) → no-store
- `/v1/auth/me 401` (no cookie + unknown session) → no-store

### Tests
- 496 backend tests pass (was 495). +1 new test (405 row), other commits added assertions to existing tests.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 496/496 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)