### PR TITLE
feat(web): palette message grouping + sidebar/composer productivity polish

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -399,18 +399,23 @@ export function ChatWindow({
     .map((m) => m.content)
     .reverse();
   const historyIdxRef = useRef<number>(-1);
+  const [historyIdx, setHistoryIdx] = useState<number>(-1);
+  const setHistoryIdxBoth = (n: number) => {
+    historyIdxRef.current = n;
+    setHistoryIdx(n);
+  };
 
   const onComposerKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       submit();
-      historyIdxRef.current = -1;
+      setHistoryIdxBoth(-1);
       return;
     }
     if (e.key === 'Escape' && draft.length > 0) {
       e.preventDefault();
       setDraft('');
-      historyIdxRef.current = -1;
+      setHistoryIdxBoth(-1);
       return;
     }
     if (e.key === 'ArrowUp' && userPromptHistory.length > 0) {
@@ -428,7 +433,7 @@ export function ChatWindow({
       if ((draft.length === 0 || cyclingActive) && (isAtStart || onFirstLine)) {
         e.preventDefault();
         const nextIdx = Math.min(historyIdxRef.current + 1, userPromptHistory.length - 1);
-        historyIdxRef.current = nextIdx;
+        setHistoryIdxBoth(nextIdx);
         setDraft(userPromptHistory[nextIdx] ?? '');
       }
       return;
@@ -436,7 +441,7 @@ export function ChatWindow({
     if (e.key === 'ArrowDown' && historyIdxRef.current >= 0) {
       e.preventDefault();
       const nextIdx = historyIdxRef.current - 1;
-      historyIdxRef.current = nextIdx;
+      setHistoryIdxBoth(nextIdx);
       setDraft(nextIdx < 0 ? '' : userPromptHistory[nextIdx] ?? '');
       return;
     }
@@ -1021,6 +1026,26 @@ export function ChatWindow({
         </div>
       ) : null}
 
+      {historyIdx >= 0 && userPromptHistory.length > 0 ? (
+        <div
+          aria-live="polite"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            padding: '4px 0.85rem',
+            background: '#15203b',
+            borderTop: '1px solid #2a2a30',
+            color: '#9aa6ff',
+            fontSize: '0.7rem',
+          }}
+        >
+          <span aria-hidden>↑</span>
+          <span>
+            Recalling prompt {Math.min(historyIdx + 1, userPromptHistory.length)} of {userPromptHistory.length} · ↓ to step back · Esc to clear
+          </span>
+        </div>
+      ) : null}
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -1039,7 +1064,10 @@ export function ChatWindow({
           ref={textareaRef}
           value={draft}
           rows={1}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (historyIdxRef.current >= 0) setHistoryIdxBoth(-1);
+          }}
           onKeyDown={onComposerKeyDown}
           onFocus={() => onFocus?.(id)}
           placeholder={

--- a/apps/web/src/features/workspace/Workspace.tsx
+++ b/apps/web/src/features/workspace/Workspace.tsx
@@ -197,6 +197,10 @@ export function Workspace({
     }
     forceTick((n: number) => n + 1);
   };
+  const markAsRead = useCallback((id: string) => {
+    lastSeenRef.current[id] = Date.now();
+    forceTick((n: number) => n + 1);
+  }, []);
 
   const previousTitleRef = useRef<string | null>(null);
   useEffect(() => {
@@ -240,6 +244,7 @@ export function Workspace({
         unreadByWindow={unreadByWindow}
         unreadCountByWindow={unreadCountByWindow}
         onMarkAllAsRead={totalUnread > 0 ? markAllAsRead : undefined}
+        onMarkAsRead={markAsRead}
         onFocus={state.focus}
         onClose={state.close}
         onReopen={state.reopen}

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -146,6 +146,33 @@ export function WorkspaceCommandPalette({
       .slice(0, 6);
   }, [query, pinnedSet, recentEntries, activeId, visibleWindows, closedWindows]);
 
+  type MessageMatch = typeof messageMatches[number];
+  const PER_WINDOW_LIMIT = 3;
+  const messageGroups = useMemo(() => {
+    const order: string[] = [];
+    const map = new Map<string, { windowId: string; window: ChatWindow; items: MessageMatch[] }>();
+    for (const m of messageMatches) {
+      const existing = map.get(m.windowId);
+      if (existing) {
+        existing.items.push(m);
+      } else {
+        order.push(m.windowId);
+        map.set(m.windowId, { windowId: m.windowId, window: m.window, items: [m] });
+      }
+    }
+    return order.map((id) => {
+      const g = map.get(id)!;
+      const visible = g.items.slice(0, PER_WINDOW_LIMIT);
+      const hidden = Math.max(0, g.items.length - visible.length);
+      return { windowId: g.windowId, window: g.window, items: visible, total: g.items.length, hiddenCount: hidden };
+    });
+  }, [messageMatches]);
+  const visibleMessageItems: MessageMatch[] = useMemo(() => {
+    const out: MessageMatch[] = [];
+    for (const g of messageGroups) for (const m of g.items) out.push(m);
+    return out;
+  }, [messageGroups]);
+
   const unifiedItems: UnifiedItem[] = useMemo(() => {
     const out: UnifiedItem[] = [];
     for (const it of recentEntries) {
@@ -164,13 +191,13 @@ export function WorkspaceCommandPalette({
       if (pinnedEntries.some((r) => r.window.id === it.window.id)) continue;
       out.push({ kind: 'window', key: `w-${it.window.id}`, entry: it });
     }
-    for (let i = 0; i < messageMatches.length; i += 1) {
-      const m = messageMatches[i];
+    for (let i = 0; i < visibleMessageItems.length; i += 1) {
+      const m = visibleMessageItems[i];
       if (!m) continue;
       out.push({ kind: 'message', key: `m-${m.windowId}-${m.messageId}-${i}`, match: m });
     }
     return out;
-  }, [recentEntries, pinnedEntries, filteredWorkspaces, filtered, messageMatches]);
+  }, [recentEntries, pinnedEntries, filteredWorkspaces, filtered, visibleMessageItems]);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQuery(query), 200);
@@ -532,67 +559,100 @@ export function WorkspaceCommandPalette({
             })
           )}
         </ul>
-        {messageMatches.length > 0 ? (
+        {messageGroups.length > 0 ? (
           <>
-            <div style={sectionLabelStyle}>Messages · {messageMatches.length}</div>
-            <ul role="list" style={{ ...listStyle, maxHeight: 240 }}>
-              {messageMatches.map((m, i) => {
-                const idx = unifiedItems.findIndex(
-                  (u) => u.kind === 'message' && u.match === m,
-                );
-                const isHover = idx === Math.min(hover, unifiedItems.length - 1);
-                return (
-                  <li key={`${m.windowId}-${m.messageId}-${i}`} style={{ listStyle: 'none' }}>
+            <div style={sectionLabelStyle}>
+              Messages · {messageMatches.length} match{messageMatches.length === 1 ? '' : 'es'} in {messageGroups.length} window{messageGroups.length === 1 ? '' : 's'}
+            </div>
+            <ul role="list" style={{ ...listStyle, maxHeight: 280 }}>
+              {messageGroups.map((g) => (
+                <li key={`grp-${g.windowId}`} style={{ listStyle: 'none', marginBottom: 4 }}>
+                  <div style={{ fontSize: '0.62rem', color: '#6a6a75', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '4px 6px 2px' }}>
+                    {g.window.title} · {g.total} match{g.total === 1 ? '' : 'es'}
+                  </div>
+                  {g.items.map((m, i) => {
+                    const idx = unifiedItems.findIndex(
+                      (u) => u.kind === 'message' && u.match === m,
+                    );
+                    const isHover = idx === Math.min(hover, unifiedItems.length - 1);
+                    return (
+                      <button
+                        key={`${m.windowId}-${m.messageId}-${i}`}
+                        type="button"
+                        role="option"
+                        aria-selected={isHover}
+                        onMouseEnter={() => idx >= 0 && setHover(idx)}
+                        onClick={() => {
+                          const visible = visibleWindows.some((w) => w.id === m.windowId);
+                          if (!visible) onReopen(m.windowId);
+                          else onFocus(m.windowId);
+                          setOpen(false);
+                          setQuery('');
+                          if (typeof window !== 'undefined') {
+                            const url = new URL(window.location.href);
+                            url.hash = `msg-${m.messageId}`;
+                            window.history.replaceState(null, '', url.toString());
+                            window.dispatchEvent(new HashChangeEvent('hashchange'));
+                          }
+                        }}
+                        style={{
+                          ...rowStyle,
+                          width: '100%',
+                          background: isHover ? '#1c1c28' : 'transparent',
+                          border: `1px solid ${isHover ? '#3a3f6b' : 'transparent'}`,
+                          textAlign: 'left',
+                          cursor: 'pointer',
+                          fontFamily: 'inherit',
+                          color: '#cfcfd6',
+                        }}
+                      >
+                        <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                          <div
+                            style={{
+                              fontSize: '0.78rem',
+                              color: '#e8e8ef',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {renderHighlighted(m.snippet, query)}
+                          </div>
+                          <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
+                            {m.role}
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })}
+                  {g.hiddenCount > 0 ? (
                     <button
                       type="button"
-                      role="option"
-                      aria-selected={isHover}
-                      onMouseEnter={() => idx >= 0 && setHover(idx)}
                       onClick={() => {
-                        const visible = visibleWindows.some((w) => w.id === m.windowId);
-                        if (!visible) onReopen(m.windowId);
-                        else onFocus(m.windowId);
+                        const visible = visibleWindows.some((w) => w.id === g.windowId);
+                        if (!visible) onReopen(g.windowId);
+                        else onFocus(g.windowId);
                         setOpen(false);
                         setQuery('');
-                        if (typeof window !== 'undefined') {
-                          // Use hash to trigger ChatWindow's existing #msg-<id> scroll/flash effect
-                          const url = new URL(window.location.href);
-                          url.hash = `msg-${m.messageId}`;
-                          window.history.replaceState(null, '', url.toString());
-                          window.dispatchEvent(new HashChangeEvent('hashchange'));
-                        }
                       }}
+                      aria-label={`Open ${g.window.title} to see ${g.hiddenCount} more matches`}
                       style={{
                         ...rowStyle,
                         width: '100%',
-                        background: isHover ? '#1c1c28' : 'transparent',
-                        border: `1px solid ${isHover ? '#3a3f6b' : 'transparent'}`,
+                        background: 'transparent',
+                        border: '1px dashed #2a2a30',
                         textAlign: 'left',
                         cursor: 'pointer',
                         fontFamily: 'inherit',
-                        color: '#cfcfd6',
+                        color: '#9aa6ff',
+                        fontSize: '0.72rem',
                       }}
                     >
-                      <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-                        <div
-                          style={{
-                            fontSize: '0.78rem',
-                            color: '#e8e8ef',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                          }}
-                        >
-                          {renderHighlighted(m.snippet, query)}
-                        </div>
-                        <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
-                          {m.role} · {m.window.title}
-                        </div>
-                      </div>
+                      + {g.hiddenCount} more match{g.hiddenCount === 1 ? '' : 'es'} in this window — open
                     </button>
-                  </li>
-                );
-              })}
+                  ) : null}
+                </li>
+              ))}
             </ul>
           </>
         ) : null}

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -25,6 +25,7 @@ interface WorkspaceSidebarProps {
   unreadByWindow?: Record<string, boolean>;
   unreadCountByWindow?: Record<string, number>;
   onMarkAllAsRead?: () => void;
+  onMarkAsRead?: (id: string) => void;
   onFocus: (id: string) => void;
   onClose: (id: string) => void;
   onReopen: (id: string) => void;
@@ -51,6 +52,7 @@ export function WorkspaceSidebar({
   unreadByWindow,
   unreadCountByWindow,
   onMarkAllAsRead,
+  onMarkAsRead,
   onFocus,
   onClose,
   onReopen,
@@ -207,6 +209,7 @@ export function WorkspaceSidebar({
               pending={pendingByWindow?.[w.id]}
               unread={unreadByWindow?.[w.id]}
               unreadCount={unreadCountByWindow?.[w.id]}
+              onMarkAsRead={onMarkAsRead}
               onClick={() => onFocus(w.id)}
               onAction={() => onClose(w.id)}
               actionLabel="×"
@@ -229,6 +232,7 @@ export function WorkspaceSidebar({
                 lastActivity={lastActivityByWindow?.[w.id]}
                 unread={unreadByWindow?.[w.id]}
                 unreadCount={unreadCountByWindow?.[w.id]}
+                onMarkAsRead={onMarkAsRead}
                 onClick={() => onReopen(w.id)}
                 onAction={() => onReopen(w.id)}
                 actionLabel="↺"
@@ -695,13 +699,14 @@ interface WindowRowProps {
   pending?: boolean;
   unread?: boolean;
   unreadCount?: number;
+  onMarkAsRead?: (id: string) => void;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onMarkAsRead, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -902,6 +907,28 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, unrea
           ) : null}
         </div>
       </div>
+      {unread && onMarkAsRead ? (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onMarkAsRead(window.id);
+          }}
+          aria-label={`Mark ${window.title} as read`}
+          title="Mark as read"
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#9aa6ff',
+            cursor: 'pointer',
+            fontSize: '0.85rem',
+            padding: '2px 5px',
+            borderRadius: 4,
+            lineHeight: 1,
+          }}
+        >
+          ✓
+        </button>
+      ) : null}
       <button
         onClick={(e) => {
           e.stopPropagation();

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -60,6 +60,9 @@ export function WorkspaceSidebar({
   onReset,
 }: WorkspaceSidebarProps) {
   const total = visibleWindows.length + closedWindows.length;
+  const totalUnreadVisible = unreadByWindow
+    ? visibleWindows.reduce((acc, w) => acc + (unreadByWindow[w.id] ? 1 : 0), 0)
+    : 0;
   const [windowFilter, setWindowFilter] = useState('');
   const filterEnabled = total >= 5;
   const lowerFilter = windowFilter.trim().toLowerCase();
@@ -173,6 +176,27 @@ export function WorkspaceSidebar({
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <SectionLabel>
             Open · {filterEnabled && lowerFilter ? `${filteredVisible.length}/${visibleWindows.length}` : visibleWindows.length}
+            {totalUnreadVisible > 0 ? (
+              <span
+                aria-label={`${totalUnreadVisible} window${totalUnreadVisible === 1 ? '' : 's'} with unread replies`}
+                title={`${totalUnreadVisible} unread`}
+                style={{
+                  marginLeft: 6,
+                  fontSize: '0.6rem',
+                  padding: '0 5px',
+                  height: 14,
+                  lineHeight: '14px',
+                  borderRadius: 7,
+                  background: '#15203b',
+                  border: '1px solid #3a3f6b',
+                  color: '#9aa6ff',
+                  display: 'inline-block',
+                  verticalAlign: 'middle',
+                }}
+              >
+                {totalUnreadVisible} new
+              </span>
+            ) : null}
           </SectionLabel>
           {onMarkAllAsRead ? (
             <button


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** Palette message results are now **grouped by chat window** with up to 3 visible matches per group; if more exist, a "+ N more matches in this window — open" affordance opens the window directly. Section header shows total matches across N windows.
- **T2** Per-window **mark-as-read** affordance (✓) in the sidebar window row, threaded from `Workspace.markAsRead(id)` → `WorkspaceSidebar` → `WindowRow`. Hidden when row is not unread.
- **T3** Composer **recall position chip** ("Recalling prompt 2 of 7 · ↓ to step back · Esc to clear") shown while cycling user-prompt history with ↑/↓. Mirror the existing ref into a state variable so the UI updates without breaking sync access.
- **T4** Sidebar **Open · N** header gains a small "X new" chip when one or more visible windows have unread replies (complements the per-row badges).

## Test plan
- [ ] Search messages in palette across 2+ windows that match → results grouped by window with sub-headers; only first 3 per window visible.
- [ ] Trigger a window with >3 matches → click the "+ N more — open" link → palette closes and window opens (no hash flash since it's a generic open).
- [ ] In sidebar, an unread window shows a ✓ next to the close (×) button → click ✓ → row's unread state clears immediately, total chip updates.
- [ ] Open a chat window, type something, then ↑ from empty → chip appears at composer top with position; ↓ steps back; Esc clears draft and chip hides.
- [ ] Type while chip is visible → chip clears immediately.
- [ ] Sidebar header shows "X new" chip iff `unreadByWindow` has any visible-window entry.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)