### PR TITLE
feat(web): palette UX batch — Esc 2-step, pinned section, clear button, persisted query, a11y

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -18,7 +18,7 @@ const GROUPS: ShortcutGroup[] = [
     items: [
       { keys: ['?'], description: 'Show this help' },
       { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
-      { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft' },
+      { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft  ·  In Cmd-K palette: clear query first, then close' },
       { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, and message contents (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
     ],

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -566,8 +566,33 @@ export function WorkspaceCommandPalette({
             </ul>
           </>
         ) : null}
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          style={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            padding: 0,
+            margin: -1,
+            overflow: 'hidden',
+            clip: 'rect(0,0,0,0)',
+            whiteSpace: 'nowrap',
+            border: 0,
+          }}
+        >
+          {(() => {
+            const total = unifiedItems.length;
+            if (total === 0) return query.trim() ? `No matches for ${query}` : 'No items';
+            return query.trim() ? `${total} result${total === 1 ? '' : 's'} for ${query}` : `${total} item${total === 1 ? '' : 's'}`;
+          })()}
+        </div>
         <div style={footerStyle}>
-          <span>↑↓ navigate · Enter to open · Esc to close · type ≥2 chars to search messages</span>
+          <span>
+            {query.trim().length > 0
+              ? '↑↓ navigate · Enter to open · Esc clears query, again to close'
+              : '↑↓ navigate · Enter to open · Esc to close · type ≥2 chars to search messages'}
+          </span>
         </div>
       </div>
     </div>

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -216,7 +216,12 @@ export function WorkspaceCommandPalette({
         setOpen((v) => {
           const next = !v;
           if (next) {
-            requestAnimationFrame(() => inputRef.current?.focus());
+            const restored = readLastQuery(activeWorkspaceId);
+            if (restored) setQuery(restored);
+            requestAnimationFrame(() => {
+              inputRef.current?.focus();
+              inputRef.current?.select();
+            });
           } else {
             setQuery('');
           }
@@ -235,7 +240,12 @@ export function WorkspaceCommandPalette({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, query]);
+  }, [open, query, activeWorkspaceId]);
+
+  useEffect(() => {
+    if (!open) return;
+    writeLastQuery(activeWorkspaceId, query);
+  }, [open, query, activeWorkspaceId]);
 
   const choose = (it: PaletteWindow) => {
     if (it.open) onFocus(it.window.id);
@@ -759,6 +769,26 @@ function readRecents(workspaceId: string): string[] {
     return parsed.filter((x): x is string => typeof x === 'string').slice(0, 8);
   } catch {
     return [];
+  }
+}
+
+function readLastQuery(workspaceId: string): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    const raw = window.sessionStorage.getItem(`wav.palette.lastQuery.${workspaceId}`);
+    return typeof raw === 'string' ? raw.slice(0, 200) : '';
+  } catch {
+    return '';
+  }
+}
+
+function writeLastQuery(workspaceId: string, q: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (q) window.sessionStorage.setItem(`wav.palette.lastQuery.${workspaceId}`, q.slice(0, 200));
+    else window.sessionStorage.removeItem(`wav.palette.lastQuery.${workspaceId}`);
+  } catch {
+    // ignore
   }
 }
 

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -133,10 +133,26 @@ export function WorkspaceCommandPalette({
     return out;
   }, [query, recentIds, activeId, visibleWindows, closedWindows]);
 
+  const pinnedEntries: PaletteWindow[] = useMemo(() => {
+    if (query.trim()) return [];
+    if (pinnedSet.size === 0) return [];
+    const recentIdSet = new Set(recentEntries.map((r) => r.window.id));
+    const all = [
+      ...visibleWindows.map((w) => ({ window: w, open: true })),
+      ...closedWindows.map((w) => ({ window: w, open: false })),
+    ];
+    return all
+      .filter((it) => pinnedSet.has(it.window.id) && it.window.id !== activeId && !recentIdSet.has(it.window.id))
+      .slice(0, 6);
+  }, [query, pinnedSet, recentEntries, activeId, visibleWindows, closedWindows]);
+
   const unifiedItems: UnifiedItem[] = useMemo(() => {
     const out: UnifiedItem[] = [];
     for (const it of recentEntries) {
       out.push({ kind: 'window', key: `recent-${it.window.id}`, entry: it });
+    }
+    for (const it of pinnedEntries) {
+      out.push({ kind: 'window', key: `pinned-${it.window.id}`, entry: it });
     }
     if (filteredWorkspaces.length > 1) {
       for (const w of filteredWorkspaces) {
@@ -145,6 +161,7 @@ export function WorkspaceCommandPalette({
     }
     for (const it of filtered) {
       if (recentEntries.some((r) => r.window.id === it.window.id)) continue;
+      if (pinnedEntries.some((r) => r.window.id === it.window.id)) continue;
       out.push({ kind: 'window', key: `w-${it.window.id}`, entry: it });
     }
     for (let i = 0; i < messageMatches.length; i += 1) {
@@ -153,7 +170,7 @@ export function WorkspaceCommandPalette({
       out.push({ kind: 'message', key: `m-${m.windowId}-${m.messageId}-${i}`, match: m });
     }
     return out;
-  }, [recentEntries, filteredWorkspaces, filtered, messageMatches]);
+  }, [recentEntries, pinnedEntries, filteredWorkspaces, filtered, messageMatches]);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQuery(query), 200);
@@ -357,6 +374,37 @@ export function WorkspaceCommandPalette({
             </ul>
           </div>
         ) : null}
+        {pinnedEntries.length > 0 ? (
+          <div>
+            <div style={sectionLabelStyle}>Pinned</div>
+            <ul role="list" style={listStyle}>
+              {pinnedEntries.map((it) => {
+                const idx = unifiedItems.findIndex(
+                  (u) => u.kind === 'window' && u.key === `pinned-${it.window.id}`,
+                );
+                const isHover = idx === Math.min(hover, unifiedItems.length - 1);
+                return (
+                  <li key={`pinned-${it.window.id}`} role="option" aria-selected={isHover}
+                    onMouseEnter={() => idx >= 0 && setHover(idx)}
+                    onClick={() => choose(it)}
+                    style={{
+                      ...rowStyle,
+                      background: isHover ? '#1c1c28' : 'transparent',
+                      border: `1px solid ${isHover ? '#3a3f6b' : 'transparent'}`,
+                    }}
+                  >
+                    <span style={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {it.window.title}
+                    </span>
+                    <span style={metaStyle}>{it.window.provider} · {it.window.model}</span>
+                    {!it.open ? <span style={badgeStyle}>closed</span> : null}
+                    <span style={pinnedBadgeStyle}>pinned</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
         {filteredWorkspaces.length > 1 ? (
           <div>
             <div style={sectionLabelStyle}>Workspaces</div>
@@ -395,10 +443,10 @@ export function WorkspaceCommandPalette({
           </div>
         ) : null}
         <ul role="listbox" aria-label="Chat windows" style={listStyle}>
-          {filtered.length === 0 && messageMatches.length === 0 && filteredWorkspaces.length <= 1 && recentEntries.length === 0 ? (
+          {filtered.length === 0 && messageMatches.length === 0 && filteredWorkspaces.length <= 1 && recentEntries.length === 0 && pinnedEntries.length === 0 ? (
             <li style={emptyStyle}>No matches.</li>
           ) : (
-            filtered.filter((it) => !recentEntries.some((r) => r.window.id === it.window.id)).map((it) => {
+            filtered.filter((it) => !recentEntries.some((r) => r.window.id === it.window.id) && !pinnedEntries.some((p) => p.window.id === it.window.id)).map((it) => {
               const idx = unifiedItems.findIndex((u) => u.kind === 'window' && u.entry.window.id === it.window.id);
               const isHover = idx === Math.min(hover, unifiedItems.length - 1);
               const isActive = it.window.id === activeId;

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -209,13 +209,16 @@ export function WorkspaceCommandPalette({
       }
       if (open && e.key === 'Escape') {
         e.preventDefault();
-        setOpen(false);
-        setQuery('');
+        if (query.length > 0) {
+          setQuery('');
+        } else {
+          setOpen(false);
+        }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open]);
+  }, [open, query]);
 
   const choose = (it: PaletteWindow) => {
     if (it.open) onFocus(it.window.id);

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -444,7 +444,13 @@ export function WorkspaceCommandPalette({
         ) : null}
         <ul role="listbox" aria-label="Chat windows" style={listStyle}>
           {filtered.length === 0 && messageMatches.length === 0 && filteredWorkspaces.length <= 1 && recentEntries.length === 0 && pinnedEntries.length === 0 ? (
-            <li style={emptyStyle}>No matches.</li>
+            <li style={emptyStyle}>
+              {query.trim().length === 0
+                ? 'No chat windows yet.'
+                : query.trim().length < 2
+                  ? `No window titled “${query}”. Type 2+ chars to also search messages.`
+                  : `No matches for “${query}” in titles or messages.`}
+            </li>
           ) : (
             filtered.filter((it) => !recentEntries.some((r) => r.window.id === it.window.id) && !pinnedEntries.some((p) => p.window.id === it.window.id)).map((it) => {
               const idx = unifiedItems.findIndex((u) => u.kind === 'window' && u.entry.window.id === it.window.id);

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -314,15 +314,45 @@ export function WorkspaceCommandPalette({
         <h2 id="cmdk-title" style={titleStyle}>
           Switch chat window
         </h2>
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={onInputKeyDown}
-          placeholder="Search windows, workspaces, or messages…"
-          aria-label="Filter chat windows or workspaces"
-          style={inputStyle}
-        />
+        <div style={{ position: 'relative' }}>
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onInputKeyDown}
+            placeholder="Search windows, workspaces, or messages…"
+            aria-label="Filter chat windows or workspaces"
+            style={{ ...inputStyle, paddingRight: query.length > 0 ? 28 : undefined }}
+          />
+          {query.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => {
+                setQuery('');
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear search"
+              title="Clear search"
+              style={{
+                position: 'absolute',
+                right: 6,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                background: 'transparent',
+                border: 'none',
+                color: '#8a8a95',
+                cursor: 'pointer',
+                fontSize: '0.95rem',
+                lineHeight: 1,
+                padding: '2px 6px',
+                borderRadius: 4,
+                fontFamily: 'inherit',
+              }}
+            >
+              ×
+            </button>
+          ) : null}
+        </div>
         {query.trim().length >= 2 && activeId ? (
           <div style={{ display: 'flex', gap: 6, padding: '0 0.1rem' }}>
             <button


### PR DESCRIPTION
## Summary
Frontend-only batch focused on the Cmd-K palette and shortcuts overlay. No backend, no types changes.

- **T1** Esc inside palette now clears the query first, then closes on a second press.
- **T2** New **Pinned** section above the chat-windows list when query is empty (uses existing `pinnedSet`, deduped against Recent + main list, threaded into unified keyboard navigation).
- **T3** Empty-state message differentiates: empty query, short query (<2 chars), and full no-match for >=2 chars.
- **T4** Palette persists last query per workspace in `sessionStorage` (`wav.palette.lastQuery.<workspaceId>`); reopening restores and selects the text.
- **T5** Hidden aria-live region announces total result count or no-match state when palette is open.
- **T6** Inline clear (×) button inside the search input when query is non-empty; focuses input after clearing.
- **T7** Footer hint adapts to query state ("Esc clears query, again to close" while typing).
- **T8** KeyboardShortcutsOverlay updated to document the Esc 2-step palette behavior.

## Test plan
- [ ] Open palette (Cmd-K), type "test", press Esc → query clears; press Esc again → palette closes.
- [ ] Pin a window via the sidebar; open palette → "Pinned" section appears above the main list with that window. Pinning the active window does not show it (active filtered out).
- [ ] Type 1 char (e.g. "x") → empty-state hint says "type 2+ chars to also search messages".
- [ ] Type 2+ chars unmatched → "No matches for ..." text shown.
- [ ] Open palette, type, close (Cmd-K). Reopen → query restored, text selected.
- [ ] Switch workspaces → each remembers its own last query independently.
- [ ] Click × inside the search input → query clears, input remains focused.
- [ ] Screen reader announces result count when palette opens or query changes.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, and `build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)