### PR TITLE
feat(web): pin reorder + persisted pin order across sidebar and palette

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -21,6 +21,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft  ·  In Cmd-K palette: clear query first, then close' },
       { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, and message contents (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
+      { keys: ['Click', '▲▼'], description: 'On a pinned sidebar row: reorder pinned windows; order persists per session' },
     ],
   },
   {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -100,6 +100,20 @@ export function ChatWindow({
   useEffect(() => {
     writeBoolFlag(pinStorageKey, pinned);
     if (typeof window !== 'undefined') {
+      try {
+        const orderRaw = window.sessionStorage.getItem('wav.chat.pinned.order');
+        const orderArr: string[] = orderRaw && Array.isArray(JSON.parse(orderRaw))
+          ? (JSON.parse(orderRaw) as unknown[]).filter((x): x is string => typeof x === 'string')
+          : [];
+        let nextOrder = orderArr;
+        if (pinned && !orderArr.includes(id)) nextOrder = [...orderArr, id];
+        if (!pinned && orderArr.includes(id)) nextOrder = orderArr.filter((x) => x !== id);
+        if (nextOrder !== orderArr) {
+          window.sessionStorage.setItem('wav.chat.pinned.order', JSON.stringify(nextOrder));
+        }
+      } catch {
+        // ignore
+      }
       window.dispatchEvent(new CustomEvent('wav:pin-changed', { detail: { id, pinned } }));
     }
     if (!pinInitRef.current) {

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -47,6 +47,7 @@ export function WorkspaceCommandPalette({
 }: WorkspaceCommandPaletteProps) {
   const [open, setOpen] = useState(false);
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinned());
+  const [pinnedOrder, setPinnedOrder] = useState<string[]>(() => readPinnedOrder());
   const [recentIds, setRecentIds] = useState<string[]>(() => readRecents(activeWorkspaceId));
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
@@ -141,10 +142,16 @@ export function WorkspaceCommandPalette({
       ...visibleWindows.map((w) => ({ window: w, open: true })),
       ...closedWindows.map((w) => ({ window: w, open: false })),
     ];
+    const orderIdx = (id: string) => {
+      const i = pinnedOrder.indexOf(id);
+      return i < 0 ? Number.MAX_SAFE_INTEGER : i;
+    };
     return all
       .filter((it) => pinnedSet.has(it.window.id) && it.window.id !== activeId && !recentIdSet.has(it.window.id))
+      .slice()
+      .sort((a, b) => orderIdx(a.window.id) - orderIdx(b.window.id))
       .slice(0, 6);
-  }, [query, pinnedSet, recentEntries, activeId, visibleWindows, closedWindows]);
+  }, [query, pinnedSet, pinnedOrder, recentEntries, activeId, visibleWindows, closedWindows]);
 
   type MessageMatch = typeof messageMatches[number];
   const messageGroups = useMemo(() => {
@@ -222,8 +229,12 @@ export function WorkspaceCommandPalette({
   useEffect(() => {
     if (!open) return;
     setPinnedSet(readPinned());
+    setPinnedOrder(readPinnedOrder());
     setRecentIds(readRecents(activeWorkspaceId));
-    const onChange = () => setPinnedSet(readPinned());
+    const onChange = () => {
+      setPinnedSet(readPinned());
+      setPinnedOrder(readPinnedOrder());
+    };
     const onRecents = () => setRecentIds(readRecents(activeWorkspaceId));
     window.addEventListener('wav:pin-changed', onChange);
     window.addEventListener('wav:recents-changed', onRecents);
@@ -828,6 +839,19 @@ function readPinned(): Set<string> {
     // ignore
   }
   return out;
+}
+
+function readPinnedOrder(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.sessionStorage.getItem('wav.chat.pinned.order');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
 }
 
 const pinnedBadgeStyle: React.CSSProperties = {

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -75,20 +75,47 @@ export function WorkspaceSidebar({
     );
   };
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinnedSet());
+  const [pinnedOrder, setPinnedOrder] = useState<string[]>(() => readPinnedOrder());
   const [onlyPinned, setOnlyPinned] = useState(false);
   useEffect(() => {
     if (onlyPinned && pinnedSet.size === 0) setOnlyPinned(false);
   }, [onlyPinned, pinnedSet.size]);
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const onChange = () => setPinnedSet(readPinnedSet());
+    const onChange = () => {
+      setPinnedSet(readPinnedSet());
+      setPinnedOrder(readPinnedOrder());
+    };
     window.addEventListener('wav:pin-changed', onChange);
     return () => window.removeEventListener('wav:pin-changed', onChange);
   }, []);
+  const orderIndex = (id: string): number => {
+    const i = pinnedOrder.indexOf(id);
+    return i < 0 ? Number.MAX_SAFE_INTEGER : i;
+  };
   const sortPinnedFirst = (a: ChatWindow, b: ChatWindow): number => {
     const pa = pinnedSet.has(a.id) ? 1 : 0;
     const pb = pinnedSet.has(b.id) ? 1 : 0;
-    return pb - pa;
+    if (pa !== pb) return pb - pa;
+    if (pa === 1 && pb === 1) return orderIndex(a.id) - orderIndex(b.id);
+    return 0;
+  };
+  const movePinned = (id: string, dir: -1 | 1) => {
+    const currentPinnedIds = visibleWindows
+      .filter((w) => pinnedSet.has(w.id))
+      .slice()
+      .sort((a, b) => orderIndex(a.id) - orderIndex(b.id))
+      .map((w) => w.id);
+    const idx = currentPinnedIds.indexOf(id);
+    if (idx < 0) return;
+    const target = idx + dir;
+    if (target < 0 || target >= currentPinnedIds.length) return;
+    const next = currentPinnedIds.slice();
+    const tmp = next[idx]!;
+    next[idx] = next[target]!;
+    next[target] = tmp;
+    writePinnedOrder(next);
+    setPinnedOrder(next);
   };
   const filteredVisible = (filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows)
     .filter((w) => (onlyPinned ? pinnedSet.has(w.id) : true))
@@ -223,23 +250,40 @@ export function WorkspaceSidebar({
         {filteredVisible.length === 0 ? (
           <EmptyHint>{lowerFilter ? 'No matches' : 'No windows open'}</EmptyHint>
         ) : (
-          filteredVisible.map((w) => (
-            <WindowRow
-              key={w.id}
-              window={w}
-              active={activeId === w.id}
-              pinned={pinnedSet.has(w.id)}
-              lastActivity={lastActivityByWindow?.[w.id]}
-              pending={pendingByWindow?.[w.id]}
-              unread={unreadByWindow?.[w.id]}
-              unreadCount={unreadCountByWindow?.[w.id]}
-              onMarkAsRead={onMarkAsRead}
-              onClick={() => onFocus(w.id)}
-              onAction={() => onClose(w.id)}
-              actionLabel="×"
-              actionAria="Close window"
-            />
-          ))
+          (() => {
+            const pinnedIdsSorted = visibleWindows
+              .filter((vw) => pinnedSet.has(vw.id))
+              .slice()
+              .sort((a, b) => orderIndex(a.id) - orderIndex(b.id))
+              .map((vw) => vw.id);
+            return filteredVisible.map((w) => {
+              const isPinned = pinnedSet.has(w.id);
+              const pinIdx = isPinned ? pinnedIdsSorted.indexOf(w.id) : -1;
+              const canMoveUp = isPinned && pinIdx > 0;
+              const canMoveDown = isPinned && pinIdx >= 0 && pinIdx < pinnedIdsSorted.length - 1;
+              return (
+                <WindowRow
+                  key={w.id}
+                  window={w}
+                  active={activeId === w.id}
+                  pinned={isPinned}
+                  lastActivity={lastActivityByWindow?.[w.id]}
+                  pending={pendingByWindow?.[w.id]}
+                  unread={unreadByWindow?.[w.id]}
+                  unreadCount={unreadCountByWindow?.[w.id]}
+                  onMarkAsRead={onMarkAsRead}
+                  canMoveUp={canMoveUp}
+                  canMoveDown={canMoveDown}
+                  onMoveUp={canMoveUp ? () => movePinned(w.id, -1) : undefined}
+                  onMoveDown={canMoveDown ? () => movePinned(w.id, 1) : undefined}
+                  onClick={() => onFocus(w.id)}
+                  onAction={() => onClose(w.id)}
+                  actionLabel="×"
+                  actionAria="Close window"
+                />
+              );
+            });
+          })()
         )}
 
         {filteredClosed.length > 0 ? (
@@ -724,13 +768,17 @@ interface WindowRowProps {
   unread?: boolean;
   unreadCount?: number;
   onMarkAsRead?: (id: string) => void;
+  canMoveUp?: boolean;
+  canMoveDown?: boolean;
+  onMoveUp?: () => void;
+  onMoveDown?: () => void;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onMarkAsRead, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onMarkAsRead, canMoveUp, canMoveDown, onMoveUp, onMoveDown, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -931,6 +979,54 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, unrea
           ) : null}
         </div>
       </div>
+      {pinned && (canMoveUp || canMoveDown) ? (
+        <span style={{ display: 'inline-flex', flexDirection: 'column', gap: 0, alignItems: 'center' }}>
+          <button
+            type="button"
+            disabled={!canMoveUp}
+            onClick={(e) => {
+              e.stopPropagation();
+              onMoveUp?.();
+            }}
+            aria-label={`Move ${window.title} up among pinned`}
+            title="Move pin up"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: canMoveUp ? '#9aa6ff' : '#3a3a45',
+              cursor: canMoveUp ? 'pointer' : 'not-allowed',
+              fontSize: '0.6rem',
+              padding: '0 4px',
+              lineHeight: 1,
+              fontFamily: 'inherit',
+            }}
+          >
+            ▲
+          </button>
+          <button
+            type="button"
+            disabled={!canMoveDown}
+            onClick={(e) => {
+              e.stopPropagation();
+              onMoveDown?.();
+            }}
+            aria-label={`Move ${window.title} down among pinned`}
+            title="Move pin down"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: canMoveDown ? '#9aa6ff' : '#3a3a45',
+              cursor: canMoveDown ? 'pointer' : 'not-allowed',
+              fontSize: '0.6rem',
+              padding: '0 4px',
+              lineHeight: 1,
+              fontFamily: 'inherit',
+            }}
+          >
+            ▼
+          </button>
+        </span>
+      ) : null}
       {unread && onMarkAsRead ? (
         <button
           onClick={(e) => {
@@ -1026,4 +1122,29 @@ function readPinnedSet(): Set<string> {
     // ignore
   }
   return out;
+}
+
+const PIN_ORDER_KEY = 'wav.chat.pinned.order';
+
+function readPinnedOrder(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.sessionStorage.getItem(PIN_ORDER_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function writePinnedOrder(order: string[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(PIN_ORDER_KEY, JSON.stringify(order));
+    window.dispatchEvent(new Event('wav:pin-changed'));
+  } catch {
+    // ignore quota
+  }
 }


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** Sidebar: pinned rows now expose **▲▼ reorder buttons** (left of the ✓/× actions). Click moves the row up/down within the pinned group; non-pinned rows show nothing. Edge buttons disable cleanly.
- **T2** Palette **Pinned** section sorts by the same persisted order, so the pin sequence the user picks in the sidebar is reflected in Cmd-K.
- **T3** Order is persisted in `sessionStorage` (`wav.chat.pinned.order`) and broadcast through the existing `wav:pin-changed` event.
- **T4** Pin / unpin from the chat-window header automatically appends or removes the id from the order array, keeping it tidy.
- **T5** KeyboardShortcutsOverlay documents the new ▲▼ reorder controls.

## Test plan
- [ ] Pin 3 windows, verify order in sidebar matches the pin sequence.
- [ ] Click ▲ on the second pinned → it moves above the first; click ▼ on the first → moves to the second slot.
- [ ] Edge cases: ▲ disabled on top pinned, ▼ disabled on bottom pinned.
- [ ] Open Cmd-K → Pinned section follows the same order.
- [ ] Unpin a window → it disappears from sidebar pinned + palette pinned. Re-pin → re-appears at the end.
- [ ] Reload the page (sessionStorage persists per tab) → order survives.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)