### PR TITLE
feat(web): in-chat n/N jump-to-unread + palette grouping/footer polish

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -35,6 +35,8 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', '.'], description: 'Stop the in-flight reply in the active chat window (Ctrl+. on Linux/Win)' },
       { keys: ['G'], description: 'Jump to the latest message (when not typing)' },
       { keys: ['g', 'g'], description: 'Jump to the top of the active chat (when not typing)' },
+      { keys: ['n'], description: 'Jump to the next unread assistant reply in the active chat (when not typing)' },
+      { keys: ['Shift', 'n'], description: 'Jump to the previous unread assistant reply (when not typing)' },
     ],
   },
   {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -262,20 +262,25 @@ export function ChatWindow({
   // assistant message strictly newer than the previous lastSeen and flash it.
   const lastSeenAtRef = useRef<number>(typeof Date !== 'undefined' ? Date.now() : 0);
   const wasActiveRef = useRef<boolean>(active);
+  const unreadIdsRef = useRef<string[]>([]);
+  const unreadCursorRef = useRef<number>(-1);
   useEffect(() => {
     if (active && !wasActiveRef.current) {
       const seenAt = lastSeenAtRef.current;
       let firstUnread: { id: string; createdAt: string } | null = null;
+      const collected: string[] = [];
       for (const m of messages) {
         if (m.role !== 'assistant') continue;
         if ((m.status ?? 'ok') !== 'ok') continue;
         const t = Date.parse(m.createdAt);
         if (Number.isNaN(t)) continue;
         if (t > seenAt) {
-          firstUnread = { id: m.id, createdAt: m.createdAt };
-          break;
+          if (!firstUnread) firstUnread = { id: m.id, createdAt: m.createdAt };
+          collected.push(m.id);
         }
       }
+      unreadIdsRef.current = collected;
+      unreadCursorRef.current = collected.length > 0 ? 0 : -1;
       if (firstUnread) {
         const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(firstUnread.id)}`);
         if (el && 'scrollIntoView' in el) {
@@ -334,12 +339,31 @@ export function ChatWindow({
         requestAnimationFrame(() => textareaRef.current?.focus());
         return;
       }
-      // Vim-style: G jumps to bottom; g g jumps to top. Only when not typing.
+      // Vim-style: G jumps to bottom; g g jumps to top. n/N jumps unread.
       if (!e.metaKey && !e.ctrlKey && !e.altKey) {
         const target = e.target;
         const typing = target instanceof HTMLElement
           && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
         if (typing) return;
+        if (e.key === 'n' || e.key === 'N') {
+          const ids = unreadIdsRef.current;
+          if (ids.length === 0) return;
+          e.preventDefault();
+          const dir = e.key === 'N' ? -1 : 1;
+          const cur = unreadCursorRef.current;
+          const next = cur < 0 ? 0 : (cur + dir + ids.length) % ids.length;
+          unreadCursorRef.current = next;
+          const targetId = ids[next];
+          if (!targetId) return;
+          const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(targetId)}`);
+          if (el && 'scrollIntoView' in el) {
+            (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'smooth' });
+          }
+          stickyRef.current = false;
+          setFlashedMsgId(targetId);
+          setTimeout(() => setFlashedMsgId((prev) => (prev === targetId ? null : prev)), 1500);
+          return;
+        }
         if (e.key === 'G' && e.shiftKey) {
           e.preventDefault();
           scrollToBottom();

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -684,9 +684,17 @@ export function WorkspaceCommandPalette({
         </div>
         <div style={footerStyle}>
           <span>
-            {query.trim().length > 0
-              ? '↑↓ navigate · Enter to open · Esc clears query, again to close'
-              : '↑↓ navigate · Enter to open · Esc to close · type ≥2 chars to search messages'}
+            {(() => {
+              const sel = unifiedItems[Math.min(hover, unifiedItems.length - 1)];
+              const enterAction =
+                sel?.kind === 'workspace'
+                  ? 'Enter to switch workspace'
+                  : sel?.kind === 'message'
+                    ? 'Enter to jump to message'
+                    : 'Enter to open';
+              if (query.trim().length > 0) return `↑↓ navigate · ${enterAction} · Esc clears query, again to close`;
+              return `↑↓ navigate · ${enterAction} · Esc to close · type ≥2 chars to search messages`;
+            })()}
           </span>
         </div>
       </div>

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -567,8 +567,13 @@ export function WorkspaceCommandPalette({
             <ul role="list" style={{ ...listStyle, maxHeight: 280 }}>
               {messageGroups.map((g) => (
                 <li key={`grp-${g.windowId}`} style={{ listStyle: 'none', marginBottom: 4 }}>
-                  <div style={{ fontSize: '0.62rem', color: '#6a6a75', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '4px 6px 2px' }}>
-                    {g.window.title} · {g.total} match{g.total === 1 ? '' : 'es'}
+                  <div style={{ fontSize: '0.62rem', color: '#6a6a75', textTransform: 'uppercase', letterSpacing: '0.06em', padding: '4px 6px 2px', display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span>{g.window.title} · {g.total} match{g.total === 1 ? '' : 'es'}</span>
+                    {g.windowId === activeId ? (
+                      <span style={{ color: '#9aa6ff', textTransform: 'none', letterSpacing: 0, fontSize: '0.6rem' }}>
+                        (active)
+                      </span>
+                    ) : null}
                   </div>
                   {g.items.map((m, i) => {
                     const idx = unifiedItems.findIndex(


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** ChatWindow: when a window becomes active, capture all unread assistant message ids; pressing **n** scrolls/flashes the next, **Shift+n** the previous (cycles, only when not typing).
- **T2** KeyboardShortcutsOverlay documents the new `n` and `Shift+n` keys.
- **T3** Palette message-group header now marks `(active)` when the group is the currently active window — clarifies "the matches I'm scrolling through are right here".
- **T4** Palette footer hint adapts to the selected row kind: "Enter to open / switch workspace / jump to message".

## Test plan
- [ ] Open a chat, switch to another, wait for replies; switch back. Press `n` → scrolls and flashes next unread; pressing again rotates through them; `Shift+n` goes backwards.
- [ ] Type into composer → `n` does nothing (typing-target guard).
- [ ] No unread → `n` does nothing.
- [ ] Press `?` → see "n" and "Shift+n" entries listed under Active chat window.
- [ ] In palette, search a term that matches messages in the active window → group header shows "(active)".
- [ ] Arrow into a workspace row → footer says "Enter to switch workspace". Arrow into a message → footer says "Enter to jump to message".
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)