### PR TITLE
feat(web): Cmd-K palette — Recent section + debounced search + scope toggle

### DIFF
--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -113,7 +113,19 @@ export function Workspace({
   useEffect(() => {
     if (!state.activeId) return;
     lastSeenRef.current[state.activeId] = Date.now();
-  }, [state.activeId, activeLastActivity]);
+    if (typeof window !== 'undefined') {
+      try {
+        const key = `wav.workspace.recents.${activeWorkspace.id}`;
+        const raw = window.sessionStorage.getItem(key);
+        const list: string[] = raw ? (JSON.parse(raw) as string[]).filter((x) => typeof x === 'string') : [];
+        const next = [state.activeId, ...list.filter((x) => x !== state.activeId)].slice(0, 8);
+        window.sessionStorage.setItem(key, JSON.stringify(next));
+        window.dispatchEvent(new Event('wav:recents-changed'));
+      } catch {
+        // ignore
+      }
+    }
+  }, [state.activeId, activeLastActivity, activeWorkspace.id]);
 
   const visibleWindowsForKey = state.visibleWindows;
   const activeIdForKey = state.activeId;

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -49,6 +49,7 @@ export function WorkspaceCommandPalette({
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinned());
   const [recentIds, setRecentIds] = useState<string[]>(() => readRecents(activeWorkspaceId));
   const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
   const [hover, setHover] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -74,7 +75,7 @@ export function WorkspaceCommandPalette({
   }, [workspaces, query]);
 
   const messageMatches = useMemo(() => {
-    const q = query.trim().toLowerCase();
+    const q = debouncedQuery.trim().toLowerCase();
     if (!q || q.length < 2 || !getMessages) return [] as Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }>;
     const allWindows = [...visibleWindows, ...closedWindows];
     const out: Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }> = [];
@@ -104,7 +105,7 @@ export function WorkspaceCommandPalette({
       if (out.length >= 24) break;
     }
     return out;
-  }, [query, getMessages, visibleWindows, closedWindows]);
+  }, [debouncedQuery, getMessages, visibleWindows, closedWindows]);
 
   type UnifiedItem =
     | { kind: 'workspace'; key: string; workspace: Workspace }
@@ -150,6 +151,11 @@ export function WorkspaceCommandPalette({
     }
     return out;
   }, [recentEntries, filteredWorkspaces, filtered, messageMatches]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 200);
+    return () => clearTimeout(t);
+  }, [query]);
 
   useEffect(() => {
     if (!open) {

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -47,6 +47,7 @@ export function WorkspaceCommandPalette({
 }: WorkspaceCommandPaletteProps) {
   const [open, setOpen] = useState(false);
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinned());
+  const [recentIds, setRecentIds] = useState<string[]>(() => readRecents(activeWorkspaceId));
   const [query, setQuery] = useState('');
   const [hover, setHover] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -110,14 +111,36 @@ export function WorkspaceCommandPalette({
     | { kind: 'window'; key: string; entry: PaletteWindow }
     | { kind: 'message'; key: string; match: typeof messageMatches[number] };
 
+  const recentEntries: PaletteWindow[] = useMemo(() => {
+    if (query.trim()) return [];
+    const all = [
+      ...visibleWindows.map((w) => ({ window: w, open: true })),
+      ...closedWindows.map((w) => ({ window: w, open: false })),
+    ];
+    const byId = new Map(all.map((it) => [it.window.id, it]));
+    const out: PaletteWindow[] = [];
+    for (const id of recentIds) {
+      if (id === activeId) continue; // skip the currently focused one
+      const it = byId.get(id);
+      if (!it) continue;
+      out.push(it);
+      if (out.length >= 5) break;
+    }
+    return out;
+  }, [query, recentIds, activeId, visibleWindows, closedWindows]);
+
   const unifiedItems: UnifiedItem[] = useMemo(() => {
     const out: UnifiedItem[] = [];
+    for (const it of recentEntries) {
+      out.push({ kind: 'window', key: `recent-${it.window.id}`, entry: it });
+    }
     if (filteredWorkspaces.length > 1) {
       for (const w of filteredWorkspaces) {
         out.push({ kind: 'workspace', key: `ws-${w.id}`, workspace: w });
       }
     }
     for (const it of filtered) {
+      if (recentEntries.some((r) => r.window.id === it.window.id)) continue;
       out.push({ kind: 'window', key: `w-${it.window.id}`, entry: it });
     }
     for (let i = 0; i < messageMatches.length; i += 1) {
@@ -126,7 +149,7 @@ export function WorkspaceCommandPalette({
       out.push({ kind: 'message', key: `m-${m.windowId}-${m.messageId}-${i}`, match: m });
     }
     return out;
-  }, [filteredWorkspaces, filtered, messageMatches]);
+  }, [recentEntries, filteredWorkspaces, filtered, messageMatches]);
 
   useEffect(() => {
     if (!open) {
@@ -146,10 +169,16 @@ export function WorkspaceCommandPalette({
   useEffect(() => {
     if (!open) return;
     setPinnedSet(readPinned());
+    setRecentIds(readRecents(activeWorkspaceId));
     const onChange = () => setPinnedSet(readPinned());
+    const onRecents = () => setRecentIds(readRecents(activeWorkspaceId));
     window.addEventListener('wav:pin-changed', onChange);
-    return () => window.removeEventListener('wav:pin-changed', onChange);
-  }, [open]);
+    window.addEventListener('wav:recents-changed', onRecents);
+    return () => {
+      window.removeEventListener('wav:pin-changed', onChange);
+      window.removeEventListener('wav:recents-changed', onRecents);
+    };
+  }, [open, activeWorkspaceId]);
 
   useEffect(() => {
     const onKey = (e: globalThis.KeyboardEvent) => {
@@ -255,6 +284,37 @@ export function WorkspaceCommandPalette({
           aria-label="Filter chat windows or workspaces"
           style={inputStyle}
         />
+        {recentEntries.length > 0 ? (
+          <div>
+            <div style={sectionLabelStyle}>Recent</div>
+            <ul role="list" style={listStyle}>
+              {recentEntries.map((it) => {
+                const idx = unifiedItems.findIndex(
+                  (u) => u.kind === 'window' && u.key === `recent-${it.window.id}`,
+                );
+                const isHover = idx === Math.min(hover, unifiedItems.length - 1);
+                return (
+                  <li key={`recent-${it.window.id}`} role="option" aria-selected={isHover}
+                    onMouseEnter={() => idx >= 0 && setHover(idx)}
+                    onClick={() => choose(it)}
+                    style={{
+                      ...rowStyle,
+                      background: isHover ? '#1c1c28' : 'transparent',
+                      border: `1px solid ${isHover ? '#3a3f6b' : 'transparent'}`,
+                    }}
+                  >
+                    <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {it.window.title}
+                    </span>
+                    <span style={metaStyle}>{it.window.provider} · {it.window.model}</span>
+                    {!it.open ? <span style={badgeStyle}>closed</span> : null}
+                    {pinnedSet.has(it.window.id) ? <span style={pinnedBadgeStyle}>pinned</span> : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
         {filteredWorkspaces.length > 1 ? (
           <div>
             <div style={sectionLabelStyle}>Workspaces</div>
@@ -293,10 +353,10 @@ export function WorkspaceCommandPalette({
           </div>
         ) : null}
         <ul role="listbox" aria-label="Chat windows" style={listStyle}>
-          {filtered.length === 0 ? (
+          {filtered.length === 0 && messageMatches.length === 0 && filteredWorkspaces.length <= 1 && recentEntries.length === 0 ? (
             <li style={emptyStyle}>No matches.</li>
           ) : (
-            filtered.map((it) => {
+            filtered.filter((it) => !recentEntries.some((r) => r.window.id === it.window.id)).map((it) => {
               const idx = unifiedItems.findIndex((u) => u.kind === 'window' && u.entry.window.id === it.window.id);
               const isHover = idx === Math.min(hover, unifiedItems.length - 1);
               const isActive = it.window.id === activeId;
@@ -591,4 +651,17 @@ function renderHighlighted(content: string, query: string): React.ReactNode {
     cursor = idx + q.length;
   }
   return out;
+}
+
+function readRecents(workspaceId: string): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.sessionStorage.getItem(`wav.workspace.recents.${workspaceId}`);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string').slice(0, 8);
+  } catch {
+    return [];
+  }
 }

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -50,6 +50,7 @@ export function WorkspaceCommandPalette({
   const [recentIds, setRecentIds] = useState<string[]>(() => readRecents(activeWorkspaceId));
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [scopeActiveOnly, setScopeActiveOnly] = useState(false);
   const [hover, setHover] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
@@ -77,7 +78,9 @@ export function WorkspaceCommandPalette({
   const messageMatches = useMemo(() => {
     const q = debouncedQuery.trim().toLowerCase();
     if (!q || q.length < 2 || !getMessages) return [] as Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }>;
-    const allWindows = [...visibleWindows, ...closedWindows];
+    const allWindows = scopeActiveOnly && activeId
+      ? [...visibleWindows, ...closedWindows].filter((w) => w.id === activeId)
+      : [...visibleWindows, ...closedWindows];
     const out: Array<{ windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; createdAt: string }> = [];
     for (const w of allWindows) {
       const list = getMessages(w.id);
@@ -105,7 +108,7 @@ export function WorkspaceCommandPalette({
       if (out.length >= 24) break;
     }
     return out;
-  }, [debouncedQuery, getMessages, visibleWindows, closedWindows]);
+  }, [debouncedQuery, getMessages, visibleWindows, closedWindows, scopeActiveOnly, activeId]);
 
   type UnifiedItem =
     | { kind: 'workspace'; key: string; workspace: Workspace }
@@ -290,6 +293,36 @@ export function WorkspaceCommandPalette({
           aria-label="Filter chat windows or workspaces"
           style={inputStyle}
         />
+        {query.trim().length >= 2 && activeId ? (
+          <div style={{ display: 'flex', gap: 6, padding: '0 0.1rem' }}>
+            <button
+              type="button"
+              onClick={() => setScopeActiveOnly(false)}
+              aria-pressed={!scopeActiveOnly}
+              style={{
+                ...scopeChipStyle,
+                background: !scopeActiveOnly ? '#1c1c28' : 'transparent',
+                color: !scopeActiveOnly ? '#9aa6ff' : '#8a8a95',
+                borderColor: !scopeActiveOnly ? '#3a3f6b' : '#24242c',
+              }}
+            >
+              All windows
+            </button>
+            <button
+              type="button"
+              onClick={() => setScopeActiveOnly(true)}
+              aria-pressed={scopeActiveOnly}
+              style={{
+                ...scopeChipStyle,
+                background: scopeActiveOnly ? '#1c1c28' : 'transparent',
+                color: scopeActiveOnly ? '#9aa6ff' : '#8a8a95',
+                borderColor: scopeActiveOnly ? '#3a3f6b' : '#24242c',
+              }}
+            >
+              Active window only
+            </button>
+          </div>
+        ) : null}
         {recentEntries.length > 0 ? (
           <div>
             <div style={sectionLabelStyle}>Recent</div>
@@ -671,3 +704,14 @@ function readRecents(workspaceId: string): string[] {
     return [];
   }
 }
+
+
+const scopeChipStyle: React.CSSProperties = {
+  fontSize: '0.66rem',
+  padding: '2px 8px',
+  borderRadius: 999,
+  border: '1px solid #24242c',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  letterSpacing: '0.02em',
+};


### PR DESCRIPTION
Three additive features on top of the unified palette nav (#161).

## What
- **Recent windows section** — Workspace records every active-window change in `wav.workspace.recents.<workspaceId>` (sessionStorage, capped at 8) and dispatches `wav:recents-changed`. The palette renders a "Recent" section above Workspaces / Chat windows when the query is empty, showing up to 5 prior windows (excluding the currently active one). De-duped against the main Chat windows list. Integrates with the unified keyboard navigation.
- **Debounced message search (200ms)** — window/workspace name filters still update on every keystroke for snappiness, but the more expensive cross-window message scan now waits 200ms of typing-quiet before re-running. Prevents laggy keystrokes on large workspaces.
- **Scope toggle** — when the query is ≥2 chars and there's an active chat window, two chips appear under the input: "All windows" (default) and "Active window only". The latter limits message search to the active window. `aria-pressed` reflects state.

## Files changed
- `apps/web/src/features/workspace/Workspace.tsx`
- `apps/web/src/features/workspace/WorkspaceCommandPalette.tsx`

## Checks
- pnpm --filter @webapp/web typecheck ✅ (every commit)
- pnpm --filter @webapp/web lint ✅
- pnpm --filter @webapp/web build ✅

## Notes
No backend, no API contract changes, no shared-types changes, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)