### PR TITLE
feat(web): drag-and-drop pin reorder + starred Show-all grouping

### DIFF
--- a/apps/web/src/components/KeyboardShortcutsOverlay.tsx
+++ b/apps/web/src/components/KeyboardShortcutsOverlay.tsx
@@ -22,6 +22,7 @@ const GROUPS: ShortcutGroup[] = [
       { keys: ['⌘', 'K'], description: 'Open command palette — search windows, workspaces, message contents, starred messages, and other projects (Ctrl+K on Linux/Win)' },
       { keys: ['⌥', '↑/↓'], description: 'Cycle active chat window up/down (Alt+↑ / Alt+↓)' },
       { keys: ['Click', '▲▼'], description: 'On a pinned sidebar row: reorder pinned windows; order persists per session' },
+      { keys: ['Drag', '⇅'], description: 'Drag a pinned sidebar row onto another pinned row to insert it at that position' },
       { keys: ['⌥', 'Shift', '↑/↓'], description: 'Reorder the active pinned window up/down (Alt+Shift+↑ / Alt+Shift+↓)' },
     ],
   },

--- a/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
+++ b/apps/web/src/features/workspace/WorkspaceCommandPalette.tsx
@@ -689,13 +689,27 @@ export function WorkspaceCommandPalette({
               </span>
             </div>
             <ul role="list" style={showAllStarred ? { ...listStyle, maxHeight: 280, overflowY: 'auto' } : listStyle}>
-              {starredEntries.map((s) => {
+              {starredEntries.map((s, i) => {
                 const idx = unifiedItems.findIndex(
                   (u) => u.kind === 'starred' && u.key === `star-${s.key}`,
                 );
                 const isHover = idx === Math.min(hover, unifiedItems.length - 1);
+                const showGroupHeader = showAllStarred && (i === 0 || starredEntries[i - 1]?.windowId !== s.windowId);
                 return (
                   <li key={`starred-${s.key}`} style={{ listStyle: 'none' }}>
+                    {showGroupHeader ? (
+                      <div
+                        style={{
+                          fontSize: '0.62rem',
+                          color: '#6a6a75',
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.06em',
+                          padding: '6px 6px 2px',
+                        }}
+                      >
+                        {s.window.title}
+                      </div>
+                    ) : null}
                     <button
                       type="button"
                       role="option"
@@ -743,7 +757,7 @@ export function WorkspaceCommandPalette({
                           {(isHover ? (s.fullContent || s.snippet) : s.snippet) || '(empty)'}
                         </div>
                         <div style={{ fontSize: '0.65rem', color: '#8a8a95', marginTop: 2 }}>
-                          {s.role} · {s.window.title}
+                          {showAllStarred ? s.role : `${s.role} · ${s.window.title}`}
                         </div>
                       </div>
                     </button>

--- a/apps/web/src/features/workspace/WorkspaceSidebar.tsx
+++ b/apps/web/src/features/workspace/WorkspaceSidebar.tsx
@@ -100,6 +100,22 @@ export function WorkspaceSidebar({
     if (pa === 1 && pb === 1) return orderIndex(a.id) - orderIndex(b.id);
     return 0;
   };
+  const reorderPinned = (fromId: string, toId: string) => {
+    if (fromId === toId) return;
+    const currentPinnedIds = visibleWindows
+      .filter((w) => pinnedSet.has(w.id))
+      .slice()
+      .sort((a, b) => orderIndex(a.id) - orderIndex(b.id))
+      .map((w) => w.id);
+    const fromIdx = currentPinnedIds.indexOf(fromId);
+    const toIdx = currentPinnedIds.indexOf(toId);
+    if (fromIdx < 0 || toIdx < 0) return;
+    const next = currentPinnedIds.slice();
+    next.splice(fromIdx, 1);
+    next.splice(toIdx, 0, fromId);
+    writePinnedOrder(next);
+    setPinnedOrder(next);
+  };
   const movePinned = (id: string, dir: -1 | 1) => {
     const currentPinnedIds = visibleWindows
       .filter((w) => pinnedSet.has(w.id))
@@ -293,6 +309,7 @@ export function WorkspaceSidebar({
                   canMoveDown={canMoveDown}
                   onMoveUp={canMoveUp ? () => movePinned(w.id, -1) : undefined}
                   onMoveDown={canMoveDown ? () => movePinned(w.id, 1) : undefined}
+                  onReorderPinned={isPinned ? reorderPinned : undefined}
                   onClick={() => onFocus(w.id)}
                   onAction={() => onClose(w.id)}
                   actionLabel="×"
@@ -789,15 +806,21 @@ interface WindowRowProps {
   canMoveDown?: boolean;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  onReorderPinned?: (fromId: string, toId: string) => void;
   onClick: () => void;
   onAction: () => void;
   actionLabel: string;
   actionAria: string;
 }
 
-function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onMarkAsRead, canMoveUp, canMoveDown, onMoveUp, onMoveDown, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
+const DRAG_MIME = 'application/x-wav-pinned-window-id';
+
+function WindowRow({ window, active, muted, pinned, lastActivity, pending, unread, unreadCount, onMarkAsRead, canMoveUp, canMoveDown, onMoveUp, onMoveDown, onReorderPinned, onClick, onAction, actionLabel, actionAria }: WindowRowProps) {
   const stamp = formatRelative(lastActivity ?? window.updatedAt ?? window.createdAt);
   const rowRef = useRef<HTMLDivElement | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const dragEnabled = !!(pinned && onReorderPinned);
   useEffect(() => {
     if (!active) return;
     const el = rowRef.current;
@@ -817,6 +840,37 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, unrea
       ref={rowRef}
       role="button"
       tabIndex={0}
+      draggable={dragEnabled}
+      onDragStart={dragEnabled ? (e) => {
+        try {
+          e.dataTransfer.effectAllowed = 'move';
+          e.dataTransfer.setData(DRAG_MIME, window.id);
+          e.dataTransfer.setData('text/plain', window.id);
+        } catch { /* ignore */ }
+        setDragging(true);
+      } : undefined}
+      onDragEnd={dragEnabled ? () => {
+        setDragging(false);
+        setDragOver(false);
+      } : undefined}
+      onDragEnter={dragEnabled ? (e) => {
+        if (e.dataTransfer.types.includes(DRAG_MIME)) {
+          setDragOver(true);
+        }
+      } : undefined}
+      onDragOver={dragEnabled ? (e) => {
+        if (e.dataTransfer.types.includes(DRAG_MIME)) {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+        }
+      } : undefined}
+      onDragLeave={dragEnabled ? () => setDragOver(false) : undefined}
+      onDrop={dragEnabled ? (e) => {
+        e.preventDefault();
+        const fromId = e.dataTransfer.getData(DRAG_MIME) || e.dataTransfer.getData('text/plain');
+        setDragOver(false);
+        if (fromId && onReorderPinned) onReorderPinned(fromId, window.id);
+      } : undefined}
       onClick={onClick}
       onAuxClick={(e) => {
         if (e.button === 1) {
@@ -831,20 +885,21 @@ function WindowRow({ window, active, muted, pinned, lastActivity, pending, unrea
         }
       }}
       aria-current={active ? 'true' : undefined}
-      aria-label={`${window.title} — ${window.provider} ${window.model}`}
+      aria-grabbed={dragEnabled ? dragging : undefined}
+      aria-label={`${window.title} — ${window.provider} ${window.model}${dragEnabled ? ' (draggable to reorder pinned)' : ''}`}
       style={{
         display: 'flex',
         alignItems: 'center',
         gap: '0.5rem',
         padding: '0.5rem 0.55rem',
         borderRadius: 8,
-        cursor: 'pointer',
-        background: active ? '#1c1c28' : 'transparent',
-        border: `1px solid ${active ? '#4f6bff' : 'transparent'}`,
+        cursor: dragging ? 'grabbing' : dragEnabled ? 'grab' : 'pointer',
+        background: dragOver ? '#1c2436' : active ? '#1c1c28' : 'transparent',
+        border: `1px solid ${dragOver ? '#4f6bff' : active ? '#4f6bff' : 'transparent'}`,
         boxShadow: active ? '0 0 0 1px rgba(79,107,255,0.25)' : 'none',
-        opacity: muted ? 0.55 : 1,
+        opacity: dragging ? 0.5 : muted ? 0.55 : 1,
         marginBottom: 2,
-        transition: 'background 120ms ease, border-color 120ms ease',
+        transition: 'background 120ms ease, border-color 120ms ease, opacity 120ms ease',
       }}
     >
       <span


### PR DESCRIPTION
## Summary
Frontend-only batch. No backend, no API or types changes.

- **T1** Pinned sidebar rows are now native HTML5 drag sources/targets. Drop one onto another to insert at that position. Persists via the existing `wav.chat.pinned.order` sessionStorage key, so DnD and the existing ▲▼ buttons + Alt+Shift+↑/↓ shortcut all share the same source of truth. Visual cues: cursor flips to grab/grabbing, drop target highlights with the accent border, dragged row dims to opacity 0.5.
- **T2** KeyboardShortcutsOverlay documents the new drag affordance.
- **T3** Cmd-K palette **Starred messages** Show-all view now groups entries by window with sub-headers; the per-row footer drops the redundant window title in this mode (it's already in the group header). Top-6 collapsed view stays unchanged.

## Test plan
- [ ] Pin 3+ windows. Drag the second onto the first → second becomes first; drag onto the third → moves to that position.
- [ ] Drag a non-pinned row → no DnD activates (draggable=false).
- [ ] Drop confusion: dragging a pinned row outside the sidebar produces no change; dropping back on itself is a no-op.
- [ ] Existing ▲▼ buttons and Alt+Shift+↑/↓ keep working and reflect the new order.
- [ ] Star ≥7 messages across multiple windows. Open Cmd-K → Show all → entries grouped by window with sub-header per group.
- [ ] Top-6 collapsed mode still shows `role · window.title` per row (no grouping needed).
- [ ] `pnpm --filter @webapp/web typecheck`, `lint`, `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)