### PR TITLE
feat(web): announce draft preservation when closing window via Cmd+Shift+W

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -31,7 +31,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', 'F'], description: 'Find inside the active chat window (Ctrl+F on Linux/Win)' },
       { keys: ['⌘', 'J'], description: 'Focus the composer (Ctrl+J on Linux/Win)' },
       { keys: ['⌘', 'E'], description: 'Rename the active chat window (Ctrl+E on Linux/Win)' },
-      { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; Ctrl+Shift+W on Linux/Win)' },
+      { keys: ['⌘', 'Shift', 'W'], description: 'Close the active chat window (hides locally; draft is preserved and announced via toast; Ctrl+Shift+W on Linux/Win)' },
       { keys: ['⌘', 'Shift', '⌫'], description: 'Clear the composer draft (Ctrl+Shift+Backspace)' },
       { keys: ['⌘', 'Shift', 'T'], description: 'Open the prompt template menu in the active composer (Ctrl+Shift+T)' },
       { keys: ['⌘', '.'], description: 'Stop the in-flight reply in the active chat window (Ctrl+. on Linux/Win)' },

--- a/apps/web/src/features/chat/ChatWindow.tsx
+++ b/apps/web/src/features/chat/ChatWindow.tsx
@@ -368,6 +368,9 @@ export function ChatWindow({
       }
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'w' || e.key === 'W') && onClose) {
         e.preventDefault();
+        if (draft.trim().length > 0) {
+          toast.push('info', 'Draft preserved — reopen to continue');
+        }
         onClose(id);
         return;
       }
@@ -434,7 +437,7 @@ export function ChatWindow({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [active, onRename, onClose, onCancel, pending, title, id]);
+  }, [active, onRename, onClose, onCancel, pending, title, id, draft, toast]);
 
   const commitRename = () => {
     const trimmed = titleDraft.trim();


### PR DESCRIPTION
## Summary
Frontend-only mini-batch. No backend, no API or types changes. Disjoint from any palette/starred area.

- **T1** When the user closes the active chat with `⌘ Shift W` (or Ctrl+Shift+W) and the composer has non-empty content, a toast announces "Draft preserved — reopen to continue" so the user knows their work survived. Draft persistence itself was already in place; this just makes it discoverable.
- **T2** KeyboardShortcutsOverlay description for `⌘ Shift W` mentions the draft-preserved announcement.

## Test plan
- [ ] Type into the composer of the active chat, hit Cmd+Shift+W → window hides locally and a toast says "Draft preserved — reopen to continue".
- [ ] With empty composer, Cmd+Shift+W → no toast (existing behavior preserved).
- [ ] Reopen the window from the sidebar Closed list → draft is still there.
- [ ] Open the shortcuts overlay (?) → the entry for ⌘ Shift W mentions the toast and preservation.
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)