### PR TITLE
feat(web): starred messages in palette + cross-window starred indicator

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -19,7 +19,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['?'], description: 'Show this help' },
       { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
       { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft  ·  In Cmd-K palette: clear query first, then close' },
-      { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, and message contents (Ctrl+K on Linux/Win)' },
+      { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, message contents, recent windows, and starred messages (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
       { keys: ['Click', '▲▼'], description: 'On a pinned sidebar row: reorder pinned windows; order persists per session' },
     ],

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -538,9 +538,17 @@ export function ChatWindow({
 
   const starredStorageKey = `wav.chat.starred.${id}`;
   const [starredIds, setStarredIds] = useState<Set<string>>(() => readStarred(starredStorageKey));
+  const starredInitRef = useRef(false);
   useEffect(() => {
     writeStarred(starredStorageKey, starredIds);
-  }, [starredStorageKey, starredIds]);
+    if (!starredInitRef.current) {
+      starredInitRef.current = true;
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('wav:starred-changed', { detail: { windowId: id } }));
+    }
+  }, [starredStorageKey, starredIds, id]);
   const toggleStar = (msgId: string) => {
     setStarredIds((prev) => {
       const next = new Set(prev);

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -179,6 +179,16 @@ export function WorkspaceCommandPalette({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, getMessages, visibleWindows, closedWindows, starredTick]);
 
+  const starredByWindow = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const w of [...visibleWindows, ...closedWindows]) {
+      const ids = readStarredIdsForWindow(w.id);
+      if (ids.length > 0) map.set(w.id, new Set(ids));
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleWindows, closedWindows, starredTick]);
+
   type MessageMatch = typeof messageMatches[number];
   const messageGroups = useMemo(() => {
     const order: string[] = [];
@@ -733,9 +743,17 @@ export function WorkspaceCommandPalette({
                               overflow: 'hidden',
                               textOverflow: 'ellipsis',
                               whiteSpace: 'nowrap',
+                              display: 'flex',
+                              gap: 6,
+                              alignItems: 'center',
                             }}
                           >
-                            {renderHighlighted(m.snippet, query)}
+                            {starredByWindow.get(m.windowId)?.has(m.messageId) ? (
+                              <span aria-label="starred" title="Starred message" style={{ color: '#f0c14b', flexShrink: 0 }}>★</span>
+                            ) : null}
+                            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                              {renderHighlighted(m.snippet, query)}
+                            </span>
                           </div>
                           <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
                             {m.role}

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -48,6 +48,7 @@ export function WorkspaceCommandPalette({
   const [open, setOpen] = useState(false);
   const [pinnedSet, setPinnedSet] = useState<Set<string>>(() => readPinned());
   const [pinnedOrder, setPinnedOrder] = useState<string[]>(() => readPinnedOrder());
+  const [starredTick, setStarredTick] = useState(0);
   const [recentIds, setRecentIds] = useState<string[]>(() => readRecents(activeWorkspaceId));
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
@@ -114,7 +115,8 @@ export function WorkspaceCommandPalette({
   type UnifiedItem =
     | { kind: 'workspace'; key: string; workspace: Workspace }
     | { kind: 'window'; key: string; entry: PaletteWindow }
-    | { kind: 'message'; key: string; match: typeof messageMatches[number] };
+    | { kind: 'message'; key: string; match: typeof messageMatches[number] }
+    | { kind: 'starred'; key: string; star: { windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string } };
 
   const recentEntries: PaletteWindow[] = useMemo(() => {
     if (query.trim()) return [];
@@ -153,6 +155,30 @@ export function WorkspaceCommandPalette({
       .slice(0, 6);
   }, [query, pinnedSet, pinnedOrder, recentEntries, activeId, visibleWindows, closedWindows]);
 
+  const starredEntries = useMemo(() => {
+    if (query.trim()) return [] as Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string }>;
+    if (!getMessages) return [];
+    const out: Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string }> = [];
+    const allWindows = [...visibleWindows, ...closedWindows];
+    for (const w of allWindows) {
+      const ids = readStarredIdsForWindow(w.id);
+      if (ids.length === 0) continue;
+      const idSet = new Set(ids);
+      const list = getMessages(w.id);
+      for (const m of list) {
+        if (!idSet.has(m.id)) continue;
+        const content = (m.content ?? '').replace(/\s+/g, ' ').trim();
+        const snippet = content.length > 90 ? `${content.slice(0, 90)}…` : content;
+        out.push({ key: `${w.id}-${m.id}`, windowId: w.id, window: w, messageId: m.id, role: m.role, snippet });
+        if (out.length >= 6) break;
+      }
+      if (out.length >= 6) break;
+    }
+    return out;
+    // starredTick is intentionally a dep so listener-driven refresh re-runs the memo
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, getMessages, visibleWindows, closedWindows, starredTick]);
+
   type MessageMatch = typeof messageMatches[number];
   const messageGroups = useMemo(() => {
     const order: string[] = [];
@@ -188,6 +214,9 @@ export function WorkspaceCommandPalette({
     for (const it of pinnedEntries) {
       out.push({ kind: 'window', key: `pinned-${it.window.id}`, entry: it });
     }
+    for (const s of starredEntries) {
+      out.push({ kind: 'starred', key: `star-${s.key}`, star: s });
+    }
     if (filteredWorkspaces.length > 1) {
       for (const w of filteredWorkspaces) {
         out.push({ kind: 'workspace', key: `ws-${w.id}`, workspace: w });
@@ -204,7 +233,7 @@ export function WorkspaceCommandPalette({
       out.push({ kind: 'message', key: `m-${m.windowId}-${m.messageId}-${i}`, match: m });
     }
     return out;
-  }, [recentEntries, pinnedEntries, filteredWorkspaces, filtered, visibleMessageItems]);
+  }, [recentEntries, pinnedEntries, starredEntries, filteredWorkspaces, filtered, visibleMessageItems]);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQuery(query), 200);
@@ -236,11 +265,14 @@ export function WorkspaceCommandPalette({
       setPinnedOrder(readPinnedOrder());
     };
     const onRecents = () => setRecentIds(readRecents(activeWorkspaceId));
+    const onStarred = () => setStarredTick((n) => n + 1);
     window.addEventListener('wav:pin-changed', onChange);
     window.addEventListener('wav:recents-changed', onRecents);
+    window.addEventListener('wav:starred-changed', onStarred);
     return () => {
       window.removeEventListener('wav:pin-changed', onChange);
       window.removeEventListener('wav:recents-changed', onRecents);
+      window.removeEventListener('wav:starred-changed', onStarred);
     };
   }, [open, activeWorkspaceId]);
 
@@ -315,6 +347,21 @@ export function WorkspaceCommandPalette({
       if (typeof window !== 'undefined') {
         const url = new URL(window.location.href);
         url.hash = `msg-${m.messageId}`;
+        window.history.replaceState(null, '', url.toString());
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      }
+      return;
+    }
+    if (item.kind === 'starred') {
+      const s = item.star;
+      const visible = visibleWindows.some((w) => w.id === s.windowId);
+      if (!visible) onReopen(s.windowId);
+      else onFocus(s.windowId);
+      setOpen(false);
+      setQuery('');
+      if (typeof window !== 'undefined') {
+        const url = new URL(window.location.href);
+        url.hash = `msg-${s.messageId}`;
         window.history.replaceState(null, '', url.toString());
         window.dispatchEvent(new HashChangeEvent('hashchange'));
       }
@@ -477,6 +524,62 @@ export function WorkspaceCommandPalette({
                     <span style={metaStyle}>{it.window.provider} · {it.window.model}</span>
                     {!it.open ? <span style={badgeStyle}>closed</span> : null}
                     <span style={pinnedBadgeStyle}>pinned</span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ) : null}
+        {starredEntries.length > 0 ? (
+          <div>
+            <div style={sectionLabelStyle}>Starred messages · {starredEntries.length}</div>
+            <ul role="list" style={listStyle}>
+              {starredEntries.map((s) => {
+                const idx = unifiedItems.findIndex(
+                  (u) => u.kind === 'starred' && u.key === `star-${s.key}`,
+                );
+                const isHover = idx === Math.min(hover, unifiedItems.length - 1);
+                return (
+                  <li key={`starred-${s.key}`} style={{ listStyle: 'none' }}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isHover}
+                      onMouseEnter={() => idx >= 0 && setHover(idx)}
+                      onClick={() => {
+                        const visible = visibleWindows.some((w) => w.id === s.windowId);
+                        if (!visible) onReopen(s.windowId);
+                        else onFocus(s.windowId);
+                        setOpen(false);
+                        setQuery('');
+                        if (typeof window !== 'undefined') {
+                          const url = new URL(window.location.href);
+                          url.hash = `msg-${s.messageId}`;
+                          window.history.replaceState(null, '', url.toString());
+                          window.dispatchEvent(new HashChangeEvent('hashchange'));
+                        }
+                      }}
+                      style={{
+                        ...rowStyle,
+                        width: '100%',
+                        background: isHover ? '#1c1c28' : 'transparent',
+                        border: `1px solid ${isHover ? '#3a3f6b' : 'transparent'}`,
+                        textAlign: 'left',
+                        cursor: 'pointer',
+                        fontFamily: 'inherit',
+                        color: '#cfcfd6',
+                      }}
+                    >
+                      <span aria-hidden style={{ color: '#f0c14b', flexShrink: 0 }}>★</span>
+                      <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+                        <div style={{ fontSize: '0.78rem', color: '#e8e8ef', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          {s.snippet || '(empty)'}
+                        </div>
+                        <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
+                          {s.role} · {s.window.title}
+                        </div>
+                      </div>
+                    </button>
                   </li>
                 );
               })}
@@ -702,7 +805,9 @@ export function WorkspaceCommandPalette({
                   ? 'Enter to switch workspace'
                   : sel?.kind === 'message'
                     ? 'Enter to jump to message'
-                    : 'Enter to open';
+                    : sel?.kind === 'starred'
+                      ? 'Enter to jump to starred message'
+                      : 'Enter to open';
               if (query.trim().length > 0) return `↑↓ navigate · ${enterAction} · Esc clears query, again to close`;
               return `↑↓ navigate · ${enterAction} · Esc to close · type ≥2 chars to search messages`;
             })()}
@@ -845,6 +950,19 @@ function readPinnedOrder(): string[] {
   if (typeof window === 'undefined') return [];
   try {
     const raw = window.sessionStorage.getItem('wav.chat.pinned.order');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function readStarredIdsForWindow(windowId: string): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(`wav.chat.starred.${windowId}`);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** ChatWindow now broadcasts a `wav:starred-changed` event whenever a user toggles a star, so other components can refresh without coupling to localStorage internals.
- **T2** Palette gains a **Starred messages** section (visible when query is empty) that aggregates up to 6 starred messages across visible + closed windows. Activating a starred row opens or focuses the source window and jumps via the existing `#msg-<id>` hash flash.
- **T3** Palette message-search rows now show a small ★ when the matched message is starred, so users see "this is one I marked" without leaving the search.
- **T4** KeyboardShortcutsOverlay description for Cmd-K mentions starred messages.

## Test plan
- [ ] Star a couple of messages in different windows.
- [ ] Open Cmd-K with the search empty → see the **Starred messages** section listing them with ★ + window title; click one → palette closes, target window focuses, message scrolls and flashes.
- [ ] Type 2+ chars in palette → search works as before, with a small ★ next to message rows that are starred in their window.
- [ ] Unstar from inside the chat → palette refreshes immediately (event-driven).
- [ ] If no starred messages exist anywhere → no Starred section appears.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)