### PR TITLE
Backend hardening batch 13: anti-indexing header pins on health + version endpoints

### DIFF
--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -74,6 +74,10 @@ describe('GET /v1/health/deep', () => {
     const res = await fetch(`${baseUrl}/v1/health/deep`);
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control')).toBe('no-store');
+    // Mirror of the /health pin — keep the deep probe out of search
+    // engine indexes too. Same risk profile (always 200 in healthy
+    // state, small predictable JSON body).
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
     await close();
   });
 });

--- a/apps/api/src/controllers/version.controller.test.ts
+++ b/apps/api/src/controllers/version.controller.test.ts
@@ -22,5 +22,11 @@ describe('GET /v1/version', () => {
     expect(typeof body.data.buildTimestamp).toBe('string');
     // commit may be null when no GIT_SHA-style env var is set
     expect(body.data.commit === null || typeof body.data.commit === 'string').toBe(true);
+    // /version exposes the deployed service version + commit — useful
+    // for ops, but every reason for crawlers to NOT index it (lets a
+    // search engine snapshot a stale deployment SHA forever, and lets
+    // a probe enumerate what version is in production via cached
+    // search results). Pin the anti-indexing header.
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
   });
 });

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -20,6 +20,11 @@ describe('GET /health', () => {
     expect(res.headers.get('x-request-id')).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
+    // Health endpoints are the most common target for misrouted Googlebot
+    // hits — they're indexed without effort because they always 200 and
+    // return a small JSON body. Pin X-Robots-Tag explicitly so this stays
+    // out of search results regardless of any future caching/CDN tweak.
+    expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
 
     const body = (await res.json()) as ApiResponse<HealthStatus>;
     expect(body.ok).toBe(true);


### PR DESCRIPTION
## Summary

Three-commit deliberately-narrow batch. After 12 batches of layered regression coverage, the auth/session/messages surface is exhaustively pinned. This batch finishes one small remaining gap: the **anti-indexing header** (`X-Robots-Tag: noindex, nofollow`) added globally in batch 3 was not asserted on the three Googlebot-magnet endpoints — health and version probes that always 200 with a small JSON body.

### Pins added
- `GET /health` → `X-Robots-Tag: noindex, nofollow`
- `GET /v1/health/deep` → same pin
- `GET /v1/version` → same pin (extra reason: stops search engines from snapshotting a stale deployment SHA forever)

### Why this is the last useful regression-pin batch
Every observable response shape (success + 4xx + 5xx, user-scoped + global + auth + transport) now has explicit assertions for Cache-Control, security headers, X-Request-Id, no-Set-Cookie-on-401, 404-parity, cookie attributes, etc. The remaining real candidates require explicit product/architecture decisions that aren't appropriate for a pure-backend regression batch:

- Vary: Cookie on /me — needs cache strategy
- HTTP server requestTimeout/headersTimeout — affects long-running SSE streams
- Password whitespace policy — contract change
- OAuth-style refresh tokens — greenfield
- Idle-stream timeout / keepalive ping — UX architecture

### Tests
- 496 backend tests pass (no count change — pins added to existing success-path tests).
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 496/496 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)