### PR TITLE
chore(api): scope Vary: Cookie to user-scoped paths + tests

### DIFF
--- a/apps/api/src/controllers/health-deep.controller.test.ts
+++ b/apps/api/src/controllers/health-deep.controller.test.ts
@@ -80,4 +80,30 @@ describe('GET /v1/health/deep', () => {
     expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
     await close();
   });
+
+  it('never emits Set-Cookie on the public health probe', async () => {
+    // /v1/health/deep is a public, anonymous endpoint. Any Set-Cookie
+    // here would either leak a session into a poller or accidentally
+    // pin a cookie on a probe origin. Lock the absence so a future
+    // refactor that threads session resolution everywhere doesn't
+    // bleed cookies onto unauthenticated routes.
+    const { baseUrl, close } = await startServer(makeDeps('ok'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toBeNull();
+    await close();
+  });
+
+  it('emits Vary: Origin only (no Cookie) — health is not user-scoped', async () => {
+    // Deep health is anonymous and identical for all viewers. Vary: Cookie
+    // here only fragments shared caches needlessly; the only legitimate
+    // Vary axis is Origin (so multi-origin CORS deployments key correctly).
+    const { baseUrl, close } = await startServer(makeDeps('ok'));
+    const res = await fetch(`${baseUrl}/v1/health/deep`);
+    const vary = res.headers.get('vary') ?? '';
+    if (vary) {
+      expect(vary).not.toContain('Cookie');
+    }
+    await close();
+  });
 });

--- a/apps/api/src/controllers/version.controller.test.ts
+++ b/apps/api/src/controllers/version.controller.test.ts
@@ -29,4 +29,20 @@ describe('GET /v1/version', () => {
     // search results). Pin the anti-indexing header.
     expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
   });
+
+  it('does not emit Vary: Cookie — version is identical for all viewers', async () => {
+    // Pin the absence: if /v1/version ever started carrying Vary: Cookie,
+    // a shared cache would fragment by every visitor's cookie state and
+    // multiply storage load for a response that never depends on it.
+    const res = await fetch(`${harness.baseUrl}/v1/version`);
+    const vary = res.headers.get('vary') ?? '';
+    if (vary) {
+      expect(vary).not.toContain('Cookie');
+    }
+  });
+
+  it('never emits Set-Cookie on the public version endpoint', async () => {
+    const res = await fetch(`${harness.baseUrl}/v1/version`);
+    expect(res.headers.get('set-cookie')).toBeNull();
+  });
 });

--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -114,10 +114,14 @@ describe('OPTIONS preflight', () => {
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
     expect(res.headers.get('x-permitted-cross-domain-policies')).toBe('none');
     expect(res.headers.get('x-robots-tag')).toBe('noindex, nofollow');
-    // Preflight rides the same Vary: Cookie as every other CORS-headered
-    // response (preflight is opted-in to the same buildCorsHeaders call).
-    // Pin so a refactor that special-cases OPTIONS doesn't accidentally
-    // drop the cache-keying signal.
+    // Preflight on a non-user-scoped path (health) must NOT include
+    // Vary: Cookie — only user-scoped routes get cookie-keyed caching.
+    expect(res.headers.get('vary') ?? '').not.toContain('Cookie');
+  });
+
+  it('OPTIONS preflight on a user-scoped path emits Vary: Cookie', async () => {
+    const res = await fetch(`${harness.baseUrl}${API_PROJECTS_PATH}`, { method: 'OPTIONS' });
+    expect(res.status).toBe(204);
     expect(res.headers.get('vary') ?? '').toContain('Cookie');
   });
 });
@@ -144,15 +148,23 @@ describe('CORS with explicit origin — credentialed auth', () => {
     expect(res.headers.get('vary')).toContain('Origin');
   });
 
-  it('emits Vary: Cookie alongside Origin (defence-in-depth on user-scoped responses)', async () => {
+  it('emits Vary: Cookie alongside Origin on user-scoped responses', async () => {
     // Cache-Control: no-store on user-scoped routes is the primary guard
     // (batches 11-12); Vary: Cookie is the secondary signal so any future
     // shared cache that decides to honour private/max-age over no-store
-    // still keys responses by the session cookie. Pin both list members.
-    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`);
+    // still keys responses by the session cookie. Pin both list members
+    // on a user-scoped path; health is NOT user-scoped so no Cookie there.
+    const res = await fetch(`${s.baseUrl}${API_PROJECTS_PATH}`);
     const vary = res.headers.get('vary') ?? '';
     expect(vary).toContain('Origin');
     expect(vary).toContain('Cookie');
+  });
+
+  it('does NOT emit Vary: Cookie on the public health path', async () => {
+    const res = await fetch(`${s.baseUrl}${API_HEALTH_PATH}`);
+    const vary = res.headers.get('vary') ?? '';
+    expect(vary).toContain('Origin');
+    expect(vary).not.toContain('Cookie');
   });
 
   it('preflight also carries credentials + explicit origin', async () => {
@@ -213,12 +225,16 @@ describe('CORS with wildcard — non-credentialed default', () => {
     expect(res.headers.get('access-control-allow-credentials')).toBeNull();
   });
 
-  it('still emits Vary: Cookie even on the wildcard branch', async () => {
-    // The wildcard branch is the dev / open-API path. We don't ship
-    // ACAO=*+credentials (browsers reject the combo) but we do still
-    // want caches to key by Cookie if anyone ever puts a shared cache
-    // in front of an unauthenticated probe path. Pin the header.
-    const res = await fetch(`${harness.baseUrl}${API_HEALTH_PATH}`);
-    expect(res.headers.get('vary')).toContain('Cookie');
+  it('emits Vary: Cookie on the wildcard branch for user-scoped paths only', async () => {
+    // Wildcard branch is the dev / open-API path. We still want caches
+    // to key by Cookie on user-scoped paths but NOT on public health
+    // probes (so a shared cache can coalesce health checks).
+    const userScoped = await fetch(`${harness.baseUrl}${API_PROJECTS_PATH}`);
+    expect(userScoped.headers.get('vary') ?? '').toContain('Cookie');
+    const health = await fetch(`${harness.baseUrl}${API_HEALTH_PATH}`);
+    const healthVary = health.headers.get('vary');
+    if (healthVary !== null) {
+      expect(healthVary).not.toContain('Cookie');
+    }
   });
 });

--- a/apps/api/src/middleware/handle-request.test.ts
+++ b/apps/api/src/middleware/handle-request.test.ts
@@ -6,6 +6,36 @@ import { startTestServer, type Harness } from '../test/server-harness.js';
 import { createApiServer } from '../lib/server.js';
 import { Router } from '../lib/router.js';
 import { routes } from '../routes/index.js';
+import { isUserScopedPath } from './handle-request.js';
+
+describe('isUserScopedPath — Vary: Cookie scope', () => {
+  it('returns false for the public health probes', () => {
+    expect(isUserScopedPath('/health')).toBe(false);
+    expect(isUserScopedPath('/v1/health')).toBe(false);
+    expect(isUserScopedPath('/v1/health/deep')).toBe(false);
+  });
+
+  it('returns false for the public version endpoint', () => {
+    expect(isUserScopedPath('/v1/version')).toBe(false);
+  });
+
+  it('returns true for auth, state, projects, workspaces, chat-windows, messages, provider-connections', () => {
+    expect(isUserScopedPath('/v1/auth/login')).toBe(true);
+    expect(isUserScopedPath('/v1/auth/me')).toBe(true);
+    expect(isUserScopedPath('/v1/state')).toBe(true);
+    expect(isUserScopedPath('/v1/projects')).toBe(true);
+    expect(isUserScopedPath('/v1/projects/abc')).toBe(true);
+    expect(isUserScopedPath('/v1/workspaces')).toBe(true);
+    expect(isUserScopedPath('/v1/chat-windows')).toBe(true);
+    expect(isUserScopedPath('/v1/messages')).toBe(true);
+    expect(isUserScopedPath('/v1/provider-connections')).toBe(true);
+  });
+
+  it('returns true for unknown paths (closed by default — safer to over-key than miss a user-scoped route)', () => {
+    expect(isUserScopedPath('/v1/whatever-future-route')).toBe(true);
+    expect(isUserScopedPath('/random-junk')).toBe(true);
+  });
+});
 
 describe('dispatch — error envelopes', () => {
   let harness: Harness;

--- a/apps/api/src/middleware/handle-request.ts
+++ b/apps/api/src/middleware/handle-request.ts
@@ -19,19 +19,37 @@ function parseAllowedOrigins(corsOrigin: string): string[] {
     .filter((s) => s.length > 0);
 }
 
-function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Record<string, string> {
+// Public, non-user-scoped routes — health probes and version metadata. These
+// responses are identical regardless of the session cookie, so emitting
+// Vary: Cookie on them only adds noise to caches and (worse) prevents
+// shared caches from coalescing public health checks across viewers.
+const NON_USER_SCOPED_EXACT = new Set<string>([
+  '/health',
+  '/v1/health',
+  '/v1/health/deep',
+  '/v1/version',
+]);
+
+export function isUserScopedPath(path: string): boolean {
+  if (NON_USER_SCOPED_EXACT.has(path)) return false;
+  return true;
+}
+
+function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null, userScoped: boolean): Record<string, string> {
   if (corsOrigin === '*') {
-    return {
+    const headers: Record<string, string> = {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
-      // Defence-in-depth: every authenticated response varies by the
-      // session cookie. Cache-Control: no-store on user-scoped routes is
-      // the primary guard; this Vary signal is the secondary guard for
-      // any future shared cache (CDN, corp proxy) that decides to honour
-      // private/max-age over no-store. Harmless on cookieless requests.
-      'Vary': 'Cookie',
     };
+    if (userScoped) {
+      // Defence-in-depth: user-scoped responses vary by the session cookie.
+      // Cache-Control: no-store on user-scoped routes is the primary guard;
+      // this Vary signal is the secondary guard for any shared cache (CDN,
+      // corp proxy) that decides to honour private/max-age over no-store.
+      headers['Vary'] = 'Cookie';
+    }
+    return headers;
   }
   const allowed = parseAllowedOrigins(corsOrigin);
   // ACAO must echo the actual request Origin when credentials are involved.
@@ -47,12 +65,11 @@ function buildCorsHeaders(corsOrigin: string, requestOrigin: string | null): Rec
     'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Allow-Credentials': 'true',
-    // Origin: response varies by the requesting origin (multi-allowlist).
-    // Cookie: response varies by the session cookie — defence-in-depth on
-    // top of the per-route Cache-Control: no-store pins (batches 11-12)
-    // for any shared cache that decides to honour private/max-age over
-    // no-store at some point in the future.
-    'Vary': 'Origin, Cookie',
+    // Origin: always varies by the requesting origin (multi-allowlist).
+    // Cookie: only added on user-scoped routes (defence-in-depth on top of
+    // per-route Cache-Control: no-store). Public health/version responses
+    // get Vary: Origin only so they remain cacheable across viewers.
+    'Vary': userScoped ? 'Origin, Cookie' : 'Origin',
   };
 }
 
@@ -70,7 +87,8 @@ export async function handleRequest(
   const path = url.pathname;
 
   const reqOrigin = typeof req.headers.origin === 'string' ? req.headers.origin : null;
-  for (const [k, v] of Object.entries(buildCorsHeaders(corsOrigin, reqOrigin))) {
+  const userScoped = isUserScopedPath(path);
+  for (const [k, v] of Object.entries(buildCorsHeaders(corsOrigin, reqOrigin, userScoped))) {
     res.setHeader(k, v);
   }
 


### PR DESCRIPTION
## Summary
Backend-only batch. No DB migrations, no API contract changes, no \`packages/types\` modifications.

- **T1** \`buildCorsHeaders\` now takes a \`userScoped\` flag. Public probes (\`/health\`, \`/v1/health\`, \`/v1/health/deep\`, \`/v1/version\`) receive \`Vary: Origin\` only on the explicit-origin branch and **no** \`Vary\` on the wildcard branch — letting shared caches coalesce health checks across viewers. User-scoped routes still emit \`Vary: Origin, Cookie\` (or \`Vary: Cookie\` on the wildcard branch) as before. New helper \`isUserScopedPath()\` is exported for tests.
- **T2** Unit tests for \`isUserScopedPath\` covering health/version/auth/state/projects/workspaces/chat-windows/messages/provider-connections + a "closed by default" assertion for unknown paths.
- **T3** \`health-deep.controller.test.ts\` pins \`Set-Cookie === null\` and \`Vary !contain Cookie\` invariants on the public deep-probe response.
- **T4** \`version.controller.test.ts\` mirrors the same two invariants for \`/v1/version\`.
- **T5** Existing CORS tests rewritten to assert against a user-scoped path (\`API_PROJECTS_PATH\`) for Cookie-keying expectations and against \`API_HEALTH_PATH\` for the absence assertion.

## Test plan
- [x] \`pnpm --filter @webapp/api typecheck\` — clean
- [x] \`pnpm --filter @webapp/api test\` — 509 passed (40 files)
- [x] \`pnpm --filter @webapp/api build\` — clean
- [ ] Hit \`/v1/health\` and \`/v1/version\` in dev → \`Vary\` header should not contain \`Cookie\`
- [ ] Hit \`/v1/auth/me\` or \`/v1/projects\` → \`Vary\` header should contain \`Cookie\`

## What this is NOT
- No refresh tokens, no idle-stream timeout, no global HTTP timeouts, no password whitespace policy, no auth refactor, no DB migration, no types change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)