### PR TITLE
feat(web): starred preview-on-hover, bulk Unstar all, Alt+Shift+↑/↓ pin reorder

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -22,6 +22,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, message contents, recent windows, and starred messages (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
       { keys: ['Click', '▲▼'], description: 'On a pinned sidebar row: reorder pinned windows; order persists per session' },
+      { keys: ['⌥', 'Shift', '↑/↓'], description: 'Reorder the active pinned window up/down (Alt+Shift+↑ / Alt+Shift+↓)' },
     ],
   },
   {

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -540,6 +540,24 @@ export function ChatWindow({
   const [starredIds, setStarredIds] = useState<Set<string>>(() => readStarred(starredStorageKey));
   const starredInitRef = useRef(false);
   useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onExternal = (ev: Event) => {
+      const detail = (ev as CustomEvent<{ bulk?: boolean; windowId?: string }>).detail ?? {};
+      if (!detail.bulk && detail.windowId !== id) return;
+      const next = readStarred(starredStorageKey);
+      setStarredIds((prev) => {
+        if (prev.size === next.size) {
+          let same = true;
+          for (const v of prev) if (!next.has(v)) { same = false; break; }
+          if (same) return prev;
+        }
+        return next;
+      });
+    };
+    window.addEventListener('wav:starred-changed', onExternal);
+    return () => window.removeEventListener('wav:starred-changed', onExternal);
+  }, [id, starredStorageKey]);
+  useEffect(() => {
     writeStarred(starredStorageKey, starredIds);
     if (!starredInitRef.current) {
       starredInitRef.current = true;

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -542,7 +542,35 @@ export function WorkspaceCommandPalette({
         ) : null}
         {starredEntries.length > 0 ? (
           <div>
-            <div style={sectionLabelStyle}>Starred messages · {starredEntries.length}</div>
+            <div style={{ ...sectionLabelStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+              <span>Starred messages · {starredEntries.length}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (typeof window === 'undefined') return;
+                  const wins = new Set(starredEntries.map((s) => s.windowId));
+                  for (const wid of wins) {
+                    try { window.localStorage.removeItem(`wav.chat.starred.${wid}`); } catch { /* ignore */ }
+                  }
+                  window.dispatchEvent(new CustomEvent('wav:starred-changed', { detail: { bulk: true } }));
+                }}
+                aria-label="Unstar all messages shown here"
+                title="Unstar all messages currently shown in this section"
+                style={{
+                  background: 'transparent',
+                  border: 'none',
+                  color: '#9aa6ff',
+                  cursor: 'pointer',
+                  fontSize: '0.62rem',
+                  letterSpacing: '0.06em',
+                  textTransform: 'uppercase',
+                  fontFamily: 'inherit',
+                  padding: '0 0.25rem',
+                }}
+              >
+                Unstar all
+              </button>
+            </div>
             <ul role="list" style={listStyle}>
               {starredEntries.map((s) => {
                 const idx = unifiedItems.findIndex(

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -116,7 +116,7 @@ export function WorkspaceCommandPalette({
     | { kind: 'workspace'; key: string; workspace: Workspace }
     | { kind: 'window'; key: string; entry: PaletteWindow }
     | { kind: 'message'; key: string; match: typeof messageMatches[number] }
-    | { kind: 'starred'; key: string; star: { windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string } };
+    | { kind: 'starred'; key: string; star: { windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; fullContent: string } };
 
   const recentEntries: PaletteWindow[] = useMemo(() => {
     if (query.trim()) return [];
@@ -156,9 +156,9 @@ export function WorkspaceCommandPalette({
   }, [query, pinnedSet, pinnedOrder, recentEntries, activeId, visibleWindows, closedWindows]);
 
   const starredEntries = useMemo(() => {
-    if (query.trim()) return [] as Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string }>;
+    if (query.trim()) return [] as Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; fullContent: string }>;
     if (!getMessages) return [];
-    const out: Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string }> = [];
+    const out: Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; fullContent: string }> = [];
     const allWindows = [...visibleWindows, ...closedWindows];
     for (const w of allWindows) {
       const ids = readStarredIdsForWindow(w.id);
@@ -169,7 +169,7 @@ export function WorkspaceCommandPalette({
         if (!idSet.has(m.id)) continue;
         const content = (m.content ?? '').replace(/\s+/g, ' ').trim();
         const snippet = content.length > 90 ? `${content.slice(0, 90)}…` : content;
-        out.push({ key: `${w.id}-${m.id}`, windowId: w.id, window: w, messageId: m.id, role: m.role, snippet });
+        out.push({ key: `${w.id}-${m.id}`, windowId: w.id, window: w, messageId: m.id, role: m.role, snippet, fullContent: m.content ?? '' });
         if (out.length >= 6) break;
       }
       if (out.length >= 6) break;
@@ -582,8 +582,20 @@ export function WorkspaceCommandPalette({
                     >
                       <span aria-hidden style={{ color: '#f0c14b', flexShrink: 0 }}>★</span>
                       <div style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-                        <div style={{ fontSize: '0.78rem', color: '#e8e8ef', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {s.snippet || '(empty)'}
+                        <div
+                          title={s.fullContent}
+                          style={{
+                            fontSize: '0.78rem',
+                            color: '#e8e8ef',
+                            overflow: 'hidden',
+                            display: '-webkit-box',
+                            WebkitLineClamp: isHover ? 4 : 1,
+                            WebkitBoxOrient: 'vertical',
+                            whiteSpace: 'normal',
+                            wordBreak: 'break-word',
+                          }}
+                        >
+                          {(isHover ? (s.fullContent || s.snippet) : s.snippet) || '(empty)'}
                         </div>
                         <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
                           {s.role} · {s.window.title}

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -117,6 +117,23 @@ export function WorkspaceSidebar({
     writePinnedOrder(next);
     setPinnedOrder(next);
   };
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (!e.altKey || !e.shiftKey || e.metaKey || e.ctrlKey) return;
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const target = e.target;
+      const typing = target instanceof HTMLElement
+        && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+      if (typing) return;
+      if (!activeId || !pinnedSet.has(activeId)) return;
+      e.preventDefault();
+      movePinned(activeId, e.key === 'ArrowDown' ? 1 : -1);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeId, pinnedSet, pinnedOrder, visibleWindows]);
   const filteredVisible = (filterEnabled ? visibleWindows.filter(matchesFilter) : visibleWindows)
     .filter((w) => (onlyPinned ? pinnedSet.has(w.id) : true))
     .slice()


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** Palette starred row expands to a multi-line preview (4 lines) with full content when hovered/selected. Adds `title` for screen-reader full text.
- **T2** **Unstar all** button next to the Starred section header wipes the localStorage star sets for the windows shown. ChatWindow listens to `wav:starred-changed` (with `bulk` flag or matching `windowId`) and refreshes its in-memory star set so the in-window UI updates immediately.
- **T3** Alt+Shift+↑/↓ reorders the **active** pinned window up/down. Skips when target is typing in an input/textarea, and when active window isn't pinned.
- **T4** KeyboardShortcutsOverlay documents the Alt+Shift+↑/↓ shortcut.

## Test plan
- [ ] Star 3+ messages with long content. Open Cmd-K → arrow into a starred row → it expands to multi-line; arrow off → collapses back.
- [ ] Click "Unstar all" → all starred entries disappear, palette section disappears, the open chat windows reflect the change without reload.
- [ ] Make sure single-window star toggle from inside the chat still works (no infinite loop, equality short-circuit avoids duplicate state writes).
- [ ] Pin 3 windows, focus a middle pinned window → Alt+Shift+↓ → it moves down. Edge guard: if active is top, Alt+Shift+↑ does nothing (movePinned returns early).
- [ ] Alt+Shift+↑/↓ does nothing while typing in composer or any input.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)