### PR TITLE
feat(web): palette starred Show all/Show less toggle + layered Esc

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -18,7 +18,7 @@ const GROUPS: ShortcutGroup[] = [
     items: [
       { keys: ['?'], description: 'Show this help' },
       { keys: ['⌘', '/'], description: 'Show this help (also works while typing; Ctrl+/ on Linux/Win)' },
-      { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft  ·  In Cmd-K palette: clear query first, then close' },
+      { keys: ['Esc'], description: 'Close menus, modals, search bar, this help  ·  In composer: clear draft  ·  In Cmd-K palette: clear query, then collapse expanded sections, then close' },
       { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, message contents, recent windows, and starred messages (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
       { keys: ['Click', '▲▼'], description: 'On a pinned sidebar row: reorder pinned windows; order persists per session' },

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -155,7 +155,9 @@ export function WorkspaceCommandPalette({
       .slice(0, 6);
   }, [query, pinnedSet, pinnedOrder, recentEntries, activeId, visibleWindows, closedWindows]);
 
-  const starredEntries = useMemo(() => {
+  const STARRED_COLLAPSED_LIMIT = 6;
+  const STARRED_HARD_LIMIT = 60;
+  const starredAll = useMemo(() => {
     if (query.trim()) return [] as Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; fullContent: string }>;
     if (!getMessages) return [];
     const out: Array<{ key: string; windowId: string; window: ChatWindow; messageId: string; role: string; snippet: string; fullContent: string }> = [];
@@ -170,14 +172,25 @@ export function WorkspaceCommandPalette({
         const content = (m.content ?? '').replace(/\s+/g, ' ').trim();
         const snippet = content.length > 90 ? `${content.slice(0, 90)}…` : content;
         out.push({ key: `${w.id}-${m.id}`, windowId: w.id, window: w, messageId: m.id, role: m.role, snippet, fullContent: m.content ?? '' });
-        if (out.length >= 6) break;
+        if (out.length >= STARRED_HARD_LIMIT) break;
       }
-      if (out.length >= 6) break;
+      if (out.length >= STARRED_HARD_LIMIT) break;
     }
     return out;
     // starredTick is intentionally a dep so listener-driven refresh re-runs the memo
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, getMessages, visibleWindows, closedWindows, starredTick]);
+  const [showAllStarred, setShowAllStarred] = useState(false);
+  useEffect(() => {
+    if (!open) setShowAllStarred(false);
+  }, [open]);
+  useEffect(() => {
+    if (query.trim()) setShowAllStarred(false);
+  }, [query]);
+  const starredEntries = useMemo(() => {
+    if (showAllStarred) return starredAll;
+    return starredAll.slice(0, STARRED_COLLAPSED_LIMIT);
+  }, [starredAll, showAllStarred]);
 
   const starredByWindow = useMemo(() => {
     const map = new Map<string, Set<string>>();
@@ -540,38 +553,66 @@ export function WorkspaceCommandPalette({
             </ul>
           </div>
         ) : null}
-        {starredEntries.length > 0 ? (
+        {starredAll.length > 0 ? (
           <div>
             <div style={{ ...sectionLabelStyle, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-              <span>Starred messages · {starredEntries.length}</span>
-              <button
-                type="button"
-                onClick={() => {
-                  if (typeof window === 'undefined') return;
-                  const wins = new Set(starredEntries.map((s) => s.windowId));
-                  for (const wid of wins) {
-                    try { window.localStorage.removeItem(`wav.chat.starred.${wid}`); } catch { /* ignore */ }
-                  }
-                  window.dispatchEvent(new CustomEvent('wav:starred-changed', { detail: { bulk: true } }));
-                }}
-                aria-label="Unstar all messages shown here"
-                title="Unstar all messages currently shown in this section"
-                style={{
-                  background: 'transparent',
-                  border: 'none',
-                  color: '#9aa6ff',
-                  cursor: 'pointer',
-                  fontSize: '0.62rem',
-                  letterSpacing: '0.06em',
-                  textTransform: 'uppercase',
-                  fontFamily: 'inherit',
-                  padding: '0 0.25rem',
-                }}
-              >
-                Unstar all
-              </button>
+              <span>
+                Starred messages · {starredEntries.length}
+                {starredAll.length > starredEntries.length ? ` of ${starredAll.length}` : ''}
+                {starredAll.length >= STARRED_HARD_LIMIT ? '+' : ''}
+              </span>
+              <span style={{ display: 'inline-flex', gap: 6 }}>
+                {starredAll.length > STARRED_COLLAPSED_LIMIT ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllStarred((v) => !v)}
+                    aria-pressed={showAllStarred}
+                    aria-label={showAllStarred ? 'Show fewer starred messages' : `Show all ${starredAll.length} starred messages`}
+                    title={showAllStarred ? 'Collapse to top 6' : `Show all ${starredAll.length}`}
+                    style={{
+                      background: 'transparent',
+                      border: 'none',
+                      color: '#9aa6ff',
+                      cursor: 'pointer',
+                      fontSize: '0.62rem',
+                      letterSpacing: '0.06em',
+                      textTransform: 'uppercase',
+                      fontFamily: 'inherit',
+                      padding: '0 0.25rem',
+                    }}
+                  >
+                    {showAllStarred ? 'Show less' : `Show all (${starredAll.length})`}
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (typeof window === 'undefined') return;
+                    const wins = new Set(starredAll.map((s) => s.windowId));
+                    for (const wid of wins) {
+                      try { window.localStorage.removeItem(`wav.chat.starred.${wid}`); } catch { /* ignore */ }
+                    }
+                    window.dispatchEvent(new CustomEvent('wav:starred-changed', { detail: { bulk: true } }));
+                  }}
+                  aria-label={`Unstar all ${starredAll.length} starred messages`}
+                  title={`Unstar all ${starredAll.length} starred messages across all windows`}
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    color: '#9aa6ff',
+                    cursor: 'pointer',
+                    fontSize: '0.62rem',
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    fontFamily: 'inherit',
+                    padding: '0 0.25rem',
+                  }}
+                >
+                  Unstar all
+                </button>
+              </span>
             </div>
-            <ul role="list" style={listStyle}>
+            <ul role="list" style={showAllStarred ? { ...listStyle, maxHeight: 280, overflowY: 'auto' } : listStyle}>
               {starredEntries.map((s) => {
                 const idx = unifiedItems.findIndex(
                   (u) => u.kind === 'starred' && u.key === `star-${s.key}`,

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -326,6 +326,8 @@ export function WorkspaceCommandPalette({
         e.preventDefault();
         if (query.length > 0) {
           setQuery('');
+        } else if (showAllStarred) {
+          setShowAllStarred(false);
         } else {
           setOpen(false);
         }
@@ -333,7 +335,7 @@ export function WorkspaceCommandPalette({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, query, activeWorkspaceId]);
+  }, [open, query, activeWorkspaceId, showAllStarred]);
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1+T2** Palette **Starred messages** section now collects up to 60 starred messages across windows. Default view stays at top 6; a "Show all (N)" / "Show less" toggle reveals the full set in a scrollable list. Header now reports both displayed and total counts (e.g. "Starred messages · 6 of 18").
- **T3** Esc inside the palette is layered: clears query → collapses Show-all if expanded → closes the palette. No regression on the existing "clear before close" behavior.
- **T4** Unstar all now wipes every starred message across all windows (not just the displayed 6); aria-label and tooltip reflect total.
- **T5** KeyboardShortcutsOverlay updated for layered Esc.

## Test plan
- [ ] Star ≥7 messages across multiple windows → palette shows "Starred messages · 6 of 7" with "Show all (7)" button.
- [ ] Click "Show all" → list expands to scrollable area with full set; button switches to "Show less".
- [ ] Esc collapses the expanded list; another Esc closes the palette.
- [ ] Starring 60+ messages caps the collected list at 60 with a "+" suffix on the count.
- [ ] Click "Unstar all" → all starred messages cleared across windows; section disappears; open ChatWindows reflect the change live.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)