### PR TITLE
feat(web): workspace-wide message search in Cmd-K palette

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -19,7 +19,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['?'], description: 'Show this help' },
       { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
       { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft' },
-      { keys: ['⌘', 'K'], description: 'Open command palette — switch chat window by title (Ctrl+K on Linux/Win)' },
+      { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, and message contents (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
     ],
   },

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -219,21 +219,42 @@ export function ChatWindow({
   }, [searchStorageKey, searchQuery]);
 
   const [flashedMsgId, setFlashedMsgId] = useState<string | null>(null);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
+  const handleHashJump = () => {
+    if (typeof window === 'undefined') return null;
     const hash = window.location.hash;
-    if (!hash || !hash.startsWith('#msg-')) return;
+    if (!hash || !hash.startsWith('#msg-')) return null;
     const targetId = hash.slice(5);
     const exists = messages.some((m) => m.id === targetId);
-    if (!exists) return;
+    if (!exists) return null;
     const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(targetId)}`);
     if (el && 'scrollIntoView' in el) {
       (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'auto' });
     }
     stickyRef.current = false;
     setFlashedMsgId(targetId);
+    return targetId;
+  };
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const targetId = handleHashJump();
+    if (!targetId) return;
     const t = setTimeout(() => setFlashedMsgId(null), 1500);
     return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messagesSignature]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const onHash = () => {
+      const targetId = handleHashJump();
+      if (timer) clearTimeout(timer);
+      if (targetId) timer = setTimeout(() => setFlashedMsgId(null), 1500);
+    };
+    window.addEventListener('hashchange', onHash);
+    return () => {
+      window.removeEventListener('hashchange', onHash);
+      if (timer) clearTimeout(timer);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messagesSignature]);
 

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -262,6 +262,7 @@ export function Workspace({
         activeId={state.activeId}
         unreadByWindow={unreadByWindow}
         unreadCountByWindow={unreadCountByWindow}
+        getMessages={chat.getMessages}
         onFocus={state.focus}
         onReopen={state.reopen}
       />

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -197,7 +197,7 @@ export function WorkspaceCommandPalette({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={onInputKeyDown}
-          placeholder="Type a window title, model, or workspace…"
+          placeholder="Search windows, workspaces, or messages…"
           aria-label="Filter chat windows or workspaces"
           style={inputStyle}
         />

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
 import type { ChatWindow, Workspace } from '@webapp/types';
+import type { MockMessage } from '@/lib/data';
 
 interface PaletteWindow {
   window: ChatWindow;
@@ -18,6 +19,7 @@ interface WorkspaceCommandPaletteProps {
   activeId: string | null;
   unreadByWindow?: Record<string, boolean>;
   unreadCountByWindow?: Record<string, number>;
+  getMessages?: (windowId: string) => MockMessage[];
   onFocus: (id: string) => void;
   onReopen: (id: string) => void;
 }
@@ -39,6 +41,7 @@ export function WorkspaceCommandPalette({
   activeId,
   unreadByWindow,
   unreadCountByWindow,
+  getMessages,
   onFocus,
   onReopen,
 }: WorkspaceCommandPaletteProps) {
@@ -68,6 +71,39 @@ export function WorkspaceCommandPalette({
     if (!q) return workspaces;
     return workspaces.filter((w) => w.name.toLowerCase().includes(q));
   }, [workspaces, query]);
+
+  const messageMatches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q || q.length < 2 || !getMessages) return [] as Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }>;
+    const allWindows = [...visibleWindows, ...closedWindows];
+    const out: Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }> = [];
+    for (const w of allWindows) {
+      const list = getMessages(w.id);
+      for (const m of list) {
+        const content = m.content;
+        if (!content) continue;
+        const lc = content.toLowerCase();
+        const idx = lc.indexOf(q);
+        if (idx < 0) continue;
+        const start = Math.max(0, idx - 28);
+        const end = Math.min(content.length, idx + q.length + 60);
+        let snippet = content.slice(start, end);
+        if (start > 0) snippet = '…' + snippet;
+        if (end < content.length) snippet = snippet + '…';
+        out.push({
+          windowId: w.id,
+          window: w,
+          messageId: m.id,
+          role: m.role,
+          snippet: snippet.replace(/\s+/g, ' ').trim(),
+          createdAt: m.createdAt,
+        });
+        if (out.length >= 24) break;
+      }
+      if (out.length >= 24) break;
+    }
+    return out;
+  }, [query, getMessages, visibleWindows, closedWindows]);
 
   useEffect(() => {
     if (!open) {
@@ -241,6 +277,61 @@ export function WorkspaceCommandPalette({
             })
           )}
         </ul>
+        {messageMatches.length > 0 ? (
+          <>
+            <div style={sectionLabelStyle}>Messages · {messageMatches.length}</div>
+            <ul role="list" style={{ ...listStyle, maxHeight: 240 }}>
+              {messageMatches.map((m, i) => (
+                <li key={`${m.windowId}-${m.messageId}-${i}`} style={{ listStyle: 'none' }}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const visible = visibleWindows.some((w) => w.id === m.windowId);
+                      if (!visible) onReopen(m.windowId);
+                      else onFocus(m.windowId);
+                      setOpen(false);
+                      setQuery('');
+                      if (typeof window !== 'undefined') {
+                        // Use hash to trigger ChatWindow's existing #msg-<id> scroll/flash effect
+                        const url = new URL(window.location.href);
+                        url.hash = `msg-${m.messageId}`;
+                        window.history.replaceState(null, '', url.toString());
+                        window.dispatchEvent(new HashChangeEvent('hashchange'));
+                      }
+                    }}
+                    style={{
+                      ...rowStyle,
+                      width: '100%',
+                      background: 'transparent',
+                      border: 'none',
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      color: '#cfcfd6',
+                    }}
+                  >
+                    <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                      <div
+                        style={{
+                          fontSize: '0.78rem',
+                          color: '#e8e8ef',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {m.snippet}
+                      </div>
+                      <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
+                        {m.role} · {m.window.title}
+                      </div>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
         <div style={footerStyle}>
           <span>↑↓ navigate · Enter to switch · Esc to close</span>
         </div>


### PR DESCRIPTION
The Cmd-K command palette gains a third search dimension: it now searches across the contents of every message in every chat window of the current workspace, not just window titles and workspace names.

## What
- **Messages section in palette** — when the trimmed query is at least 2 characters, the palette renders a "Messages · N" section under the chat-windows list with up to 24 hits. Each row shows:
  - a snippet (~28 chars before the match + 60 after)
  - role · host window title
- **Click → focus + jump** — clicking a result focuses (or reopens, if closed) the host window and triggers the existing `#msg-<id>` hash handler in ChatWindow so the target bubble scrolls into view and flashes for ~1.5s.
- **Hash listener in ChatWindow** — the existing scroll/flash effect was only triggered on `messagesSignature` changes (i.e. fresh renders). Added a `hashchange` listener that re-runs the same logic, so the palette can drive scroll/flash via a mid-session URL update without remounting the window.
- **Placeholder + overlay copy** updated to advertise the new capability ("Search windows, workspaces, or messages…").

## Files changed
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`
- `apps/web/src/features/chat/ChatWindow.tsx`
- `apps/web/src/components/KeyboardShortcutsOverlay.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
- Pure client-side filter on already-loaded messages — no backend, no API contract, no shared-types changes, no new dependencies.
- Bounded at 24 results to keep the palette snappy on large workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)