### PR TITLE
feat(web): live unread cursor in active chat + palette polish

### DIFF
--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -652,7 +652,7 @@ export function ChatWindow({
                 setUnreadCount(0);
               }}
               aria-label={`Jump to ${unreadCount} new repl${unreadCount === 1 ? 'y' : 'ies'} and clear`}
-              title={`${unreadCount} new repl${unreadCount === 1 ? 'y' : 'ies'} arrived while you were scrolled away — click to jump and clear`}
+              title={`${unreadCount} new repl${unreadCount === 1 ? 'y' : 'ies'} arrived while you were scrolled away — click to jump, or press n / Shift+n to step through`}
               style={{
                 marginTop: 4,
                 alignSelf: 'flex-start',

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -114,8 +114,14 @@ export function ChatWindow({
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.clientHeight - el.scrollTop;
     const sticky = distanceFromBottom < 64;
+    const wasSticky = stickyRef.current;
     stickyRef.current = sticky;
     setScrolledAway(!sticky);
+    if (sticky && !wasSticky && unreadIdsRef.current.length > 0) {
+      unreadIdsRef.current = [];
+      unreadCursorRef.current = -1;
+      setUnreadCount(0);
+    }
     if (restoredScrollRef.current) {
       if (scrollSaveTimerRef.current != null) {
         window.clearTimeout(scrollSaveTimerRef.current);

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -264,6 +264,8 @@ export function ChatWindow({
   const wasActiveRef = useRef<boolean>(active);
   const unreadIdsRef = useRef<string[]>([]);
   const unreadCursorRef = useRef<number>(-1);
+  const knownAssistantIdsRef = useRef<Set<string>>(new Set());
+  const [unreadCount, setUnreadCount] = useState(0);
   useEffect(() => {
     if (active && !wasActiveRef.current) {
       const seenAt = lastSeenAtRef.current;
@@ -281,6 +283,10 @@ export function ChatWindow({
       }
       unreadIdsRef.current = collected;
       unreadCursorRef.current = collected.length > 0 ? 0 : -1;
+      setUnreadCount(collected.length);
+      const known = new Set<string>();
+      for (const m of messages) if (m.role === 'assistant') known.add(m.id);
+      knownAssistantIdsRef.current = known;
       if (firstUnread) {
         const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(firstUnread.id)}`);
         if (el && 'scrollIntoView' in el) {
@@ -299,6 +305,23 @@ export function ChatWindow({
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, messagesSignature]);
+
+  useEffect(() => {
+    if (!active) return;
+    const known = knownAssistantIdsRef.current;
+    let appended = false;
+    for (const m of messages) {
+      if (m.role !== 'assistant') continue;
+      if ((m.status ?? 'ok') !== 'ok') continue;
+      if (known.has(m.id)) continue;
+      known.add(m.id);
+      if (stickyRef.current) continue;
+      unreadIdsRef.current.push(m.id);
+      appended = true;
+    }
+    if (appended) setUnreadCount(unreadIdsRef.current.length);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [messagesSignature, active]);
 
   useEffect(() => {
     if (!active) return;
@@ -602,6 +625,46 @@ export function ChatWindow({
             </span>
           )}
           <ProviderBadge provider={provider} model={model} />
+          {active && unreadCount > 0 ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                const ids = unreadIdsRef.current;
+                if (ids.length === 0) return;
+                const targetId = ids[ids.length - 1];
+                if (!targetId) return;
+                const el = scrollRef.current?.querySelector(`#msg-${cssEscapeId(targetId)}`);
+                if (el && 'scrollIntoView' in el) {
+                  (el as HTMLElement).scrollIntoView({ block: 'start', behavior: 'smooth' });
+                }
+                stickyRef.current = false;
+                setFlashedMsgId(targetId);
+                setTimeout(() => setFlashedMsgId((prev) => (prev === targetId ? null : prev)), 1500);
+                unreadIdsRef.current = [];
+                unreadCursorRef.current = -1;
+                setUnreadCount(0);
+              }}
+              aria-label={`Jump to ${unreadCount} new repl${unreadCount === 1 ? 'y' : 'ies'} and clear`}
+              title={`${unreadCount} new repl${unreadCount === 1 ? 'y' : 'ies'} arrived while you were scrolled away — click to jump and clear`}
+              style={{
+                marginTop: 4,
+                alignSelf: 'flex-start',
+                fontSize: '0.62rem',
+                color: '#9aa6ff',
+                background: '#15203b',
+                border: '1px solid #3a3f6b',
+                borderRadius: 999,
+                padding: '1px 8px',
+                cursor: 'pointer',
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                fontFamily: 'inherit',
+              }}
+            >
+              {unreadCount} new ↓
+            </button>
+          ) : null}
           {pending ? (
             <span
               role="status"

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -147,7 +147,6 @@ export function WorkspaceCommandPalette({
   }, [query, pinnedSet, recentEntries, activeId, visibleWindows, closedWindows]);
 
   type MessageMatch = typeof messageMatches[number];
-  const PER_WINDOW_LIMIT = 3;
   const messageGroups = useMemo(() => {
     const order: string[] = [];
     const map = new Map<string, { windowId: string; window: ChatWindow; items: MessageMatch[] }>();
@@ -160,9 +159,10 @@ export function WorkspaceCommandPalette({
         map.set(m.windowId, { windowId: m.windowId, window: m.window, items: [m] });
       }
     }
+    const perWindowLimit = order.length === 1 ? 6 : 3;
     return order.map((id) => {
       const g = map.get(id)!;
-      const visible = g.items.slice(0, PER_WINDOW_LIMIT);
+      const visible = g.items.slice(0, perWindowLimit);
       const hidden = Math.max(0, g.items.length - visible.length);
       return { windowId: g.windowId, window: g.window, items: visible, total: g.items.length, hiddenCount: hidden };
     });


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** ChatWindow: while a window stays active, new assistant replies arriving while the user is scrolled away (sticky=false) are appended to the live unread cursor. New header pill **"N new ↓"** appears in this case — click to jump to the latest and clear the cursor; `n` / `Shift+n` continue to step through.
- **T2** Scrolling back to the bottom (sticky transition) auto-clears the live unread cursor and pill.
- **T3** Palette: when only one window matches a message search, expand the per-window match limit from 3 to 6 so users see more matches before needing the "more — open" affordance.
- **T4** Unread pill `title` mentions the keyboard shortcut.

## Test plan
- [ ] Active a chat, scroll to top, send a message in another chat → wait for streaming reply in the inactive (it would be filtered by lastSeen anyway, this concerns the active path). Then in the active chat: while scrolled away, simulate a new assistant reply (e.g. send a message) → "N new ↓" pill appears in the header.
- [ ] Click the pill → scrolls to the latest unread, flashes it, pill disappears.
- [ ] After pill is visible, scroll to bottom → pill clears automatically.
- [ ] Press `n` while pill is visible → cycles through unread; pill remains until cleared by scroll-to-bottom or click.
- [ ] In palette, search a term that matches messages in only one window → up to 6 matches shown; if more, overflow link appears.
- [ ] If matches span 2+ windows → still 3 per window.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)