### PR TITLE
feat(api): SSE keepalive comment ping on /v1/messages/stream (proxy-idle survival)

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -318,6 +318,26 @@ export async function streamMessageDbController(
   // sniff content-type can decide to buffer the whole response.
   res.flushHeaders();
 
+  // Keepalive comment ping: the SSE spec ignores any line starting with ":"
+  // — every conformant client lib treats it as a no-op. Many reverse proxies
+  // and load balancers drop "idle" connections after 30-60s of zero bytes,
+  // which kills legitimate slow upstream responses. Sending a comment line
+  // every 25s keeps the socket warm without surfacing anything in the
+  // application-level event stream.
+  const KEEPALIVE_MS = 25_000;
+  const keepaliveTimer = setInterval(() => {
+    // writableEnded guards against a race where the timer fires after we've
+    // already res.end()'d in a terminal branch. write() on an ended response
+    // would throw ERR_STREAM_WRITE_AFTER_END.
+    if (res.writableEnded) return;
+    try { res.write(':keepalive\n\n'); } catch { /* socket gone — close listener will clear */ }
+  }, KEEPALIVE_MS);
+  // unref so a leaked timer can never block process shutdown if a terminal
+  // branch ever forgets to clear (defence in depth — every branch below
+  // also calls clearKeepalive explicitly).
+  keepaliveTimer.unref?.();
+  const clearKeepalive = (): void => { clearInterval(keepaliveTimer); };
+
   const startedAt = Date.now();
   let assistantContent = '';
   let model = cw.model;
@@ -332,6 +352,7 @@ export async function streamMessageDbController(
   // mid-response socket teardown — only the ServerResponse 'close' does.
   const upstreamAbort = new AbortController();
   res.on('close', () => {
+    clearKeepalive();
     if (!res.writableEnded) {
       aborted = true;
       upstreamAbort.abort();
@@ -343,6 +364,7 @@ export async function streamMessageDbController(
   // mark aborted, and swallow — the catch block downstream will see the
   // for-await throw and exit cleanly.
   res.on('error', () => {
+    clearKeepalive();
     aborted = true;
     upstreamAbort.abort();
   });
@@ -363,6 +385,7 @@ export async function streamMessageDbController(
     // throw happens because we asked the upstream to stop. Don't ship an
     // 'error' SSE event (the client is gone anyway) and don't capture it.
     if (aborted) {
+      clearKeepalive();
       logger.info('stream cancelled by client disconnect', {
         requestId: ctx.requestId,
         provider: cw.provider,
@@ -373,6 +396,7 @@ export async function streamMessageDbController(
       try { res.end(); } catch { /* socket already closed */ }
       return respondStreamed(499);
     }
+    clearKeepalive();
     captureException(err, { provider: cw.provider, model: cw.model, route: '/v1/messages/stream' });
     const detail = err instanceof Error ? err.message : 'Unknown provider error';
     sseWrite(res, { error: detail });
@@ -382,6 +406,7 @@ export async function streamMessageDbController(
   }
 
   if (aborted || assistantContent.length === 0) {
+    clearKeepalive();
     // Client gave up or provider produced nothing — do NOT persist a half-baked pair.
     if (!aborted) sseWrite(res, { error: 'empty_response' });
     res.write('data: [DONE]\n\n');
@@ -400,12 +425,14 @@ export async function streamMessageDbController(
 
   const pair = await deps.persistMessagePair(chatWindowId, user.id, content, assistantContent, assistantMetadata);
   if (pair === null) {
+    clearKeepalive();
     sseWrite(res, { error: 'chat_window_not_found' });
     res.write('data: [DONE]\n\n');
     res.end();
     return respondStreamed(404);
   }
 
+  clearKeepalive();
   sseWrite(res, {
     done: true,
     userMessage:      toMessage(pair.userRow),

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -1,6 +1,6 @@
 import type { AddressInfo } from 'node:net';
 import type { Server } from 'node:http';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { AIProvider, ApiResponse, GeneratedMessagePair, Message, MessageRole } from '@webapp/types';
 import { Router } from '../lib/router.js';
 import { createApiServer } from '../lib/server.js';
@@ -806,6 +806,84 @@ describe('POST /v1/messages/stream — authenticated', () => {
     await readSseEvents(res); // drain
     expect(receivedSignal).toBeInstanceOf(AbortSignal);
     await close();
+  });
+
+  it('emits SSE comment keepalive lines while the upstream is silent (proxy-idle survival)', async () => {
+    // Reverse proxies often drop "idle" sockets after 30-60s. The controller
+    // sends a `:keepalive\n\n` SSE comment every 25s so the bytes-on-the-wire
+    // counter never goes idle from the proxy's POV. Conformant SSE clients
+    // ignore comment lines (start with ':') so the application-level event
+    // stream is unaffected.
+    //
+    // Fake the interval timer so the test doesn't actually wait 25s. We
+    // narrowly fake only setInterval/clearInterval — leaving setTimeout real
+    // means AbortSignal.timeout, PROVIDER_TIMEOUT_MS and the test's own
+    // backoff loops are unaffected.
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    let resumeGenerator!: () => void;
+    const generatorParked = new Promise<void>((resolve) => { resumeGenerator = resolve; });
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      generateStream: async function* () {
+        // Park until the test releases us — simulates an upstream that's
+        // mid-thinking but hasn't produced any deltas yet.
+        await generatorParked;
+        yield { type: 'done', model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 0, totalTokens: 1 } };
+      },
+      persistMessagePair: async () => null,
+    }));
+
+    try {
+      const res = await fetch(`${baseUrl}/v1/messages/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatWindowId: 'cw-1', role: 'user', content: 'hi' }),
+      });
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error('no body');
+
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = '';
+      const collectChunks = async (deadlineMs: number): Promise<void> => {
+        const start = Date.now();
+        while (Date.now() - start < deadlineMs) {
+          const { value, done } = await Promise.race([
+            reader.read(),
+            new Promise<{ value: undefined; done: false }>((r) =>
+              setTimeout(() => r({ value: undefined, done: false }), 50),
+            ),
+          ]);
+          if (done) return;
+          if (value) buf += dec.decode(value, { stream: true });
+          if (buf.includes(':keepalive')) return;
+        }
+      };
+
+      // Advance the fake interval clock past two firings (25s * 2 + slack)
+      // BEFORE attempting to read so the writes are queued by the time the
+      // reader pulls.
+      await vi.advanceTimersByTimeAsync(60_000);
+      await collectChunks(2_000);
+
+      // Two keepalive comments should have been written by now (both ticks
+      // of the 25s interval inside the 60s virtual window).
+      const matches = buf.match(/:keepalive\n\n/g) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+
+      // Release the generator so the controller can finish cleanly. Even
+      // though persistMessagePair returns null (404 path), the test only
+      // cares that the keepalive lines were emitted before the terminal
+      // SSE event.
+      resumeGenerator();
+      try { await reader.cancel(); } catch { /* expected */ }
+    } finally {
+      vi.useRealTimers();
+      await close();
+    }
   });
 
   it('aborts the upstream signal when the client disconnects mid-stream', async () => {


### PR DESCRIPTION
## Summary

Adds an SSE comment-line ping (`:keepalive\n\n`) every 25s to `/v1/messages/stream` so reverse proxies / load balancers don't drop the socket as "idle" while the upstream provider is silently mid-thinking. Purely additive — no contract change, no new env var, no migration.

### Why
Common proxies (nginx default `proxy_read_timeout`, AWS ALB default 60s, Cloudflare ~100s) drop sockets that produce zero bytes for 30-60s. The OpenAI/Anthropic/Perplexity streams can pause silently for many seconds before the first delta, and on slow / long completions the gaps between deltas can also exceed the proxy idle threshold.

### How
- `setInterval(() => res.write(':keepalive\\n\\n'), 25_000)` started immediately after `res.flushHeaders()`.
- SSE spec ignores any line starting with `:` — every conformant client lib (EventSource, eventsource-parser, etc.) drops it before yielding to the app, so the application-level event stream is unaffected.
- Centralised cleanup helper `clearKeepalive()` called from every terminal branch:
  - success (200)
  - abort / client disconnect (499) — also in `res.on('close')` and `res.on('error')`
  - provider error (502)
  - empty / aborted (499/502)
  - persist-null (404)
- Interval is `.unref()`'d as defence-in-depth so a leaked timer cannot block process shutdown.

### Test
Vitest fake timers narrowly faked to `setInterval`/`clearInterval` only (real `setTimeout` for `AbortSignal.timeout` etc.). The generator parks; the test advances virtual time 60s; reads response bytes; asserts at least one `:keepalive\n\n` was written; releases the generator and lets the controller finish cleanly.

### Tests
- 497 backend tests pass (was 496). +1 new test.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 497/497 pass (5 reruns of the keepalive test all green)
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes
- [x] No new env / config

🤖 Generated with [Claude Code](https://claude.com/claude-code)