### PR TITLE
feat(api): Vary: Cookie defence-in-depth on CORS-headered responses

### DIFF
--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -139,6 +139,17 @@ describe('CORS with explicit origin — credentialed auth', () => {
     expect(res.headers.get('vary')).toContain('Origin');
   });
 
+  it('emits Vary: Cookie alongside Origin (defence-in-depth on user-scoped responses)', async () => {
+    // Cache-Control: no-store on user-scoped routes is the primary guard
+    // (batches 11-12); Vary: Cookie is the secondary signal so any future
+    // shared cache that decides to honour private/max-age over no-store
+    // still keys responses by the session cookie. Pin both list members.
+    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`);
+    const vary = res.headers.get('vary') ?? '';
+    expect(vary).toContain('Origin');
+    expect(vary).toContain('Cookie');
+  });
+
   it('preflight also carries credentials + explicit origin', async () => {
     const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`, { method: 'OPTIONS' });
     expect(res.status).toBe(204);
@@ -195,5 +206,14 @@ describe('CORS with wildcard — non-credentialed default', () => {
   it('does NOT emit Access-Control-Allow-Credentials for wildcard', async () => {
     const res = await fetch(`${harness.baseUrl}${API_HEALTH_PATH}`);
     expect(res.headers.get('access-control-allow-credentials')).toBeNull();
+  });
+
+  it('still emits Vary: Cookie even on the wildcard branch', async () => {
+    // The wildcard branch is the dev / open-API path. We don't ship
+    // ACAO=*+credentials (browsers reject the combo) but we do still
+    // want caches to key by Cookie if anyone ever puts a shared cache
+    // in front of an unauthenticated probe path. Pin the header.
+    const res = await fetch(`${harness.baseUrl}${API_HEALTH_PATH}`);
+    expect(res.headers.get('vary')).toContain('Cookie');
   });
 });

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -114,6 +114,11 @@ describe('OPTIONS preflight', () => {
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
     expect(res.headers.get('x-permitted-cross-domain-policies')).toBe('none');
     expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
+    // Preflight rides the same Vary: Cookie as every other CORS-headered
+    // response (preflight is opted-in to the same buildCorsHeaders call).
+    // Pin so a refactor that special-cases OPTIONS doesn't accidentally
+    // drop the cache-keying signal.
+    expect(res.headers.get('vary') ?? '').toContain('Cookie');
   });
 });
 

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -25,6 +25,12 @@ function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Rec
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
+      // Defence-in-depth: every authenticated response varies by the
+      // session cookie. Cache-Control: no-store on user-scoped routes is
+      // the primary guard; this Vary signal is the secondary guard for
+      // any future shared cache (CDN, corp proxy) that decides to honour
+      // private/max-age over no-store. Harmless on cookieless requests.
+      'Vary': 'Cookie',
     };
   }
   const allowed = parseAllowedOrigins(corsOrigin);
@@ -41,7 +47,12 @@ function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Rec
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Allow-Credentials': 'true',
-    'Vary': 'Origin',
+    // Origin: response varies by the requesting origin (multi-allowlist).
+    // Cookie: response varies by the session cookie — defence-in-depth on
+    // top of the per-route Cache-Control: no-store pins (batches 11-12)
+    // for any shared cache that decides to honour private/max-age over
+    // no-store at some point in the future.
+    'Vary': 'Origin, Cookie',
   };
 }
 

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -550,6 +550,10 @@ describe('GET /v1/auth/me', () => {
     // explicit caching directive on this route would silently leak.
     expect(res.headers.get('cache-control')).toBe('no-store');
     expect(res.headers.get('x-request-id')).toBeTruthy();
+    // Defence-in-depth: Vary: Cookie tells any future shared cache that
+    // /me responses are session-cookie-keyed. Cache-Control: no-store is
+    // the primary guard; this is the secondary one.
+    expect(res.headers.get('vary') ?? '').toContain('Cookie');
     await close();
   });
 
@@ -595,6 +599,11 @@ describe('GET /v1/auth/me', () => {
     // user 'you're not logged in' for the duration of the cache TTL —
     // worst-possible UX for the auth flow. Pin explicitly.
     expect(res.headers.get('cache-control')).toBe('no-store');
+    // Vary: Cookie applies to the 401 path too — without it, a cache
+    // could legitimately serve a 'no cookie' 401 to a request that
+    // DOES have a cookie (matching path, both lacking the Vary signal
+    // appears coincidentally identical to the cache).
+    expect(res.headers.get('vary') ?? '').toContain('Cookie');
     await close();
   });
 


### PR DESCRIPTION
## Summary

Adds `Vary: Cookie` to every CORS-headered response in handle-request. The per-route `Cache-Control: no-store` pins (batches 11-12) are the primary guard against a shared cache returning user A's response to user B; this Vary signal is the secondary guard for any future shared cache (CDN, corp proxy) that decides to honour `private` / `max-age` over `no-store`.

### Change
Two CORS branches in `buildCorsHeaders`:
- **Wildcard (`*`)** — ship `Vary: Cookie` on its own (we don't add Origin because the wildcard already opts out of Origin keying).
- **Explicit-origin** — extend the existing `Vary: Origin` to `Vary: Origin, Cookie`. Browsers and conformant caches treat the comma-separated list as "vary on either header".

Purely additive header — invisible to clients, harmless on cookieless requests, no contract change, no env var, no migration, no `packages/types` touch.

### Tests pinned
- `Vary` contains both `Origin` AND `Cookie` on the credentialed branch.
- `Vary` contains `Cookie` on the wildcard branch.
- Existing `Vary: Origin` assertion preserved as a base-case pin.
- `/v1/auth/me 200` carries `Vary: Cookie`.
- `/v1/auth/me 401` carries `Vary: Cookie` (without it a cache could legitimately serve a "no cookie" 401 to a request that DOES have a cookie).
- `OPTIONS` preflight rides `Vary: Cookie` (preflight uses the same buildCorsHeaders path).

### Tests
- 499 backend tests pass (was 497). +2 new tests + assertions added to existing tests.
- `pnpm --filter @webapp/api typecheck` clean.
- `pnpm typecheck` (monorepo) clean.
- `pnpm build` (monorepo) clean.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 499/499 pass
- [x] `pnpm typecheck` (monorepo) — clean
- [x] `pnpm build` (monorepo) — clean
- [x] No DB migrations
- [x] No `packages/types` changes
- [x] No frontend changes
- [x] No new env / config

🤖 Generated with [Claude Code](https://claude.com/claude-code)