### PR TITLE
fix(tooling): detect branch rulesets in task doctor

### DIFF
--- a/tools/task-doctor.mjs
+++ b/tools/task-doctor.mjs
@@ -113,13 +113,46 @@ function checkGit() {
   };
 }
 
+export function rulesetTargetsMain(ruleset) {
+  if (!ruleset || ruleset.enforcement !== 'active') return false;
+  if (ruleset.target !== 'branch') return false;
+  const include = ruleset.conditions?.ref_name?.include ?? [];
+  const exclude = ruleset.conditions?.ref_name?.exclude ?? [];
+  const targetsMain = include.some((p) => p === '~DEFAULT_BRANCH' || p === '~ALL' || p === 'refs/heads/main' || p === 'main');
+  const explicitlyExcluded = exclude.some((p) => p === 'refs/heads/main' || p === 'main');
+  return targetsMain && !explicitlyExcluded;
+}
+
 function checkBranchProtection() {
-  const r = run('gh', ['api', 'repos/Yuume2/WebAppV1/branches/main/protection']);
-  if (r.code === 0) return { status: status.OK, detail: 'main is protected' };
-  if (/Branch not protected/i.test(r.stderr) || /404/.test(r.stderr)) {
-    return { status: status.WARN, detail: 'main NOT protected — required before Phase 2 --exec is active' };
+  const classic = run('gh', ['api', 'repos/Yuume2/WebAppV1/branches/main/protection']);
+  if (classic.code === 0) return { status: status.OK, detail: 'main is protected (classic branch protection)' };
+
+  // Fall back to repository rulesets — required for repos using the new ruleset model.
+  // The list endpoint omits `conditions`, so candidate rulesets must be re-fetched
+  // individually via /rulesets/{id} to inspect ref_name include/exclude.
+  const list = run('gh', ['api', 'repos/Yuume2/WebAppV1/rulesets']);
+  if (list.code === 0) {
+    let parsed = [];
+    try { parsed = JSON.parse(list.stdout); } catch { parsed = []; }
+    const candidates = parsed.filter((r) => r.enforcement === 'active' && r.target === 'branch');
+    const matched = [];
+    for (const c of candidates) {
+      const detail = run('gh', ['api', `repos/Yuume2/WebAppV1/rulesets/${c.id}`]);
+      if (detail.code !== 0) continue;
+      let full;
+      try { full = JSON.parse(detail.stdout); } catch { continue; }
+      if (rulesetTargetsMain(full)) matched.push(full);
+    }
+    if (matched.length > 0) {
+      const names = matched.map((r) => `"${r.name}"`).join(', ');
+      return { status: status.OK, detail: `active via ruleset ${names}` };
+    }
   }
-  return { status: status.WARN, detail: `cannot read protection: ${r.stderr.split('\n')[0]}` };
+
+  if (/Branch not protected/i.test(classic.stderr) || /404/.test(classic.stderr)) {
+    return { status: status.WARN, detail: 'main NOT protected — no classic protection and no active ruleset targets main' };
+  }
+  return { status: status.WARN, detail: `cannot read protection: ${classic.stderr.split('\n')[0]}` };
 }
 
 function checkGhAuth() {

--- a/tools/task-doctor.test.mjs
+++ b/tools/task-doctor.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { checkPhase3Secrets } from './task-doctor.mjs';
+import { checkPhase3Secrets, rulesetTargetsMain } from './task-doctor.mjs';
 
 describe('checkPhase3Secrets', () => {
   it('reports n/a when no env present', () => {
@@ -17,5 +17,60 @@ describe('checkPhase3Secrets', () => {
   it('reports ok when all env present', () => {
     const r = checkPhase3Secrets({ NOTION_TOKEN: 'x', NOTION_QUESTIONS_DATABASE_ID: 'y' });
     assert.equal(r.status, 'ok');
+  });
+});
+
+describe('rulesetTargetsMain', () => {
+  const base = {
+    enforcement: 'active',
+    target: 'branch',
+    conditions: { ref_name: { include: ['~DEFAULT_BRANCH'], exclude: [] } },
+  };
+
+  it('matches active ruleset on default branch', () => {
+    assert.equal(rulesetTargetsMain(base), true);
+  });
+
+  it('matches when include is refs/heads/main', () => {
+    assert.equal(rulesetTargetsMain({
+      ...base,
+      conditions: { ref_name: { include: ['refs/heads/main'], exclude: [] } },
+    }), true);
+  });
+
+  it('matches when include is ~ALL', () => {
+    assert.equal(rulesetTargetsMain({
+      ...base,
+      conditions: { ref_name: { include: ['~ALL'], exclude: [] } },
+    }), true);
+  });
+
+  it('rejects disabled enforcement', () => {
+    assert.equal(rulesetTargetsMain({ ...base, enforcement: 'disabled' }), false);
+    assert.equal(rulesetTargetsMain({ ...base, enforcement: 'evaluate' }), false);
+  });
+
+  it('rejects non-branch target', () => {
+    assert.equal(rulesetTargetsMain({ ...base, target: 'tag' }), false);
+  });
+
+  it('rejects when main is explicitly excluded', () => {
+    assert.equal(rulesetTargetsMain({
+      ...base,
+      conditions: { ref_name: { include: ['~ALL'], exclude: ['refs/heads/main'] } },
+    }), false);
+  });
+
+  it('rejects unrelated branches', () => {
+    assert.equal(rulesetTargetsMain({
+      ...base,
+      conditions: { ref_name: { include: ['refs/heads/release/*'], exclude: [] } },
+    }), false);
+  });
+
+  it('rejects null and missing fields safely', () => {
+    assert.equal(rulesetTargetsMain(null), false);
+    assert.equal(rulesetTargetsMain({}), false);
+    assert.equal(rulesetTargetsMain({ enforcement: 'active', target: 'branch' }), false);
   });
 });


### PR DESCRIPTION
## Summary

Closes a false negative in `pnpm task:doctor` where the legacy GitHub
`/branches/main/protection` endpoint returns 404 on repos using the new
Ruleset model. The doctor now also inspects `/repos/.../rulesets` and
refetches each candidate to detect any active branch ruleset targeting `main`.

## AC vs code reality check

- [x] Verified the active ruleset on this repo (`Protect Main`, id 15973362, target `branch`, condition `~DEFAULT_BRANCH`).
- [x] `pnpm task:doctor` now prints `✓ main protection: active via ruleset "Protect Main"`.
- [x] Phase 2 gate no longer reports branch protection as a blocker.

## Test plan

- [x] `pnpm task:test` — 76/76 pass.
- [x] `pnpm task:doctor` — live verified.

## Risk and autonomy

- Risk: `risk:safe`
- Autonomy: `ai:autonomous`