### PR TITLE
feat(api): idle-stream timeout on /v1/messages/stream — explicit SSE error after 90s of provider silence

### DIFF
--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -89,6 +89,11 @@ export interface MessagesDeps {
   generateStream:    (provider: AIProvider, apiKey: string, messages: ChatMessage[], model: string, opts?: { signal?: AbortSignal }) => AsyncIterable<ChatCompletionStreamChunk>;
   maxContextMessages: number;
   providerTimeoutMs?: number;
+  // Idle-stream timeout (ms): if no useful provider delta lands within this
+  // window the controller aborts upstream and surfaces an SSE idle_timeout
+  // error. Defaults to 90s in production. Tests override to a small value
+  // so they can exercise the path in real time without faking timers.
+  idleStreamTimeoutMs?: number;
 }
 
 export function makeMessagesDeps(db: Db, sessionDeps: SessionDeps): MessagesDeps {
@@ -332,7 +337,7 @@ export async function streamMessageDbController(
   // actual delta payloads. The chosen 90s window is wide enough for slow
   // first-tokens on large prompts but tight enough to catch hung sessions
   // before they tie up a reverse-proxy slot for the global request budget.
-  const IDLE_TIMEOUT_MS = 90_000;
+  const IDLE_TIMEOUT_MS = deps.idleStreamTimeoutMs ?? 90_000;
   const keepaliveTimer = setInterval(() => {
     // writableEnded guards against a race where the timer fires after we've
     // already res.end()'d in a terminal branch. write() on an ended response
@@ -477,6 +482,28 @@ export async function streamMessageDbController(
     res.write('data: [DONE]\n\n');
     res.end();
     return respondStreamed(502);
+  }
+
+  if (idleTimedOut) {
+    // Generator exited cleanly after we aborted via idle timer (rather than
+    // throwing) — still surface the explicit SSE error. Mirrors the catch-
+    // block path so the contract is identical regardless of whether the
+    // upstream propagated the abort as a throw or a clean return.
+    cleanup();
+    logger.warn('stream aborted on idle timeout (clean upstream exit)', {
+      requestId: ctx.requestId,
+      provider: cw.provider,
+      model: cw.model,
+      idleMs: IDLE_TIMEOUT_MS,
+      partialBytes: assistantContent.length,
+      durationMs: Date.now() - startedAt,
+    });
+    if (!res.writableEnded) {
+      sseWrite(res, { error: 'idle_timeout', detail: `No provider activity for ${Math.floor(IDLE_TIMEOUT_MS / 1000)}s` });
+      res.write('data: [DONE]\n\n');
+      try { res.end(); } catch { /* socket already closed */ }
+    }
+    return respondStreamed(504);
   }
 
   if (aborted || assistantContent.length === 0) {

--- a/apps/api/src/controllers/messages-db.controller.ts
+++ b/apps/api/src/controllers/messages-db.controller.ts
@@ -325,6 +325,14 @@ export async function streamMessageDbController(
   // every 25s keeps the socket warm without surfacing anything in the
   // application-level event stream.
   const KEEPALIVE_MS = 25_000;
+  // Idle-stream timeout: if the upstream provider hasn't produced a useful
+  // delta in this many ms, we abort the call and surface an explicit SSE
+  // error so the client can show a real failure instead of waiting forever
+  // on a dead provider session. Keepalive bytes do NOT reset this — only
+  // actual delta payloads. The chosen 90s window is wide enough for slow
+  // first-tokens on large prompts but tight enough to catch hung sessions
+  // before they tie up a reverse-proxy slot for the global request budget.
+  const IDLE_TIMEOUT_MS = 90_000;
   const keepaliveTimer = setInterval(() => {
     // writableEnded guards against a race where the timer fires after we've
     // already res.end()'d in a terminal branch. write() on an ended response
@@ -334,15 +342,57 @@ export async function streamMessageDbController(
   }, KEEPALIVE_MS);
   // unref so a leaked timer can never block process shutdown if a terminal
   // branch ever forgets to clear (defence in depth — every branch below
-  // also calls clearKeepalive explicitly).
+  // also calls cleanup() explicitly).
   keepaliveTimer.unref?.();
-  const clearKeepalive = (): void => { clearInterval(keepaliveTimer); };
 
   const startedAt = Date.now();
   let assistantContent = '';
   let model = cw.model;
   let usage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
   let aborted = false;
+  let idleTimedOut = false;
+
+  const upstreamAbort = new AbortController();
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+  const armIdleTimer = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      // Provider went silent past IDLE_TIMEOUT_MS. Mark idle, kill the
+      // upstream call so we stop paying for a hung session, and let the
+      // for-await loop throw — the catch block will see idleTimedOut=true
+      // and emit the explicit SSE error.
+      if (res.writableEnded) return;
+      idleTimedOut = true;
+      aborted = true;
+      upstreamAbort.abort();
+    }, IDLE_TIMEOUT_MS);
+    idleTimer.unref?.();
+  };
+  // Centralised cleanup: every terminal branch (success / abort / error /
+  // idle timeout) calls this exactly once. Listeners are removed so a late
+  // 'close' or 'error' event after we've already ended the response can't
+  // double-fire any of the cleanup logic.
+  const onClose = (): void => {
+    cleanup();
+    if (!res.writableEnded) {
+      aborted = true;
+      upstreamAbort.abort();
+    }
+  };
+  const onError = (): void => {
+    cleanup();
+    aborted = true;
+    upstreamAbort.abort();
+  };
+  const cleanup = (): void => {
+    clearInterval(keepaliveTimer);
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+    res.off('close', onClose);
+    res.off('error', onError);
+  };
 
   // Cancel the upstream provider call when the downstream client drops the
   // connection — stops billing for tokens nobody will read. The for-await
@@ -350,42 +400,66 @@ export async function streamMessageDbController(
   // We listen on `res` (not `req`) because once the request body has been
   // fully read, Node's IncomingMessage 'close' event does not fire on
   // mid-response socket teardown — only the ServerResponse 'close' does.
-  const upstreamAbort = new AbortController();
-  res.on('close', () => {
-    clearKeepalive();
-    if (!res.writableEnded) {
-      aborted = true;
-      upstreamAbort.abort();
-    }
-  });
+  res.on('close', onClose);
   // A mid-stream socket error (ECONNRESET, EPIPE) emits 'error' on the
   // ServerResponse. With no listener, Node treats it as unhandled and the
   // process can crash. Treat it like a client disconnect: cancel upstream,
   // mark aborted, and swallow — the catch block downstream will see the
   // for-await throw and exit cleanly.
-  res.on('error', () => {
-    clearKeepalive();
-    aborted = true;
-    upstreamAbort.abort();
-  });
+  res.on('error', onError);
+
+  // Arm the idle timer before the first read. The provider may take a while
+  // to produce its first token; 90s of total silence (no deltas, only our
+  // keepalive bytes) is the threshold beyond which we treat the session as
+  // hung and surface an explicit error.
+  armIdleTimer();
 
   try {
     for await (const chunk of deps.generateStream(cw.provider, apiKey, contextMessages, cw.model, { signal: upstreamAbort.signal })) {
       if (aborted) break;
       if (chunk.type === 'delta') {
-        assistantContent += chunk.content;
-        sseWrite(res, { delta: chunk.content });
+        // A useful delta only counts as activity if it carries content.
+        // An empty-string delta is a provider quirk (some SDKs emit them as
+        // "still alive" placeholders); we don't treat it as progress so a
+        // provider that emits empty deltas indefinitely still trips the
+        // idle timeout.
+        if (chunk.content.length > 0) {
+          assistantContent += chunk.content;
+          sseWrite(res, { delta: chunk.content });
+          armIdleTimer();
+        }
       } else {
         model = chunk.model;
         usage = chunk.usage;
       }
     }
   } catch (err) {
+    // Idle-timeout path: the upstream was aborted by us because no useful
+    // delta had landed in IDLE_TIMEOUT_MS. Surface an explicit SSE error
+    // so the client can distinguish this from a generic provider failure
+    // or a client-side disconnect.
+    if (idleTimedOut) {
+      cleanup();
+      logger.warn('stream aborted on idle timeout', {
+        requestId: ctx.requestId,
+        provider: cw.provider,
+        model: cw.model,
+        idleMs: IDLE_TIMEOUT_MS,
+        partialBytes: assistantContent.length,
+        durationMs: Date.now() - startedAt,
+      });
+      if (!res.writableEnded) {
+        sseWrite(res, { error: 'idle_timeout', detail: `No provider activity for ${Math.floor(IDLE_TIMEOUT_MS / 1000)}s` });
+        res.write('data: [DONE]\n\n');
+        try { res.end(); } catch { /* socket already closed */ }
+      }
+      return respondStreamed(504);
+    }
     // Aborted-by-us (client disconnected) is not a real error — the for-await
     // throw happens because we asked the upstream to stop. Don't ship an
     // 'error' SSE event (the client is gone anyway) and don't capture it.
     if (aborted) {
-      clearKeepalive();
+      cleanup();
       logger.info('stream cancelled by client disconnect', {
         requestId: ctx.requestId,
         provider: cw.provider,
@@ -396,7 +470,7 @@ export async function streamMessageDbController(
       try { res.end(); } catch { /* socket already closed */ }
       return respondStreamed(499);
     }
-    clearKeepalive();
+    cleanup();
     captureException(err, { provider: cw.provider, model: cw.model, route: '/v1/messages/stream' });
     const detail = err instanceof Error ? err.message : 'Unknown provider error';
     sseWrite(res, { error: detail });
@@ -406,7 +480,7 @@ export async function streamMessageDbController(
   }
 
   if (aborted || assistantContent.length === 0) {
-    clearKeepalive();
+    cleanup();
     // Client gave up or provider produced nothing — do NOT persist a half-baked pair.
     if (!aborted) sseWrite(res, { error: 'empty_response' });
     res.write('data: [DONE]\n\n');
@@ -425,14 +499,14 @@ export async function streamMessageDbController(
 
   const pair = await deps.persistMessagePair(chatWindowId, user.id, content, assistantContent, assistantMetadata);
   if (pair === null) {
-    clearKeepalive();
+    cleanup();
     sseWrite(res, { error: 'chat_window_not_found' });
     res.write('data: [DONE]\n\n');
     res.end();
     return respondStreamed(404);
   }
 
-  clearKeepalive();
+  cleanup();
   sseWrite(res, {
     done: true,
     userMessage:      toMessage(pair.userRow),

--- a/apps/api/src/routes/messages-db.test.ts
+++ b/apps/api/src/routes/messages-db.test.ts
@@ -933,4 +933,133 @@ describe('POST /v1/messages/stream — authenticated', () => {
     expect(persisted).toBe(false);
     await close();
   });
+
+  it('emits an explicit SSE idle_timeout error when no provider delta lands within the idle window', async () => {
+    // Pin the idle-stream timeout: when the upstream goes silent past
+    // idleStreamTimeoutMs the controller must abort upstream, surface a
+    // discriminable SSE error event, and end the stream with [DONE].
+    // We override the deps idle window to a small value so the test
+    // exercises the path in real time without touching node-internal
+    // timers via fake clocks.
+    let aborted = false;
+    let persisted = false;
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      idleStreamTimeoutMs: 250,
+      generateStream: async function* (_p, _k, _msgs, _model, opts) {
+        yield { type: 'delta', content: 'first ' };
+        // Park forever — the controller must trip its idle timer and abort.
+        await new Promise<void>((resolve) => {
+          if (opts?.signal?.aborted) { aborted = true; return resolve(); }
+          opts?.signal?.addEventListener('abort', () => { aborted = true; resolve(); }, { once: true });
+        });
+      },
+      persistMessagePair: async () => { persisted = true; return null; },
+    }));
+
+    try {
+      const res = await fetch(`${baseUrl}/v1/messages/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatWindowId: 'cw-1', role: 'user', content: 'hi' }),
+      });
+      expect(res.status).toBe(200);
+      const events = await readSseEvents(res);
+      const parsed = events
+        .filter((e) => e !== '[DONE]')
+        .map((e) => { try { return JSON.parse(e) as { delta?: string; error?: string; detail?: string }; } catch { return {}; } });
+      const idleErr = parsed.find((e) => e.error === 'idle_timeout');
+      expect(idleErr).toBeTruthy();
+      expect(idleErr?.detail).toMatch(/No provider activity/i);
+      expect(events).toContain('[DONE]');
+      expect(events[events.length - 1]).toBe('[DONE]');
+      expect(aborted).toBe(true);
+      expect(persisted).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it('does not trip the idle timeout when deltas keep arriving', async () => {
+    // Sanity counter-test: a generator that yields content deltas back to
+    // back must NOT trigger idle_timeout. Guards against a regression
+    // where the timer arms once and never resets on subsequent deltas.
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      idleStreamTimeoutMs: 250,
+      generateStream: async function* () {
+        yield { type: 'delta', content: 'a ' };
+        await new Promise((r) => setTimeout(r, 50));
+        yield { type: 'delta', content: 'b ' };
+        await new Promise((r) => setTimeout(r, 50));
+        yield { type: 'delta', content: 'c' };
+        yield { type: 'done', model: 'gpt-4o-mini', usage: { promptTokens: 1, completionTokens: 3, totalTokens: 4 } };
+      },
+      persistMessagePair: async (chatWindowId, _userId, userContent, assistantContent) =>
+        mockPair(chatWindowId, userContent, assistantContent),
+    }));
+
+    try {
+      const res = await fetch(`${baseUrl}/v1/messages/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatWindowId: 'cw-1', role: 'user', content: 'hi' }),
+      });
+      expect(res.status).toBe(200);
+      const events = await readSseEvents(res);
+      const errs = events
+        .filter((e) => e !== '[DONE]')
+        .map((e) => { try { return JSON.parse(e) as { error?: string }; } catch { return {}; } })
+        .filter((e) => typeof e.error === 'string');
+      expect(errs).toHaveLength(0);
+      expect(events[events.length - 1]).toBe('[DONE]');
+    } finally {
+      await close();
+    }
+  });
+
+  it('empty-content deltas do not reset the idle timer (still trips on prolonged silence)', async () => {
+    // Some provider SDKs emit zero-length delta payloads as keepalive-ish
+    // signals. We do NOT consider those useful progress: a stream that
+    // emits only empty deltas must still trip idle_timeout once the
+    // window elapses without a content-bearing delta.
+    const { baseUrl, close } = await startServer(makeDeps({
+      resolveUser:    async () => USER_1,
+      findChatWindow: async () => mockChatWindow('openai', 'gpt-4o-mini'),
+      getApiKey:      async () => 'sk-test',
+      listMessages:   async () => [],
+      idleStreamTimeoutMs: 250,
+      generateStream: async function* (_p, _k, _msgs, _model, opts) {
+        yield { type: 'delta', content: '' };
+        yield { type: 'delta', content: '' };
+        await new Promise<void>((resolve) => {
+          if (opts?.signal?.aborted) return resolve();
+          opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+      persistMessagePair: async () => null,
+    }));
+
+    try {
+      const res = await fetch(`${baseUrl}/v1/messages/stream`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatWindowId: 'cw-1', role: 'user', content: 'hi' }),
+      });
+      expect(res.status).toBe(200);
+      const events = await readSseEvents(res);
+      const parsed = events
+        .filter((e) => e !== '[DONE]')
+        .map((e) => { try { return JSON.parse(e) as { error?: string }; } catch { return {}; } });
+      expect(parsed.some((e) => e.error === 'idle_timeout')).toBe(true);
+    } finally {
+      await close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
Backend-only batch implementing the validated idle-stream timeout decision. No DB migration, no contract change beyond the added `idle_timeout` SSE error semantics that were already validated.

- **T1** Controller adds an idle timer armed at the start of streaming and re-armed on every **content-bearing** delta (empty-string deltas don't count as activity, so providers that emit them as keepalive-style placeholders still trip the timeout).
- **T2** When the timer fires past **90s** of provider silence: aborts the upstream call (`upstreamAbort.abort()`), emits `data: {"error":"idle_timeout","detail":"No provider activity for 90s"}\n\n`, writes `data: [DONE]\n\n`, ends the response. Result code: `respondStreamed(504)`.
- **T3** Idle-timeout is handled in **both** post-loop branches (clean upstream exit after abort, and throw from for-await on abort) so the contract is identical regardless of how the provider SDK propagates the abort signal.
- **T4** Centralised `cleanup()` clears keepalive interval, idle timeout, and detaches `close`/`error` listeners on the response — replaces the previous `clearKeepalive` calls. Every terminal branch (success, persist-failure, provider error, client disconnect, idle timeout, empty response) calls `cleanup()` exactly once.
- **T5** Threshold is exposed via `MessagesDeps.idleStreamTimeoutMs` (default `90_000`) — additive, no env or types change. Tests use `idleStreamTimeoutMs: 250` to exercise the path in real time without faking node-internal timers.
- **T6** Three new tests in `messages-db.test.ts`: idle_timeout fires when the generator parks; deltas reset the timer (counter-test); empty-content deltas do **not** reset the timer.

## Test plan
- [x] `pnpm --filter @webapp/api typecheck` — clean
- [x] `pnpm --filter @webapp/api test` — 516 passed (40 files)
- [x] `pnpm --filter @webapp/api build` — clean

## What this is NOT
- No global HTTP timeout, no headers timeout for SSE.
- No refresh tokens, no password whitespace policy, no DB migration, no `packages/types` change.
- Keepalive interval (25s) preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)