### PR TITLE
feat(local-control): secure local cockpit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ coverage/
 apps/e2e/test-results/
 apps/e2e/playwright-report/
 apps/e2e/blob-report/
+
+# local-control runtime state (auth token, logs)
+.local-control/

--- a/docs/ops/autonomous-claude-code-prompt.md
+++ b/docs/ops/autonomous-claude-code-prompt.md
@@ -156,3 +156,12 @@ Add at the top of the prompt: `Pick task #<N> only.` and skip `task:next`.
 ### Plan-only (no exec)
 
 Replace step 5 with: `pnpm task:run -- --task=<N> --plan-only` and stop after producing the plan.
+
+### Pilotage via cockpit local
+
+Au lieu d'envoyer ce prompt en CLI, lancer le cockpit (`pnpm local:control` → `http://127.0.0.1:8787`) et utiliser :
+- Onglet **Prompt** → preset `plan-next-task` ou `run-one-safe-task`.
+- Onglet **Tasks** → bouton **Plan** sur l'issue ciblée.
+- Onglet **Logs** pour suivre en temps réel via SSE.
+
+Doc : `docs/ops/local-control-panel.md`.

--- a/docs/ops/first-autonomous-run.md
+++ b/docs/ops/first-autonomous-run.md
@@ -154,3 +154,15 @@ If a task is stuck mid-execution:
 2. Issue stays in "In Progress" or moves to "Blocked" via `pnpm project:status:blocked N`.
 3. Next session can either pick up the same task (`pnpm task:run -- --task=N`) or move on.
 4. Stale branches accumulate — clean weekly with `pnpm clean_gone` (already in `commit-commands` skill) or manually.
+
+## Cockpit local (UI)
+
+Pour piloter via interface au lieu de CLI :
+
+```bash
+pnpm local:control
+# ouvre http://127.0.0.1:8787
+# token : .local-control/settings.json (chmod 600, généré au premier run)
+```
+
+Détails : `docs/ops/local-control-panel.md`. Téléphone : `docs/ops/local-control-phone.md`.

--- a/docs/ops/local-control-panel.md
+++ b/docs/ops/local-control-panel.md
@@ -1,0 +1,62 @@
+# Local Control Panel — Cockpit Local
+
+Cockpit web local pour piloter Claude Code en mode semi-autonome sur WebAppV1.
+
+## Architecture
+
+- **Backend** : `tools/local-control/server.mjs` (responsabilité de Claude A — non inclus dans cette PR).
+- **Frontend** : `tools/local-control/public/` — HTML + JS modules ESM, zéro dépendance, servi statiquement par le backend.
+- **Contrat API** : `tools/local-control/api-contract.json` (côté UI). À aligner avec l'implémentation backend.
+- **Bind par défaut** : `127.0.0.1` (loopback). LAN désactivé par défaut.
+
+## Pages
+
+| Pane       | Rôle |
+|------------|------|
+| Dashboard  | branche, git status, doctor, protection main, phase gates, compteurs, dernier run |
+| Tasks      | table issues exécutables — score, classification, risk, autonomy ; boutons Plan / Run |
+| Runner     | démarrer un run plan/exec/loop avec garde-fous |
+| Prompt     | prompt libre + presets (plan-next, run-one-safe, loop-safe, resume-after-answer, analyze-blockage) |
+| Logs       | flux SSE temps réel + historique runs |
+| Questions  | questions humaines en attente — réponse renvoyée vers GitHub via n8n |
+| Settings   | maxPRs, maxMinutes, dry-run, allowExec, allowLoop, allowAutoMerge, staleDays, allowed labels/risk/autonomy |
+
+## Lancer
+
+Backend (Claude A — quand prêt) :
+
+```bash
+node tools/local-control/server.mjs
+# par défaut http://127.0.0.1:8787
+```
+
+Ouvre le navigateur sur `http://127.0.0.1:8787`. L'UI est servie depuis `tools/local-control/public/`.
+
+## Tester l'UI seule (sans backend)
+
+Tu peux servir le dossier statique pour valider le rendu :
+
+```bash
+npx serve tools/local-control/public
+```
+
+Les appels API échoueront (pas de serveur), mais le layout, la navigation, les confirmations et les validations fonctionnent.
+
+## Tests JS
+
+```bash
+node --test tools/local-control/tests/
+```
+
+Couvre :
+- redaction côté client
+- validation formulaires runner / settings
+- client API (fetch mocké)
+
+## Sécurité
+
+Voir `docs/ops/local-control-security.md`.
+
+## Téléphone
+
+Voir `docs/ops/local-control-phone.md`.

--- a/docs/ops/local-control-phone.md
+++ b/docs/ops/local-control-phone.md
@@ -1,0 +1,48 @@
+# Local Control — Accès Téléphone
+
+L'UI est responsive et utilisable depuis un téléphone tant que l'appareil est sur le **même réseau Wi-Fi** que la machine de Yume.
+
+## Activer le mode LAN
+
+Par défaut, le backend écoute sur `127.0.0.1` (loopback) — invisible depuis le téléphone.
+
+Pour ouvrir au LAN :
+1. Modifier la config backend (Claude A) → `lan.enabled = true`, bind `0.0.0.0`.
+2. Redémarrer le serveur.
+3. L'UI affiche un badge `LAN` orange en haut à droite.
+
+## Trouver l'IP locale du Mac
+
+```bash
+ipconfig getifaddr en0      # Wi-Fi
+ipconfig getifaddr en1      # Ethernet (selon machine)
+```
+
+Exemple : `192.168.1.42` → ouvrir sur le téléphone : `http://192.168.1.42:8787`.
+
+## QR code (optionnel)
+
+Le backend peut afficher un QR au démarrage (Claude A — à confirmer) :
+
+```
+URL: http://192.168.1.42:8787
+[QR]
+```
+
+## UX mobile
+
+L'UI applique automatiquement le breakpoint `720px` :
+- onglets horizontaux scrollables ;
+- cartes Dashboard sur 2 colonnes (1 colonne <420px) ;
+- formulaires en pleine largeur ;
+- boutons hauteur min 44px (cible tactile iOS) ;
+- vue logs réduite à 50vh, polices monospace plus petites.
+
+## Recommandations
+
+- N'active LAN que **temporairement** quand tu es loin du Mac.
+- Coupe le LAN dès que tu n'en as plus besoin.
+- Pose toujours un token bearer dans les settings backend si LAN activé.
+- Ne lance jamais `auto-merge` ni `loop` depuis le téléphone sans avoir vu un run réussir en local d'abord.
+
+Voir aussi : `docs/ops/local-control-security.md`.

--- a/docs/ops/local-control-security.md
+++ b/docs/ops/local-control-security.md
@@ -1,0 +1,57 @@
+# Local Control — Sécurité
+
+Le cockpit local pilote Claude Code, lit le repo, lance des commandes shell, peut créer des PR et merger. Surface d'attaque à prendre au sérieux.
+
+## Principes
+
+1. **Loopback par défaut.** Backend bind `127.0.0.1`. LAN nécessite opt-in explicite + warning UI.
+2. **Pas de secrets dans le navigateur.** Aucun token API jamais envoyé au client. Le backend redige les logs avant de les pousser via SSE.
+3. **Redaction défense en profondeur.** L'UI re-redige tout ce qu'elle reçoit (`tools/local-control/public/lib/redact.js`).
+4. **Confirmations fortes.** Toute action destructrice (exec/loop/auto-merge) demande de taper un mot magique (`EXEC`, `LOOP`, `AUTOMERGE`).
+5. **Whitelist labels/risk/autonomy.** Settings imposent une liste autorisée — runner refuse si une issue n'y rentre pas.
+6. **Auto-merge protégé.** Le backend exige header `X-Confirm-AutoMerge: yes` ET `allowAutoMerge=true` ET dry-run désactivé.
+
+## Modes opérationnels
+
+| Mode      | Effet réseau | Auto-merge | Loop | Recommandation |
+|-----------|--------------|------------|------|----------------|
+| Dry-run   | Loopback     | jamais     | jamais | défaut quotidien |
+| Live      | Loopback     | si activé  | si activé | session supervisée |
+| LAN       | Réseau local | déconseillé | déconseillé | usage temporaire téléphone |
+
+## Badges UI
+
+- `DRY-RUN` (vert) : aucune action destructrice possible.
+- `LIVE` (orange) : actions réelles.
+- `LAN` (orange) : accessible depuis le réseau local.
+- `AUTO-MERGE` (rouge) : PR fusionnés automatiquement.
+
+## Token bearer (LAN)
+
+Si LAN activé, exiger un token :
+
+```jsonc
+// settings.local.json côté backend
+{
+  "localControl": {
+    "lan": { "enabled": true, "host": "0.0.0.0", "port": 7878 },
+    "token": "<random 32+ chars>"
+  }
+}
+```
+
+L'UI le lit depuis `localStorage.localControlToken` ou un prompt au premier accès.
+
+## Liste de contrôle avant `Live`
+
+- [ ] Branche propre ou backup poussé.
+- [ ] `task:doctor` vert.
+- [ ] Settings pose `dryRunDefault=false` consciemment.
+- [ ] `allowAutoMerge` désactivé sauf nécessité documentée.
+- [ ] Logs en cours de visionnage.
+
+## Risques résiduels
+
+- Backend peut exécuter du shell — un attaquant local sur la machine peut tout faire de toute manière.
+- LAN expose à tous les appareils du Wi-Fi local — utiliser un Wi-Fi de confiance.
+- Si le repo contient un hook git malveillant, lancer `task-runner` peut l'exécuter. Mitiger via revue git régulière.

--- a/docs/ops/notion-whatsapp-live.md
+++ b/docs/ops/notion-whatsapp-live.md
@@ -1,0 +1,94 @@
+# Notion + WhatsApp + n8n — Pipeline live
+
+Pipeline complet pour les questions humaines posées par Claude Code pendant un run autonome.
+
+```
+Claude Code ──(GitHub comment label:claude-question)──▶ GitHub Issue
+                                                            │
+                                                            ▼
+                                              n8n (poll GitHub or webhook)
+                                                            │
+                                              mirror question → Notion DB Questions
+                                                            │
+                                                            ▼
+                                              n8n → WhatsApp notif (Yume)
+                                                            │
+                                              Yume répond dans Notion
+                                                            │
+                                                            ▼
+                                              n8n (Notion changement → GitHub)
+                                              poste comment label:claude-answer
+                                                            │
+                                                            ▼
+                                              task-runner detect réponse
+                                              resume issue
+```
+
+## Pré-requis
+
+- Notion DB Questions : `scripts/notion/questions-schema.md` (déjà documenté).
+- n8n cloud : `yumeee.app.n8n.cloud`.
+- Workflows n8n : 
+  - `scripts/n8n/webappv1-question-to-whatsapp.json`
+  - `scripts/n8n/webappv1-notion-answer-to-github.json`
+- GitHub PAT scope `repo` (réservé à n8n).
+- Notion integration token (lecture/écriture sur DB Questions).
+- WhatsApp Cloud API ou bridge Twilio.
+
+## Variables n8n (placeholders)
+
+Aucun secret réel n'est commité. Définir dans n8n :
+
+| Var | Description |
+|-----|-------------|
+| `GITHUB_TOKEN` | PAT scope `repo` |
+| `GITHUB_OWNER` | `Yuume2` |
+| `GITHUB_REPO` | `WebAppV1` |
+| `NOTION_TOKEN` | integration token |
+| `NOTION_DB_QUESTIONS` | id DB Questions |
+| `WA_PHONE_ID` | WhatsApp Business phone id |
+| `WA_TOKEN` | Cloud API token |
+| `WA_TO` | numéro Yume au format E.164 |
+
+## Schéma DB Notion Questions
+
+Voir `scripts/notion/questions-schema.md`. Champs minimum :
+
+- `Issue` (number)
+- `Question` (rich text)
+- `Options` (multi-select)
+- `Recommendation` (rich text)
+- `Status` (select : open / answered / applied)
+- `Answer` (rich text)
+- `AnsweredAt` (date)
+- `IssueUrl` (url)
+
+## Synchronisation locale
+
+Outils existants :
+- `scripts/notion/sync-questions.mjs` — bridge bidirectionnel manuel/CLI.
+- `tools/task-questions.mjs` — list/extract questions depuis GitHub.
+
+Le cockpit local affiche les questions via `/api/questions` qui consomme la même source. Quand Yume répond depuis le cockpit, l'API backend crée le commentaire `claude-answer` directement (pas besoin de passer par Notion). Notion reste utile pour répondre **depuis le téléphone hors LAN**.
+
+## Test du pipeline (sans secrets)
+
+1. Importer les workflows dans n8n.
+2. Définir des credentials de test (sandbox WhatsApp, Notion DB de dev).
+3. Créer une issue manuelle avec label `claude-question` et un commentaire formaté.
+4. Vérifier la réception WhatsApp.
+5. Répondre dans Notion.
+6. Vérifier le commentaire `claude-answer` posté sur l'issue.
+
+## Sécurité
+
+- Secrets uniquement dans n8n (jamais dans le repo).
+- Token GitHub n8n distinct de celui de Claude Code.
+- DB Notion privée (pas de share public).
+- WhatsApp template approuvé pour les notifications hors fenêtre 24h.
+
+## États dégradés
+
+- n8n down : Claude Code peut tout de même attendre une réponse via le cockpit local.
+- WhatsApp rate-limited : Yume voit la question dans Notion ou directement dans GitHub.
+- Notion down : fallback = répondre directement sur l'issue GitHub avec label `claude-answer`.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
     "task:run": "node tools/task-runner.mjs",
     "task:run:plan": "node tools/task-runner.mjs --plan-only",
     "task:doctor": "node tools/task-doctor.mjs",
+    "local:control": "node tools/local-control/server.mjs",
+    "local:control:lan": "node tools/local-control/server.mjs --lan",
+    "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs",
+    "local:control:ui:test": "node --test tools/local-control/tests/",
     "task:test": "node --test tools/task-meta.test.mjs tools/task-deps.test.mjs tools/task-guard.test.mjs tools/task-questions.test.mjs tools/task-runner.test.mjs tools/task-doctor.test.mjs tools/apply-issue-delta.test.mjs tools/issue-status.test.mjs",
     "task:lint:test": "node --test tools/apply-issue-delta.test.mjs",
     "task:deps:test": "node --test tools/task-deps.test.mjs"

--- a/tools/local-control/api-contract.json
+++ b/tools/local-control/api-contract.json
@@ -1,0 +1,187 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Local Control API Contract",
+  "version": "1.0.0",
+  "status": "Aligned with tools/local-control/server.mjs",
+  "transport": "HTTP + Server-Sent Events for live logs",
+  "baseUrl": "http://127.0.0.1:8787",
+  "auth": {
+    "mode": "loopback-only by default; LAN requires settings.lanEnabled = true",
+    "token": "auto-generated in .local-control/settings.json (authToken). All /api/* requests require it once set; backend runs open if no token configured.",
+    "header": "Authorization: Bearer <token>",
+    "queryFallback": "?token=<token> for SSE (EventSource cannot send headers)"
+  },
+  "endpoints": [
+    {
+      "method": "GET",
+      "path": "/api/status",
+      "alias": "/api/health",
+      "returns": {
+        "ok": "boolean",
+        "version": "string",
+        "branch": "string|null",
+        "dirty": "boolean",
+        "activeRunId": "string|null",
+        "uptimeSeconds": "number",
+        "uptimeSec": "number"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/dashboard",
+      "returns": {
+        "branch": "string|null",
+        "gitStatus": { "clean": "boolean", "ahead": "number", "behind": "number", "files": "string[]" },
+        "doctor": { "ok": "boolean|null", "phase": "1|2|3|null", "blockers": "string[]", "checkedAt": "isoDate|null" },
+        "mainProtection": { "enabled": "boolean|null", "type": "branch_protection|ruleset|none|unknown", "checks": "string[]" },
+        "phaseGates": { "phase1": "ok|blocked|unknown", "phase2": "ok|blocked|unknown", "phase3": "ok|blocked|unknown" },
+        "openIssues": "number|null",
+        "autonomousTasks": "number|null",
+        "pendingQuestions": "number|null",
+        "latestRun": { "id": "string|null", "status": "idle|running|done|error", "startedAt": "isoDate|null", "endedAt": "isoDate|null" },
+        "activeRunId": "string|null"
+      }
+    },
+    {
+      "method": "GET",
+      "path": "/api/settings",
+      "returns": {
+        "maxPrsPerRun": "number (1-10)",
+        "maxMinutes": "number (1-240)",
+        "dryRunDefault": "boolean",
+        "allowExec": "boolean",
+        "allowLoop": "boolean",
+        "allowAutoMerge": "boolean",
+        "allowedRisk": "string[]",
+        "allowedAutonomy": "string[]",
+        "staleDays": "number (0-365)",
+        "preferredIssue": "number|null",
+        "lanEnabled": "boolean"
+      }
+    },
+    {
+      "method": "POST",
+      "path": "/api/settings",
+      "alias": "PUT /api/settings",
+      "body": "Partial<Settings> (authToken not patchable)",
+      "returns": "Settings (authToken stripped)"
+    },
+    {
+      "method": "POST",
+      "path": "/api/command",
+      "body": { "name": "string (whitelisted)", "args": "string[]" },
+      "returns": { "runId": "string", "name": "string", "args": "string[]" },
+      "errors": ["422 invalid command/args", "409 a run is already active"]
+    },
+    {
+      "method": "POST",
+      "path": "/api/run/plan",
+      "body": { "issue": "number" },
+      "returns": { "runId": "string" }
+    },
+    {
+      "method": "POST",
+      "path": "/api/run/start",
+      "body": { "issue": "number", "dryRun": "boolean (default settings.dryRunDefault)" },
+      "returns": { "runId": "string", "dryRun": "boolean" },
+      "notes": "Real execution not yet wired. Returns 403 unless dryRun=true."
+    },
+    {
+      "method": "POST",
+      "path": "/api/run/stop",
+      "alias": "/api/runner/stop",
+      "body": { "runId": "string|null" },
+      "returns": { "ok": "boolean", "stopped": "boolean" }
+    },
+    {
+      "method": "POST",
+      "path": "/api/runner/start",
+      "body": { "mode": "plan|exec|loop", "issue": "number" },
+      "returns": { "runId": "string", "mode": "plan|plan-fallback" },
+      "notes": "exec/loop currently fallback to plan unless allowExec/allowLoop set."
+    },
+    {
+      "method": "POST",
+      "path": "/api/doctor/run",
+      "returns": { "runId": "string" },
+      "stream": "/api/runs/:runId/events"
+    },
+    {
+      "method": "POST",
+      "path": "/api/prompt",
+      "body": { "preset": "plan-next|run-one-safe|loop-safe|resume-after-answer|analyze-blockage|null" },
+      "returns": { "runId": "string", "preset": "string|null" }
+    },
+    {
+      "method": "GET",
+      "path": "/api/tasks",
+      "returns": { "items": "TaskQueueItem[]" }
+    },
+    {
+      "method": "POST",
+      "path": "/api/tasks/:issue/plan",
+      "returns": { "runId": "string" }
+    },
+    {
+      "method": "GET",
+      "path": "/api/runs",
+      "returns": { "items": "RunSummary[]" }
+    },
+    {
+      "method": "GET",
+      "path": "/api/runs/:runId",
+      "returns": { "id": "string", "status": "running|done|error", "stdout": "string", "stderr": "string", "exitCode": "number|null" }
+    },
+    {
+      "method": "GET",
+      "path": "/api/runs/:runId/events",
+      "transport": "SSE",
+      "events": ["log", "exit"],
+      "auth": "bearer header OR ?token=<token> query"
+    },
+    {
+      "method": "GET",
+      "path": "/api/logs/:runId",
+      "transport": "SSE",
+      "events": ["log", "exit"]
+    },
+    {
+      "method": "GET",
+      "path": "/api/questions",
+      "returns": "QuestionItem[]"
+    },
+    {
+      "method": "POST",
+      "path": "/api/questions/answer",
+      "body": { "id": "string", "answer": "string (1-8000)" },
+      "returns": { "ok": "boolean", "runId": "string|null" }
+    },
+    {
+      "method": "POST",
+      "path": "/api/questions/:id/answer",
+      "body": { "answer": "string (1-8000)" },
+      "returns": { "ok": "boolean" }
+    },
+    {
+      "method": "POST",
+      "path": "/api/automerge/check",
+      "body": { "pr": "number" },
+      "returns": "AutoMergeReport"
+    },
+    {
+      "method": "POST",
+      "path": "/api/automerge/apply",
+      "body": { "pr": "number" },
+      "returns": "AutoMergeReport (with applied:boolean)",
+      "errors": ["403 allowAutoMerge disabled"]
+    }
+  ],
+  "redaction": {
+    "rule": "Server redacts secrets via tools/local-control/safety.mjs (gh*/sk-/AKIA/Bearer/*_TOKEN/_SECRET/_KEY/_PASSWORD env values) plus the live authToken before any payload returns to the UI."
+  },
+  "notes": [
+    "All long-running ops return a runId; UI subscribes to SSE for live logs.",
+    "Default bind 127.0.0.1. LAN mode requires settings.lanEnabled = true; --lan ignored otherwise.",
+    "Auth token lives in .local-control/settings.json (chmod 600). The directory is gitignored."
+  ]
+}

--- a/tools/local-control/auth.mjs
+++ b/tools/local-control/auth.mjs
@@ -1,0 +1,24 @@
+import { timingSafeEqual } from 'node:crypto';
+
+export function extractToken(req) {
+  const h = req.headers['authorization'];
+  if (typeof h === 'string' && h.startsWith('Bearer ')) return h.slice(7).trim();
+  const url = new URL(req.url, 'http://localhost');
+  const q = url.searchParams.get('token');
+  if (q) return q.trim();
+  return null;
+}
+
+export function constantTimeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  try { return timingSafeEqual(ab, bb); } catch { return false; }
+}
+
+export function isAuthenticated(req, expectedToken) {
+  const t = extractToken(req);
+  if (!t || !expectedToken) return false;
+  return constantTimeEqual(t, expectedToken);
+}

--- a/tools/local-control/automerge.mjs
+++ b/tools/local-control/automerge.mjs
@@ -1,0 +1,112 @@
+import { spawnSync } from 'node:child_process';
+import { isSensitivePath } from './safety.mjs';
+
+const SMALL_DIFF_MAX_LINES = 400;
+const SMALL_DIFF_MAX_FILES = 25;
+
+function gh(args) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 });
+  return { code: r.status ?? 1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+function ghJson(args) {
+  const r = gh(args);
+  if (r.code !== 0) return null;
+  try { return JSON.parse(r.stdout); } catch { return null; }
+}
+
+export function fetchPrContext(pr) {
+  const data = ghJson(['pr', 'view', String(pr), '--json',
+    'number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,files,labels,headRefName,baseRefName,closingIssuesReferences,reviews,additions,deletions',
+  ]);
+  return data;
+}
+export function fetchIssueLabels(issueNumber) {
+  const data = ghJson(['issue', 'view', String(issueNumber), '--json', 'labels,number,state']);
+  return data;
+}
+export function fetchBranchProtection(repoNameWithOwner, branch) {
+  const direct = gh(['api', `repos/${repoNameWithOwner}/branches/${branch}/protection`]);
+  if (direct.code === 0) return { protected: true, source: 'classic' };
+  const rulesets = ghJson(['api', `repos/${repoNameWithOwner}/rulesets`]);
+  if (Array.isArray(rulesets) && rulesets.length) return { protected: true, source: 'ruleset' };
+  return { protected: false, source: null };
+}
+export function runTaskGuard(repoRoot, headRef) {
+  const r = spawnSync('node', ['tools/task-guard.mjs', '--base', `origin/${headRef ?? 'main'}`, '--json'], {
+    cwd: repoRoot, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024,
+  });
+  if (r.status !== 0 && r.status !== 1) return { ok: false, allow: false, reason: 'guard error' };
+  try {
+    const j = JSON.parse(r.stdout);
+    return { ok: true, allow: j.allow === true, violations: j.violations ?? [] };
+  } catch {
+    return { ok: false, allow: false, reason: 'guard parse error' };
+  }
+}
+
+export function evaluateAutoMerge({ pr, settings, prData, issueLabels, branchProtection, guardResult, repoSensitivePathFn = isSensitivePath }) {
+  const reasons = [];
+  const checks = {
+    ciGreen: false,
+    linkedIssue: null,
+    issueLabels: [],
+    branchProtection: false,
+    guardAllow: false,
+    smallDiff: false,
+    noSensitivePaths: false,
+    noChangesRequested: false,
+  };
+  if (!settings?.allowAutoMerge) reasons.push('allowAutoMerge disabled in settings');
+  if (!prData) { reasons.push('PR data unavailable'); return { pr, eligible: false, applied: false, reasons, checks }; }
+  if (prData.state !== 'OPEN') reasons.push(`PR not OPEN (state=${prData.state})`);
+  if (prData.isDraft) reasons.push('PR is draft');
+
+  const rollup = Array.isArray(prData.statusCheckRollup) ? prData.statusCheckRollup : [];
+  const failed = rollup.filter((c) => {
+    const conc = c.conclusion ?? c.state ?? '';
+    return ['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(conc);
+  });
+  const pending = rollup.filter((c) => {
+    const status = c.status ?? c.state ?? '';
+    return ['IN_PROGRESS', 'QUEUED', 'PENDING', 'WAITING'].includes(status);
+  });
+  checks.ciGreen = rollup.length > 0 && failed.length === 0 && pending.length === 0;
+  if (!checks.ciGreen) reasons.push('CI not green');
+
+  const linked = Array.isArray(prData.closingIssuesReferences) ? prData.closingIssuesReferences[0] : null;
+  checks.linkedIssue = linked?.number ?? null;
+  if (!checks.linkedIssue) reasons.push('PR has no linked issue');
+
+  const labels = (issueLabels?.labels ?? []).map((l) => l.name);
+  checks.issueLabels = labels;
+  if (!labels.includes('ai:autonomous')) reasons.push('issue missing ai:autonomous label');
+  if (!labels.includes('risk:safe')) reasons.push('issue missing risk:safe label');
+
+  checks.branchProtection = !!branchProtection?.protected;
+  if (!checks.branchProtection) reasons.push('branch protection not detected');
+
+  checks.guardAllow = !!guardResult?.allow;
+  if (!checks.guardAllow) reasons.push('task-guard did not ALLOW');
+
+  const files = Array.isArray(prData.files) ? prData.files : [];
+  const totalLines = (prData.additions ?? 0) + (prData.deletions ?? 0);
+  checks.smallDiff = files.length <= SMALL_DIFF_MAX_FILES && totalLines <= SMALL_DIFF_MAX_LINES;
+  if (!checks.smallDiff) reasons.push(`diff too large (${files.length} files, ${totalLines} lines)`);
+
+  const sensitiveHits = files.map((f) => f.path).filter((p) => p && repoSensitivePathFn(p));
+  checks.noSensitivePaths = sensitiveHits.length === 0;
+  if (!checks.noSensitivePaths) reasons.push(`sensitive paths touched: ${sensitiveHits.slice(0, 3).join(', ')}`);
+
+  const reviews = Array.isArray(prData.reviews) ? prData.reviews : [];
+  const changesRequested = reviews.some((r) => r.state === 'CHANGES_REQUESTED');
+  checks.noChangesRequested = !changesRequested;
+  if (changesRequested) reasons.push('a reviewer requested changes');
+
+  const eligible = reasons.length === 0;
+  return { pr, eligible, applied: false, reasons, checks };
+}
+
+export function applyAutoMerge(pr) {
+  const r = gh(['pr', 'merge', String(pr), '--squash', '--delete-branch']);
+  return { ok: r.code === 0, stdout: r.stdout, stderr: r.stderr };
+}

--- a/tools/local-control/automerge.test.mjs
+++ b/tools/local-control/automerge.test.mjs
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateAutoMerge } from './automerge.mjs';
+
+const goodSettings = { allowAutoMerge: true };
+const goodPr = {
+  state: 'OPEN',
+  isDraft: false,
+  statusCheckRollup: [{ conclusion: 'SUCCESS', status: 'COMPLETED' }],
+  closingIssuesReferences: [{ number: 42 }],
+  files: [{ path: 'apps/web/src/foo.tsx' }],
+  additions: 30, deletions: 5,
+  headRefName: 'feat/foo', baseRefName: 'main',
+  reviews: [{ state: 'APPROVED' }],
+};
+const goodLabels = { labels: [{ name: 'ai:autonomous' }, { name: 'risk:safe' }] };
+const goodProtection = { protected: true };
+const goodGuard = { allow: true };
+
+test('all-good PR is eligible', () => {
+  const r = evaluateAutoMerge({
+    pr: 1, settings: goodSettings, prData: goodPr,
+    issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard,
+  });
+  assert.equal(r.eligible, true);
+  assert.deepEqual(r.reasons, []);
+});
+
+test('refuses if allowAutoMerge disabled', () => {
+  const r = evaluateAutoMerge({
+    pr: 1, settings: { allowAutoMerge: false }, prData: goodPr,
+    issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard,
+  });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /allowAutoMerge/.test(s)));
+});
+
+test('refuses if CI failed', () => {
+  const pr = { ...goodPr, statusCheckRollup: [{ conclusion: 'FAILURE' }] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /CI not green/.test(s)));
+});
+
+test('refuses if no linked issue', () => {
+  const pr = { ...goodPr, closingIssuesReferences: [] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: null, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /no linked issue/.test(s)));
+});
+
+test('refuses if missing ai:autonomous label', () => {
+  const labels = { labels: [{ name: 'risk:safe' }] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: goodPr, issueLabels: labels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /ai:autonomous/.test(s)));
+});
+
+test('refuses if missing risk:safe label', () => {
+  const labels = { labels: [{ name: 'ai:autonomous' }] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: goodPr, issueLabels: labels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /risk:safe/.test(s)));
+});
+
+test('refuses if branch protection missing', () => {
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: goodPr, issueLabels: goodLabels, branchProtection: { protected: false }, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /branch protection/.test(s)));
+});
+
+test('refuses if task-guard blocks', () => {
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: goodPr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: { allow: false } });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /task-guard/.test(s)));
+});
+
+test('refuses if diff is large', () => {
+  const pr = { ...goodPr, additions: 500, deletions: 100 };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /diff too large/.test(s)));
+});
+
+test('refuses if sensitive path touched', () => {
+  const pr = { ...goodPr, files: [{ path: 'apps/api/db/migrations/0001.sql' }] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /sensitive paths/.test(s)));
+});
+
+test('refuses if changes requested', () => {
+  const pr = { ...goodPr, reviews: [{ state: 'CHANGES_REQUESTED' }] };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /requested changes/.test(s)));
+});
+
+test('refuses draft PR', () => {
+  const pr = { ...goodPr, isDraft: true };
+  const r = evaluateAutoMerge({ pr: 1, settings: goodSettings, prData: pr, issueLabels: goodLabels, branchProtection: goodProtection, guardResult: goodGuard });
+  assert.equal(r.eligible, false);
+  assert.ok(r.reasons.some((s) => /draft/.test(s)));
+});

--- a/tools/local-control/commands.mjs
+++ b/tools/local-control/commands.mjs
@@ -1,0 +1,54 @@
+// commands.mjs — strict whitelist of commands the local-control server may run.
+// Each entry defines: bin, fixedArgs (always passed), argSpec (extra args constraints),
+// kind (logical category), and a stable name.
+
+const PNPM = 'pnpm';
+const GIT  = 'git';
+
+export const COMMANDS = Object.freeze({
+  'task:doctor':         { bin: PNPM, fixedArgs: ['task:doctor'],            kind: 'command', extraArgs: 'none' },
+  'task:score':          { bin: PNPM, fixedArgs: ['task:score', '--top', '10'], kind: 'command', extraArgs: 'none' },
+  'task:queue':          { bin: PNPM, fixedArgs: ['task:queue'],             kind: 'command', extraArgs: 'none' },
+  'task:deps':           { bin: PNPM, fixedArgs: ['task:deps'],              kind: 'command', extraArgs: 'none' },
+  'task:next':           { bin: PNPM, fixedArgs: ['task:next'],              kind: 'command', extraArgs: 'none' },
+  'task:stale':          { bin: PNPM, fixedArgs: ['task:stale'],             kind: 'command', extraArgs: 'none' },
+  'task:guard':          { bin: PNPM, fixedArgs: ['task:guard'],             kind: 'command', extraArgs: 'none' },
+  'task:run:plan':       { bin: PNPM, fixedArgs: ['task:run', '--plan-only'],kind: 'plan',    extraArgs: 'issue' },
+  'task:questions:list': { bin: PNPM, fixedArgs: ['task:questions', 'list'], kind: 'command', extraArgs: 'none' },
+  'git:status':          { bin: GIT,  fixedArgs: ['status', '--short'],      kind: 'command', extraArgs: 'none' },
+  'git:branch':          { bin: GIT,  fixedArgs: ['branch', '--show-current'],kind:'command', extraArgs: 'none' },
+  'git:pull':            { bin: GIT,  fixedArgs: ['pull', '--ff-only'],      kind: 'command', extraArgs: 'none' },
+});
+
+const ISSUE_FLAG_RE = /^--issue=(\d{1,6})$/;
+const ISSUE_NUM_RE  = /^\d{1,6}$/;
+
+export function resolveCommand(name, extraArgs = []) {
+  const entry = COMMANDS[name];
+  if (!entry) return { error: `command not whitelisted: ${name}` };
+  const safe = [];
+  if (entry.extraArgs === 'none') {
+    if (extraArgs.length) return { error: `command ${name} accepts no extra args` };
+  } else if (entry.extraArgs === 'issue') {
+    let issue = null;
+    for (const a of extraArgs) {
+      if (typeof a !== 'string') return { error: 'all args must be strings' };
+      const m = a.match(ISSUE_FLAG_RE);
+      if (m) { issue = Number(m[1]); continue; }
+      if (ISSUE_NUM_RE.test(a)) { issue = Number(a); continue; }
+      return { error: `arg not allowed: ${a}` };
+    }
+    if (issue == null) return { error: `command ${name} requires --issue=<n>` };
+    safe.push(`--issue=${issue}`);
+  }
+  return {
+    bin: entry.bin,
+    args: [...entry.fixedArgs, ...safe],
+    kind: entry.kind,
+    name,
+  };
+}
+
+export function listCommands() {
+  return Object.keys(COMMANDS);
+}

--- a/tools/local-control/commands.test.mjs
+++ b/tools/local-control/commands.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCommand, listCommands, COMMANDS } from './commands.mjs';
+
+test('rejects non-whitelisted command', () => {
+  const r = resolveCommand('rm', ['-rf', '/']);
+  assert.ok(r.error);
+});
+
+test('resolves task:doctor with no extra args', () => {
+  const r = resolveCommand('task:doctor', []);
+  assert.equal(r.bin, 'pnpm');
+  assert.deepEqual(r.args, ['task:doctor']);
+});
+
+test('rejects extra args for argless command', () => {
+  const r = resolveCommand('task:doctor', ['--evil']);
+  assert.ok(r.error);
+});
+
+test('task:run:plan requires issue arg', () => {
+  const r = resolveCommand('task:run:plan', []);
+  assert.ok(r.error);
+});
+
+test('task:run:plan accepts numeric issue', () => {
+  const r = resolveCommand('task:run:plan', ['42']);
+  assert.deepEqual(r.args, ['task:run', '--plan-only', '--issue=42']);
+});
+
+test('task:run:plan accepts --issue=N', () => {
+  const r = resolveCommand('task:run:plan', ['--issue=7']);
+  assert.deepEqual(r.args, ['task:run', '--plan-only', '--issue=7']);
+});
+
+test('task:run:plan rejects non-issue arg', () => {
+  const r = resolveCommand('task:run:plan', ['--exec']);
+  assert.ok(r.error);
+});
+
+test('task:run:plan rejects shell metacharacters', () => {
+  const r = resolveCommand('task:run:plan', ['; rm -rf /']);
+  assert.ok(r.error);
+});
+
+test('git:status uses fixed args', () => {
+  const r = resolveCommand('git:status', []);
+  assert.equal(r.bin, 'git');
+  assert.deepEqual(r.args, ['status', '--short']);
+});
+
+test('listCommands matches COMMANDS keys', () => {
+  assert.deepEqual(listCommands().sort(), Object.keys(COMMANDS).sort());
+});
+
+test('all whitelist entries use pnpm or git', () => {
+  for (const name of listCommands()) {
+    assert.ok(['pnpm', 'git'].includes(COMMANDS[name].bin), `unsafe bin in ${name}`);
+  }
+});

--- a/tools/local-control/logs.mjs
+++ b/tools/local-control/logs.mjs
@@ -1,0 +1,86 @@
+import { existsSync, mkdirSync, createWriteStream, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export class LogStore {
+  constructor(rootDir) {
+    this.dir = resolve(rootDir, '.local-control', 'logs');
+    this.streams = new Map();
+    this.history = new Map();
+  }
+  ensureDir() {
+    if (!existsSync(this.dir)) mkdirSync(this.dir, { recursive: true });
+  }
+  open(runId) {
+    this.ensureDir();
+    const path = resolve(this.dir, `${runId}.log`);
+    const s = createWriteStream(path, { flags: 'a' });
+    this.streams.set(runId, s);
+    this.history.set(runId, []);
+    return s;
+  }
+  append(runId, stream, chunk) {
+    const arr = this.history.get(runId);
+    if (arr) {
+      arr.push({ stream, chunk });
+      if (arr.length > 5000) arr.splice(0, arr.length - 5000);
+    }
+    const s = this.streams.get(runId);
+    if (s && !s.destroyed) {
+      try { s.write(`[${stream}] ${chunk}`); } catch { /* ignore */ }
+    }
+  }
+  close(runId) {
+    const s = this.streams.get(runId);
+    if (s) { try { s.end(); } catch { /* ignore */ } }
+    this.streams.delete(runId);
+  }
+  getHistory(runId) {
+    if (this.history.has(runId)) return this.history.get(runId);
+    const path = resolve(this.dir, `${runId}.log`);
+    if (!existsSync(path)) return [];
+    const txt = readFileSync(path, 'utf8');
+    return txt.split('\n').filter(Boolean).map((line) => {
+      const m = line.match(/^\[(stdout|stderr)\]\s?(.*)$/);
+      if (m) return { stream: m[1], chunk: m[2] + '\n' };
+      return { stream: 'stdout', chunk: line + '\n' };
+    });
+  }
+}
+
+export class StateStore {
+  constructor() {
+    this.runs = new Map();
+    this.subs = new Map();
+  }
+  createRun({ id, name, args, kind }) {
+    const r = { id, name, args, kind, startedAt: new Date().toISOString(), finishedAt: null, exitCode: null };
+    this.runs.set(id, r);
+    return r;
+  }
+  finishRun(id, exitCode) {
+    const r = this.runs.get(id);
+    if (!r) return null;
+    r.finishedAt = new Date().toISOString();
+    r.exitCode = exitCode;
+    return r;
+  }
+  list(limit = 50) {
+    return Array.from(this.runs.values())
+      .sort((a, b) => (a.startedAt < b.startedAt ? 1 : -1))
+      .slice(0, limit);
+  }
+  get(id) { return this.runs.get(id) ?? null; }
+  subscribe(runId, fn) {
+    let set = this.subs.get(runId);
+    if (!set) { set = new Set(); this.subs.set(runId, set); }
+    set.add(fn);
+    return () => { set.delete(fn); if (!set.size) this.subs.delete(runId); };
+  }
+  emit(runId, event, payload) {
+    const set = this.subs.get(runId);
+    if (!set) return;
+    for (const fn of Array.from(set)) {
+      try { fn(event, payload); } catch { /* ignore */ }
+    }
+  }
+}

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -1,0 +1,98 @@
+// WebAppV1 Local Control — UI app
+// Talks to backend at same origin. Backend = tools/local-control/server.mjs (Claude A).
+// All long-running ops return a runId; UI subscribes via SSE.
+
+import { ApiClient } from "./lib/api.js";
+import { redact } from "./lib/redact.js";
+import { state, setMode, setLan, setAutoMerge } from "./lib/state.js";
+import { mountTabs } from "./lib/tabs.js";
+import { renderDashboard } from "./lib/dashboard.js";
+import { renderTasks } from "./lib/tasks.js";
+import { mountRunner } from "./lib/runner.js";
+import { mountPrompt } from "./lib/prompt.js";
+import { mountLogs } from "./lib/logs.js";
+import { renderQuestions } from "./lib/questions.js";
+import { mountSettings } from "./lib/settings.js";
+import { confirmDanger } from "./lib/confirm.js";
+
+const TOKEN_KEY = "localControlToken";
+function bootstrapToken() {
+  const url = new URL(location.href);
+  const fromUrl = url.searchParams.get("token");
+  if (fromUrl) {
+    try { localStorage.setItem(TOKEN_KEY, fromUrl); } catch {}
+    url.searchParams.delete("token");
+    history.replaceState(null, "", url.toString());
+    return fromUrl;
+  }
+  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
+}
+
+const api = new ApiClient({ baseUrl: "", token: bootstrapToken() });
+window.__api = api;
+
+mountTabs();
+mountLogs(api);
+mountRunner(api, { confirmDanger });
+mountPrompt(api);
+mountSettings(api, { onChange: applySettingsToBadges });
+
+async function refreshAll() {
+  try {
+    const [dash, tasks, questions, settings] = await Promise.all([
+      api.get("/api/dashboard"),
+      api.get("/api/tasks?limit=50"),
+      api.get("/api/questions"),
+      api.get("/api/settings"),
+    ]);
+    renderDashboard(dash);
+    renderTasks(tasks.items || [], { api, confirmDanger });
+    renderQuestions(questions.items || [], { api });
+    applySettingsToBadges(settings);
+    setConn(true);
+  } catch (e) {
+    setConn(false);
+    log("⚠ refresh failed: " + redact(String(e.message || e)));
+  }
+}
+
+function setConn(ok) {
+  document.getElementById("conn-dot").classList.toggle("ok", !!ok);
+  document.getElementById("conn-dot").classList.toggle("err", !ok);
+}
+
+function applySettingsToBadges(s) {
+  if (!s) return;
+  setMode(s.dryRunDefault ? "dry" : "live");
+  setLan(!!s.lanEnabled);
+  setAutoMerge(!!s.allowAutoMerge);
+  const modeBadge = document.getElementById("mode-badge");
+  modeBadge.textContent = s.dryRunDefault ? "DRY-RUN" : "LIVE";
+  modeBadge.classList.toggle("dry", s.dryRunDefault);
+  modeBadge.classList.toggle("live", !s.dryRunDefault);
+  document.getElementById("lan-badge").classList.toggle("hidden", !s.lanEnabled);
+  document.getElementById("automerge-badge").classList.toggle("hidden", !s.allowAutoMerge);
+}
+
+function log(line) {
+  const view = document.getElementById("log-view");
+  if (!view) return;
+  view.textContent += line + "\n";
+  if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight;
+}
+
+document.querySelector('[data-action="refresh"]').addEventListener("click", refreshAll);
+document.querySelector('[data-action="doctor"]').addEventListener("click", async () => {
+  const r = await api.post("/api/doctor/run", {});
+  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+});
+document.querySelector('[data-action="score"]').addEventListener("click", () => api.post("/api/tasks/score", {}).catch(() => {}));
+document.querySelector('[data-action="queue"]').addEventListener("click", () => refreshAll());
+document.querySelector('[data-action="plan-next"]').addEventListener("click", async () => {
+  const r = await api.post("/api/runner/start", { mode: "plan", dryRun: true });
+  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+});
+document.querySelector('[data-action="reload-tasks"]').addEventListener("click", refreshAll);
+
+refreshAll();
+setInterval(refreshAll, 15000);

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -1,0 +1,213 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="theme-color" content="#0b0d10" />
+<title>WebAppV1 — Local Control</title>
+<link rel="stylesheet" href="./styles.css" />
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <span class="dot" id="conn-dot" title="connection"></span>
+    <strong>WebAppV1</strong>
+    <span class="muted">Local Control</span>
+  </div>
+  <nav class="tabs" id="tabs">
+    <button data-tab="dashboard" class="active">Dashboard</button>
+    <button data-tab="tasks">Tasks</button>
+    <button data-tab="runner">Runner</button>
+    <button data-tab="prompt">Prompt</button>
+    <button data-tab="logs">Logs</button>
+    <button data-tab="questions">Questions</button>
+    <button data-tab="settings">Settings</button>
+  </nav>
+  <div class="topbar-right">
+    <span id="mode-badge" class="badge dry">DRY-RUN</span>
+    <span id="lan-badge" class="badge hidden warn">LAN</span>
+    <span id="automerge-badge" class="badge hidden danger">AUTO-MERGE</span>
+  </div>
+</header>
+
+<main>
+  <!-- DASHBOARD -->
+  <section data-pane="dashboard" class="pane active">
+    <div class="grid">
+      <div class="card">
+        <h3>Branche</h3>
+        <div id="dash-branch" class="big">—</div>
+        <div id="dash-git" class="muted small">—</div>
+      </div>
+      <div class="card">
+        <h3>Doctor</h3>
+        <div id="dash-doctor" class="big">—</div>
+        <ul id="dash-doctor-blockers" class="small"></ul>
+      </div>
+      <div class="card">
+        <h3>Main protection</h3>
+        <div id="dash-protection" class="big">—</div>
+        <div id="dash-protection-checks" class="small muted">—</div>
+      </div>
+      <div class="card">
+        <h3>Phase gates</h3>
+        <div class="row">
+          <span class="chip" id="gate-1">P1</span>
+          <span class="chip" id="gate-2">P2</span>
+          <span class="chip" id="gate-3">P3</span>
+        </div>
+      </div>
+      <div class="card">
+        <h3>Issues ouverts</h3>
+        <div id="dash-issues" class="big">—</div>
+      </div>
+      <div class="card">
+        <h3>Tâches autonomes</h3>
+        <div id="dash-auto" class="big">—</div>
+      </div>
+      <div class="card">
+        <h3>Questions humaines</h3>
+        <div id="dash-questions" class="big">—</div>
+      </div>
+      <div class="card">
+        <h3>Dernier run</h3>
+        <div id="dash-latest" class="big">—</div>
+        <div id="dash-latest-time" class="small muted">—</div>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button data-action="refresh">Refresh</button>
+      <button data-action="doctor">Run doctor</button>
+      <button data-action="score">Score tasks</button>
+      <button data-action="queue">Queue</button>
+      <button data-action="plan-next" class="primary">Plan next task</button>
+    </div>
+  </section>
+
+  <!-- TASKS -->
+  <section data-pane="tasks" class="pane">
+    <div class="filters">
+      <input id="task-filter" type="search" placeholder="Filtrer titre / labels…" />
+      <select id="task-class">
+        <option value="">Toutes classifications</option>
+        <option>trivial</option><option>safe</option><option>review</option><option>risky</option><option>blocked</option>
+      </select>
+      <button data-action="reload-tasks">Recharger</button>
+    </div>
+    <div class="table-wrap">
+      <table id="tasks-table">
+        <thead>
+          <tr>
+            <th>#</th><th>Titre</th><th>Score</th><th>Classif.</th>
+            <th>Labels</th><th>Risk</th><th>Autonomy</th><th>Raison</th><th>Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- RUNNER -->
+  <section data-pane="runner" class="pane">
+    <form id="runner-form" class="form">
+      <fieldset>
+        <legend>Mode</legend>
+        <label><input type="radio" name="mode" value="plan" checked> Plan</label>
+        <label><input type="radio" name="mode" value="exec"> Exec</label>
+        <label><input type="radio" name="mode" value="loop"> Loop</label>
+      </fieldset>
+
+      <label>Issue # <input type="number" name="issue" min="1" placeholder="ex: 41" /></label>
+      <label>Max PRs <input type="number" name="maxPRs" min="1" max="10" value="3" /></label>
+      <label>Max minutes <input type="number" name="maxMinutes" min="1" max="240" value="20" /></label>
+
+      <label class="check"><input type="checkbox" name="dryRun" checked> Dry-run</label>
+      <label class="check"><input type="checkbox" name="allowExec"> Autoriser exec</label>
+      <label class="check"><input type="checkbox" name="allowLoop"> Autoriser loop</label>
+      <label class="check danger"><input type="checkbox" name="allowAutoMerge"> Autoriser auto-merge</label>
+
+      <div class="actions">
+        <button type="submit" class="primary">Démarrer</button>
+        <button type="button" data-action="stop-runner" class="danger">Stop</button>
+      </div>
+      <p class="warn-line hidden" id="runner-warn"></p>
+    </form>
+  </section>
+
+  <!-- PROMPT -->
+  <section data-pane="prompt" class="pane">
+    <div class="presets">
+      <button data-preset="plan-next-task">Plan next task</button>
+      <button data-preset="run-one-safe-task">Run one safe task</button>
+      <button data-preset="loop-safe-tasks">Loop safe tasks</button>
+      <button data-preset="resume-after-answer">Resume after answer</button>
+      <button data-preset="analyze-blockage">Analyze blockage</button>
+    </div>
+    <textarea id="prompt-text" placeholder="Prompt libre pour Claude Code…" rows="10"></textarea>
+    <div class="actions">
+      <button id="prompt-send" class="primary">Envoyer</button>
+      <button id="prompt-clear">Clear</button>
+    </div>
+  </section>
+
+  <!-- LOGS -->
+  <section data-pane="logs" class="pane">
+    <div class="logs-toolbar">
+      <select id="log-run-select"><option value="">Run en direct</option></select>
+      <button data-action="copy-logs">Copier</button>
+      <button data-action="clear-logs">Vider la vue</button>
+      <label class="check"><input type="checkbox" id="log-autoscroll" checked> Auto-scroll</label>
+    </div>
+    <pre id="log-view" class="log-view" aria-live="polite"></pre>
+  </section>
+
+  <!-- QUESTIONS -->
+  <section data-pane="questions" class="pane">
+    <div id="questions-list"></div>
+    <p class="muted small">Questions postées par Claude. Réponse retournera dans GitHub via n8n.</p>
+  </section>
+
+  <!-- SETTINGS -->
+  <section data-pane="settings" class="pane">
+    <form id="settings-form" class="form">
+      <label>Max PRs / run <input type="number" name="maxPrsPerRun" min="1" max="10" /></label>
+      <label>Max minutes <input type="number" name="maxMinutes" min="1" max="240" /></label>
+      <label>Stale days <input type="number" name="staleDays" min="0" max="365" /></label>
+      <label>Issue préférée <input type="number" name="preferredIssue" min="1" placeholder="ex: 41" /></label>
+      <label class="check"><input type="checkbox" name="dryRunDefault"> Dry-run par défaut</label>
+      <label class="check"><input type="checkbox" name="allowExec"> Autoriser exec</label>
+      <label class="check"><input type="checkbox" name="allowLoop"> Autoriser loop</label>
+      <label class="check danger"><input type="checkbox" name="allowAutoMerge"> Autoriser auto-merge</label>
+      <label class="check"><input type="checkbox" name="lanEnabled"> Activer LAN</label>
+
+      <label>Risk autorisés <input type="text" name="allowedRisk" placeholder="safe" /></label>
+      <label>Autonomy autorisés <input type="text" name="allowedAutonomy" placeholder="autonomous" /></label>
+
+      <fieldset>
+        <legend>LAN</legend>
+        <p class="small muted" id="lan-info">Backend bind <code>127.0.0.1</code> par défaut. Cocher LAN + relancer avec <code>--lan</code> pour ouvrir au réseau local.</p>
+      </fieldset>
+
+      <div class="actions">
+        <button type="submit" class="primary">Enregistrer</button>
+      </div>
+    </form>
+  </section>
+</main>
+
+<dialog id="confirm-dialog">
+  <form method="dialog">
+    <h3 id="confirm-title">Confirmer</h3>
+    <p id="confirm-body"></p>
+    <input id="confirm-input" type="text" placeholder="Tape: CONFIRMER" />
+    <menu>
+      <button value="cancel">Annuler</button>
+      <button id="confirm-ok" value="ok" class="danger">OK</button>
+    </menu>
+  </form>
+</dialog>
+
+<script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/tools/local-control/public/lib/api.js
+++ b/tools/local-control/public/lib/api.js
@@ -1,0 +1,48 @@
+export class ApiClient {
+  constructor({ baseUrl = "", token = null } = {}) {
+    this.baseUrl = baseUrl;
+    this.token = token;
+  }
+  _headers(extra = {}) {
+    const h = { "content-type": "application/json", ...extra };
+    if (this.token) h["authorization"] = `Bearer ${this.token}`;
+    return h;
+  }
+  setToken(t) { this.token = t || null; try { if (t) localStorage.setItem("localControlToken", t); } catch {} }
+  async _fetch(path, opts = {}) {
+    const res = await fetch(this.baseUrl + path, opts);
+    if (res.status === 401) {
+      const t = (typeof window !== "undefined" && window.prompt) ? window.prompt("Token Local Control requis (cf. .local-control/settings.json) :") : null;
+      if (t) {
+        this.setToken(t);
+        const next = { ...opts, headers: this._headers(opts.headers || {}) };
+        return this._fetch(path, next);
+      }
+      throw new Error("401 unauthorized");
+    }
+    if (!res.ok) {
+      let msg = `${res.status} ${res.statusText}`;
+      try { const j = await res.json(); if (j?.error) msg += `: ${j.error}`; } catch {}
+      throw new Error(msg);
+    }
+    const ct = res.headers.get("content-type") || "";
+    return ct.includes("application/json") ? res.json() : res.text();
+  }
+  get(path) { return this._fetch(path, { headers: this._headers() }); }
+  post(path, body) { return this._fetch(path, { method: "POST", headers: this._headers(), body: JSON.stringify(body || {}) }); }
+  put(path, body) { return this._fetch(path, { method: "PUT", headers: this._headers(), body: JSON.stringify(body || {}) }); }
+  del(path) { return this._fetch(path, { method: "DELETE", headers: this._headers() }); }
+
+  subscribe(runId, { onLog, onStatus, onDone, onError } = {}) {
+    const q = this.token ? `?token=${encodeURIComponent(this.token)}` : "";
+    const url = `${this.baseUrl}/api/runs/${encodeURIComponent(runId)}/events${q}`;
+    const es = new EventSource(url);
+    if (onLog) es.addEventListener("log", (e) => onLog(safeJson(e.data)));
+    if (onStatus) es.addEventListener("status", (e) => onStatus(safeJson(e.data)));
+    if (onDone) es.addEventListener("done", (e) => { onDone(safeJson(e.data)); es.close(); });
+    if (onError) es.addEventListener("error", (e) => onError(e));
+    return es;
+  }
+}
+
+function safeJson(s) { try { return JSON.parse(s); } catch { return s; } }

--- a/tools/local-control/public/lib/confirm.js
+++ b/tools/local-control/public/lib/confirm.js
@@ -1,0 +1,20 @@
+export function confirmDanger({ title = "Confirmer", body = "", magicWord = "CONFIRMER" }) {
+  return new Promise((resolve) => {
+    const dlg = document.getElementById("confirm-dialog");
+    if (!dlg) { resolve(window.confirm(title + "\n" + body)); return; }
+    document.getElementById("confirm-title").textContent = title;
+    document.getElementById("confirm-body").textContent = body;
+    const input = document.getElementById("confirm-input");
+    input.value = "";
+    input.placeholder = "Tape: " + magicWord;
+    const okBtn = document.getElementById("confirm-ok");
+    const onClose = () => {
+      dlg.removeEventListener("close", onClose);
+      resolve(dlg.returnValue === "ok" && input.value === magicWord);
+    };
+    dlg.addEventListener("close", onClose);
+    okBtn.disabled = true;
+    input.oninput = () => { okBtn.disabled = input.value !== magicWord; };
+    dlg.showModal();
+  });
+}

--- a/tools/local-control/public/lib/dashboard.js
+++ b/tools/local-control/public/lib/dashboard.js
@@ -1,0 +1,45 @@
+import { redact } from "./redact.js";
+
+export function renderDashboard(d) {
+  if (!d) return;
+  text("dash-branch", d.branch || "—");
+  const gs = d.gitStatus || {};
+  text("dash-git", gs.clean ? "clean" : `${(gs.files || []).length} modifié(s) — ahead ${gs.ahead || 0} / behind ${gs.behind || 0}`);
+
+  const doc = d.doctor || {};
+  text("dash-doctor", doc.ok ? `Phase ${doc.phase || "?"} OK` : "Bloqué");
+  const ul = document.getElementById("dash-doctor-blockers");
+  ul.innerHTML = "";
+  (doc.blockers || []).forEach((b) => {
+    const li = document.createElement("li");
+    li.textContent = redact(b);
+    ul.appendChild(li);
+  });
+
+  const mp = d.mainProtection || {};
+  text("dash-protection", mp.enabled ? `${mp.type}` : "non configurée");
+  text("dash-protection-checks", (mp.checks || []).join(", ") || "—");
+
+  const pg = d.phaseGates || {};
+  setChip("gate-1", pg.phase1);
+  setChip("gate-2", pg.phase2);
+  setChip("gate-3", pg.phase3);
+
+  text("dash-issues", String(d.openIssues ?? "—"));
+  text("dash-auto", String(d.autonomousTasks ?? "—"));
+  text("dash-questions", String(d.pendingQuestions ?? "—"));
+  text("dash-latest", d.latestRun?.status || "—");
+  text("dash-latest-time", d.latestRun?.startedAt || "—");
+}
+
+function text(id, val) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = val;
+}
+function setChip(id, val) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.classList.remove("ok", "blocked");
+  if (val === "ok") el.classList.add("ok");
+  if (val === "blocked") el.classList.add("blocked");
+}

--- a/tools/local-control/public/lib/logs.js
+++ b/tools/local-control/public/lib/logs.js
@@ -1,0 +1,54 @@
+import { redact } from "./redact.js";
+
+export function mountLogs(api) {
+  const view = document.getElementById("log-view");
+  const select = document.getElementById("log-run-select");
+  let currentEs = null;
+  let currentRunId = null;
+
+  async function refreshRuns() {
+    try {
+      const r = await api.get("/api/runs");
+      const items = r.items || [];
+      const keep = select.value;
+      select.innerHTML = '<option value="">Run en direct</option>';
+      items.slice(0, 30).forEach((run) => {
+        const o = document.createElement("option");
+        o.value = run.id;
+        o.textContent = `${run.id.slice(0, 8)} — ${run.mode} — ${run.status}`;
+        select.appendChild(o);
+      });
+      if (keep) select.value = keep;
+    } catch {}
+  }
+
+  function subscribe(runId) {
+    if (!runId) return;
+    if (currentEs) { currentEs.close(); currentEs = null; }
+    currentRunId = runId;
+    appendLine(`— Subscribed to run ${runId} —`);
+    currentEs = api.subscribe(runId, {
+      onLog: (data) => appendLine(redact(data?.line ?? data)),
+      onStatus: (data) => appendLine(`[status] ${redact(JSON.stringify(data))}`),
+      onDone: (data) => appendLine(`[done] ${redact(JSON.stringify(data))}`),
+      onError: () => appendLine("[error] connexion SSE perdue"),
+    });
+  }
+
+  function appendLine(line) {
+    if (line == null) return;
+    view.textContent += String(line) + "\n";
+    if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight;
+  }
+
+  select.addEventListener("change", () => subscribe(select.value));
+  select.addEventListener("subscribe", (e) => { refreshRuns(); subscribe(e.detail); });
+
+  document.querySelector('[data-action="copy-logs"]').addEventListener("click", () => {
+    navigator.clipboard?.writeText(view.textContent || "").catch(() => {});
+  });
+  document.querySelector('[data-action="clear-logs"]').addEventListener("click", () => { view.textContent = ""; });
+
+  refreshRuns();
+  setInterval(refreshRuns, 10000);
+}

--- a/tools/local-control/public/lib/prompt.js
+++ b/tools/local-control/public/lib/prompt.js
@@ -1,0 +1,25 @@
+const PRESETS = {
+  "plan-next-task": "Plan la prochaine tâche exécutable. Mode dry-run.",
+  "run-one-safe-task": "Run une seule tâche classifiée 'safe' ou 'trivial'. Stop après PR.",
+  "loop-safe-tasks": "Loop tasks 'safe'/'trivial' jusqu'à maxPRs. Stop si question humaine ou erreur.",
+  "resume-after-answer": "Resume depuis la dernière réponse Notion appliquée à GitHub.",
+  "analyze-blockage": "Analyse pourquoi le runner est bloqué. Liste blockers et propose remédiation.",
+};
+
+export function mountPrompt(api) {
+  const ta = document.getElementById("prompt-text");
+  const send = document.getElementById("prompt-send");
+  const clear = document.getElementById("prompt-clear");
+  document.querySelectorAll("[data-preset]").forEach((b) => {
+    b.addEventListener("click", () => {
+      const k = b.getAttribute("data-preset");
+      ta.value = PRESETS[k] || "";
+    });
+  });
+  send.addEventListener("click", async () => {
+    if (!ta.value.trim()) return;
+    const r = await api.post("/api/prompt", { prompt: ta.value, preset: null });
+    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  });
+  clear.addEventListener("click", () => (ta.value = ""));
+}

--- a/tools/local-control/public/lib/questions.js
+++ b/tools/local-control/public/lib/questions.js
@@ -1,0 +1,37 @@
+import { redact } from "./redact.js";
+
+export function renderQuestions(items, { api }) {
+  const root = document.getElementById("questions-list");
+  if (!root) return;
+  root.innerHTML = "";
+  if (!items.length) {
+    root.innerHTML = '<p class="muted">Aucune question en attente.</p>';
+    return;
+  }
+  items.filter((q) => !q.answeredAt).forEach((q) => root.appendChild(card(q, api)));
+}
+
+function card(q, api) {
+  const el = document.createElement("div");
+  el.className = "question";
+  el.innerHTML = `
+    <h4>#${q.issue} — Question</h4>
+    <p>${escapeHtml(redact(q.question || ""))}</p>
+    <div class="options">${(q.options || []).map((o) => `<span class="chip">${escapeHtml(o)}</span>`).join("")}</div>
+    <p class="small muted">${q.recommendation ? "Reco Claude : " + escapeHtml(q.recommendation) : ""}</p>
+    <textarea placeholder="Ta réponse…"></textarea>
+    <div class="actions"><button class="primary">Envoyer</button></div>
+  `;
+  const ta = el.querySelector("textarea");
+  el.querySelector("button").addEventListener("click", async () => {
+    const answer = ta.value.trim();
+    if (!answer) return;
+    await api.post(`/api/questions/${encodeURIComponent(q.id)}/answer`, { answer });
+    el.remove();
+  });
+  return el;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}

--- a/tools/local-control/public/lib/redact.js
+++ b/tools/local-control/public/lib/redact.js
@@ -1,0 +1,28 @@
+// Defense-in-depth: even though the backend MUST redact, we redact again client-side
+// before rendering anything that came from logs or errors.
+
+const PATTERNS = [
+  // bearer tokens
+  /Bearer\s+[A-Za-z0-9_\-\.]+/gi,
+  // env-style assignments like FOO_TOKEN=xxx, FOO_KEY=xxx, FOO_SECRET=xxx
+  /\b([A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|API_KEY))\s*[:=]\s*\S+/gi,
+  // GitHub PATs
+  /ghp_[A-Za-z0-9]{20,}/g,
+  /github_pat_[A-Za-z0-9_]{20,}/g,
+  // Anthropic/OpenAI keys
+  /sk-[A-Za-z0-9_\-]{20,}/g,
+  // generic long token-looking strings inside quotes
+  /"[A-Za-z0-9_\-]{40,}"/g,
+];
+
+export function redact(input) {
+  if (input == null) return input;
+  let s = typeof input === "string" ? input : JSON.stringify(input);
+  for (const re of PATTERNS) s = s.replace(re, (m) => maskKeep(m));
+  return s;
+}
+
+function maskKeep(s) {
+  if (s.length <= 8) return "***";
+  return s.slice(0, 4) + "***REDACTED***" + s.slice(-2);
+}

--- a/tools/local-control/public/lib/runner.js
+++ b/tools/local-control/public/lib/runner.js
@@ -1,0 +1,54 @@
+import { validateRunnerForm } from "./validate.js";
+
+export function mountRunner(api, { confirmDanger }) {
+  const form = document.getElementById("runner-form");
+  const warn = document.getElementById("runner-warn");
+  if (!form) return;
+
+  const refreshWarn = () => {
+    const data = readForm(form);
+    const msgs = [];
+    if (!data.dryRun) msgs.push("⚠ DRY-RUN désactivé : actions réelles.");
+    if (data.allowAutoMerge) msgs.push("⚠ AUTO-MERGE activé : PR seront fusionnés automatiquement.");
+    if (data.allowLoop) msgs.push("⚠ LOOP autorisé : runner continuera tant qu'il trouve des tâches.");
+    warn.textContent = msgs.join(" ");
+    warn.classList.toggle("hidden", msgs.length === 0);
+  };
+  form.addEventListener("change", refreshWarn);
+  refreshWarn();
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const data = readForm(form);
+    const err = validateRunnerForm(data);
+    if (err) { warn.textContent = "✗ " + err; warn.classList.remove("hidden"); return; }
+
+    if (!data.dryRun || data.allowAutoMerge || data.allowLoop) {
+      const word = data.allowAutoMerge ? "AUTOMERGE" : data.allowLoop ? "LOOP" : "EXEC";
+      const ok = await confirmDanger({
+        title: "Confirmation requise",
+        body: `Mode ${data.mode}, dryRun=${data.dryRun}, autoMerge=${data.allowAutoMerge}, loop=${data.allowLoop}. Tape ${word} pour confirmer.`,
+        magicWord: word,
+      });
+      if (!ok) return;
+    }
+    const r = await api.post("/api/runner/start", data);
+    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  });
+
+  document.querySelector('[data-action="stop-runner"]').addEventListener("click", () => api.post("/api/runner/stop", {}).catch(() => {}));
+}
+
+function readForm(form) {
+  const fd = new FormData(form);
+  return {
+    mode: fd.get("mode") || "plan",
+    issue: fd.get("issue") ? Number(fd.get("issue")) : null,
+    maxPRs: Number(fd.get("maxPRs") || 3),
+    maxMinutes: Number(fd.get("maxMinutes") || 20),
+    dryRun: fd.get("dryRun") === "on",
+    allowExec: fd.get("allowExec") === "on",
+    allowLoop: fd.get("allowLoop") === "on",
+    allowAutoMerge: fd.get("allowAutoMerge") === "on",
+  };
+}

--- a/tools/local-control/public/lib/settings.js
+++ b/tools/local-control/public/lib/settings.js
@@ -1,0 +1,56 @@
+import { validateSettings, parseCsv } from "./validate.js";
+
+export function mountSettings(api, { onChange } = {}) {
+  const form = document.getElementById("settings-form");
+  if (!form) return;
+
+  load().catch(() => {});
+
+  async function load() {
+    const s = await api.get("/api/settings");
+    fill(form, s);
+    onChange?.(s);
+  }
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const data = read(form);
+    const err = validateSettings(data);
+    if (err) { alert("✗ " + err); return; }
+    const r = await api.post("/api/settings", data);
+    if (r) { fill(form, r); onChange?.(r); }
+  });
+}
+
+function fill(form, s) {
+  if (!s) return;
+  form.maxPrsPerRun.value = s.maxPrsPerRun ?? "";
+  form.maxMinutes.value = s.maxMinutes ?? "";
+  form.staleDays.value = s.staleDays ?? "";
+  form.preferredIssue.value = s.preferredIssue ?? "";
+  form.dryRunDefault.checked = !!s.dryRunDefault;
+  form.allowExec.checked = !!s.allowExec;
+  form.allowLoop.checked = !!s.allowLoop;
+  form.allowAutoMerge.checked = !!s.allowAutoMerge;
+  form.lanEnabled.checked = !!s.lanEnabled;
+  form.allowedRisk.value = (s.allowedRisk || []).join(",");
+  form.allowedAutonomy.value = (s.allowedAutonomy || []).join(",");
+}
+
+function read(form) {
+  const out = {
+    dryRunDefault: form.dryRunDefault.checked,
+    allowExec: form.allowExec.checked,
+    allowLoop: form.allowLoop.checked,
+    allowAutoMerge: form.allowAutoMerge.checked,
+    lanEnabled: form.lanEnabled.checked,
+    allowedRisk: parseCsv(form.allowedRisk.value),
+    allowedAutonomy: parseCsv(form.allowedAutonomy.value),
+  };
+  const n = (v) => (v === "" || v == null ? undefined : Number(v));
+  if (n(form.maxPrsPerRun.value) != null) out.maxPrsPerRun = n(form.maxPrsPerRun.value);
+  if (n(form.maxMinutes.value) != null) out.maxMinutes = n(form.maxMinutes.value);
+  if (n(form.staleDays.value) != null) out.staleDays = n(form.staleDays.value);
+  out.preferredIssue = form.preferredIssue.value === "" ? null : Number(form.preferredIssue.value);
+  return out;
+}

--- a/tools/local-control/public/lib/state.js
+++ b/tools/local-control/public/lib/state.js
@@ -1,0 +1,11 @@
+export const state = {
+  mode: "dry",
+  lan: false,
+  autoMerge: false,
+  currentRun: null,
+};
+
+export function setMode(m) { state.mode = m === "live" ? "live" : "dry"; }
+export function setLan(b) { state.lan = !!b; }
+export function setAutoMerge(b) { state.autoMerge = !!b; }
+export function setCurrentRun(id) { state.currentRun = id || null; }

--- a/tools/local-control/public/lib/tabs.js
+++ b/tools/local-control/public/lib/tabs.js
@@ -1,0 +1,17 @@
+export function mountTabs() {
+  const tabs = document.getElementById("tabs");
+  if (!tabs) return;
+  tabs.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-tab]");
+    if (!btn) return;
+    const target = btn.getAttribute("data-tab");
+    document.querySelectorAll("#tabs button").forEach((b) => b.classList.toggle("active", b === btn));
+    document.querySelectorAll("main .pane").forEach((p) => p.classList.toggle("active", p.getAttribute("data-pane") === target));
+    if (location.hash !== "#" + target) history.replaceState(null, "", "#" + target);
+  });
+  const fromHash = (location.hash || "").replace("#", "");
+  if (fromHash) {
+    const btn = tabs.querySelector(`button[data-tab="${fromHash}"]`);
+    if (btn) btn.click();
+  }
+}

--- a/tools/local-control/public/lib/tasks.js
+++ b/tools/local-control/public/lib/tasks.js
@@ -1,0 +1,61 @@
+import { redact } from "./redact.js";
+
+export function renderTasks(items, { api, confirmDanger }) {
+  const tbody = document.querySelector("#tasks-table tbody");
+  const filter = document.getElementById("task-filter");
+  const classSel = document.getElementById("task-class");
+  if (!tbody) return;
+
+  const draw = () => {
+    const f = (filter?.value || "").toLowerCase();
+    const c = classSel?.value || "";
+    tbody.innerHTML = "";
+    items
+      .filter((t) => !c || t.classification === c)
+      .filter((t) => !f || (t.title || "").toLowerCase().includes(f) || (t.labels || []).join(",").toLowerCase().includes(f))
+      .forEach((t) => tbody.appendChild(row(t, { api, confirmDanger })));
+  };
+  draw();
+  filter?.addEventListener("input", draw);
+  classSel?.addEventListener("change", draw);
+}
+
+function row(t, { api, confirmDanger }) {
+  const tr = document.createElement("tr");
+  tr.innerHTML = `
+    <td>#${t.issue}</td>
+    <td>${escapeHtml(t.title || "")}</td>
+    <td>${t.score ?? ""}</td>
+    <td>${escapeHtml(t.classification || "")}</td>
+    <td>${(t.labels || []).map(escapeHtml).join(", ")}</td>
+    <td>${escapeHtml(t.risk || "")}</td>
+    <td>${escapeHtml(t.autonomy || "")}</td>
+    <td>${escapeHtml(redact(t.reason || ""))}</td>
+  `;
+  const td = document.createElement("td");
+  const planBtn = document.createElement("button");
+  planBtn.textContent = "Plan";
+  planBtn.addEventListener("click", async () => {
+    const r = await api.post(`/api/tasks/${t.issue}/plan`, {});
+    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  });
+  const runBtn = document.createElement("button");
+  runBtn.textContent = "Run";
+  runBtn.classList.add("primary");
+  runBtn.disabled = !t.executable;
+  if (t.executable) {
+    runBtn.addEventListener("click", async () => {
+      const ok = await confirmDanger({ title: `Exécuter #${t.issue} ?`, body: `Mode exec sur "${t.title}". Tape EXEC pour confirmer.`, magicWord: "EXEC" });
+      if (!ok) return;
+      const r = await api.post("/api/runner/start", { mode: "exec", issue: t.issue, allowExec: true, dryRun: false });
+      if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+    });
+  }
+  td.append(planBtn, " ", runBtn);
+  tr.appendChild(td);
+  return tr;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}

--- a/tools/local-control/public/lib/validate.js
+++ b/tools/local-control/public/lib/validate.js
@@ -1,0 +1,23 @@
+export function validateRunnerForm(d) {
+  if (!d) return "données manquantes";
+  if (!["plan", "exec", "loop"].includes(d.mode)) return "mode invalide";
+  if (d.mode === "exec" && !d.allowExec && !d.dryRun) return "exec requiert allowExec ou dryRun";
+  if (d.mode === "loop" && !d.allowLoop) return "loop requiert allowLoop";
+  if (d.allowAutoMerge && d.dryRun) return "auto-merge incompatible avec dry-run";
+  if (!Number.isFinite(d.maxPRs) || d.maxPRs < 1 || d.maxPRs > 10) return "maxPRs hors bornes (1-10)";
+  if (!Number.isFinite(d.maxMinutes) || d.maxMinutes < 1 || d.maxMinutes > 240) return "maxMinutes hors bornes (1-240)";
+  if (d.issue != null && (!Number.isFinite(d.issue) || d.issue < 1)) return "issue invalide";
+  return null;
+}
+
+export function validateSettings(s) {
+  if (!s) return "données manquantes";
+  if (s.maxPrsPerRun != null && (s.maxPrsPerRun < 1 || s.maxPrsPerRun > 10)) return "maxPrsPerRun hors bornes (1-10)";
+  if (s.maxMinutes != null && (s.maxMinutes < 1 || s.maxMinutes > 240)) return "maxMinutes hors bornes (1-240)";
+  if (s.staleDays != null && (s.staleDays < 0 || s.staleDays > 365)) return "staleDays hors bornes (0-365)";
+  return null;
+}
+
+export function parseCsv(s) {
+  return String(s || "").split(",").map((x) => x.trim()).filter(Boolean);
+}

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -1,0 +1,118 @@
+:root {
+  --bg: #0b0d10;
+  --bg-elev: #14171c;
+  --bg-elev-2: #1b1f25;
+  --fg: #e6e8eb;
+  --fg-dim: #9aa3ad;
+  --accent: #4f8cff;
+  --ok: #2bbf6a;
+  --warn: #e0a82e;
+  --danger: #e0524a;
+  --border: #262b32;
+  --radius: 10px;
+  --gap: 12px;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; }
+body { min-height: 100vh; }
+h3 { margin: 0 0 8px; font-size: 14px; color: var(--fg-dim); text-transform: uppercase; letter-spacing: 0.06em; }
+code { background: var(--bg-elev-2); padding: 2px 6px; border-radius: 4px; font-size: 12px; }
+button { background: var(--bg-elev-2); color: var(--fg); border: 1px solid var(--border); padding: 8px 14px; border-radius: var(--radius); cursor: pointer; font-size: 14px; }
+button:hover { background: var(--bg-elev); }
+button.primary { background: var(--accent); border-color: var(--accent); color: white; }
+button.danger { background: var(--danger); border-color: var(--danger); color: white; }
+button:disabled { opacity: 0.4; cursor: not-allowed; }
+input, select, textarea { background: var(--bg-elev-2); color: var(--fg); border: 1px solid var(--border); border-radius: var(--radius); padding: 8px 10px; font-size: 14px; font-family: inherit; }
+textarea { width: 100%; resize: vertical; }
+.muted { color: var(--fg-dim); }
+.small { font-size: 12px; }
+.big { font-size: 22px; font-weight: 600; }
+.row { display: flex; gap: var(--gap); flex-wrap: wrap; }
+.hidden { display: none !important; }
+
+/* topbar */
+.topbar { display: flex; align-items: center; gap: 16px; padding: 10px 16px; background: var(--bg-elev); border-bottom: 1px solid var(--border); position: sticky; top: 0; z-index: 5; }
+.brand { display: flex; align-items: center; gap: 8px; }
+.dot { width: 10px; height: 10px; border-radius: 50%; background: var(--fg-dim); display: inline-block; }
+.dot.ok { background: var(--ok); }
+.dot.err { background: var(--danger); }
+.tabs { display: flex; gap: 4px; flex: 1; overflow-x: auto; }
+.tabs button { background: transparent; border: 1px solid transparent; padding: 6px 12px; }
+.tabs button.active { background: var(--bg-elev-2); border-color: var(--border); }
+.topbar-right { display: flex; gap: 6px; }
+.badge { padding: 4px 8px; border-radius: 6px; font-size: 11px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; background: var(--bg-elev-2); border: 1px solid var(--border); }
+.badge.dry { color: var(--ok); border-color: var(--ok); }
+.badge.live { color: var(--warn); border-color: var(--warn); }
+.badge.warn { color: var(--warn); border-color: var(--warn); }
+.badge.danger { color: var(--danger); border-color: var(--danger); }
+
+/* panes */
+main { padding: 16px; max-width: 1400px; margin: 0 auto; }
+.pane { display: none; }
+.pane.active { display: block; }
+
+/* dashboard */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: var(--gap); margin-bottom: 16px; }
+.card { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px; }
+.actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--bg-elev-2); border: 1px solid var(--border); font-size: 12px; font-weight: 600; }
+.chip.ok { color: var(--ok); border-color: var(--ok); }
+.chip.blocked { color: var(--danger); border-color: var(--danger); }
+
+/* table */
+.filters { display: flex; gap: 8px; margin-bottom: 12px; }
+.filters input, .filters select { flex: 1; }
+.table-wrap { overflow-x: auto; background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); }
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--border); }
+th { background: var(--bg-elev-2); font-weight: 600; color: var(--fg-dim); text-transform: uppercase; font-size: 11px; letter-spacing: 0.04em; }
+tbody tr:hover { background: var(--bg-elev-2); }
+
+/* forms */
+.form { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; background: var(--bg-elev); padding: 16px; border-radius: var(--radius); border: 1px solid var(--border); }
+.form fieldset { border: 1px solid var(--border); border-radius: var(--radius); padding: 10px; grid-column: 1 / -1; }
+.form legend { color: var(--fg-dim); font-size: 12px; padding: 0 6px; }
+.form label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--fg-dim); }
+.form .check { flex-direction: row; align-items: center; gap: 8px; color: var(--fg); }
+.form .check.danger { color: var(--danger); }
+.form .actions { grid-column: 1 / -1; }
+.warn-line { color: var(--warn); margin: 0; font-size: 13px; }
+
+/* prompt */
+.presets { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
+
+/* logs */
+.logs-toolbar { display: flex; gap: 8px; margin-bottom: 8px; align-items: center; }
+.log-view { background: #000; color: #c8d3df; border: 1px solid var(--border); border-radius: var(--radius); padding: 12px; max-height: 65vh; overflow: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+
+/* questions */
+.question { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 14px; margin-bottom: 10px; }
+.question h4 { margin: 0 0 6px; }
+.question .options { display: flex; gap: 6px; flex-wrap: wrap; margin: 8px 0; }
+.question textarea { min-height: 70px; }
+
+/* dialog */
+dialog { background: var(--bg-elev); color: var(--fg); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; max-width: 420px; }
+dialog::backdrop { background: rgba(0,0,0,0.6); }
+dialog menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; margin: 12px 0 0; }
+dialog input { width: 100%; margin-top: 8px; }
+
+/* mobile */
+@media (max-width: 720px) {
+  .topbar { flex-wrap: wrap; padding: 8px 10px; }
+  .tabs { order: 3; width: 100%; }
+  .tabs button { flex: 1 0 auto; padding: 10px 8px; font-size: 13px; }
+  main { padding: 10px; }
+  .grid { grid-template-columns: 1fr 1fr; }
+  .big { font-size: 18px; }
+  .form { grid-template-columns: 1fr; }
+  button { padding: 12px 16px; font-size: 15px; min-height: 44px; }
+  .filters { flex-direction: column; }
+  .log-view { max-height: 50vh; font-size: 11px; }
+  table { font-size: 12px; }
+  th, td { padding: 8px 6px; }
+}
+@media (max-width: 420px) {
+  .grid { grid-template-columns: 1fr; }
+  .topbar-right { width: 100%; justify-content: flex-end; }
+}

--- a/tools/local-control/runner.mjs
+++ b/tools/local-control/runner.mjs
@@ -1,0 +1,63 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { redactSecrets } from './safety.mjs';
+
+export class Runner {
+  constructor({ logs, state, settings, repoRoot }) {
+    this.logs = logs;
+    this.state = state;
+    this.settings = settings;
+    this.repoRoot = repoRoot;
+    this.active = new Map();
+  }
+  hasActive() { return this.active.size > 0; }
+  activeIds() { return Array.from(this.active.keys()); }
+
+  start({ name, args, bin, kind }) {
+    const id = randomUUID();
+    this.state.createRun({ id, name, args, kind });
+    this.logs.open(id);
+
+    const child = spawn(bin, args, {
+      cwd: this.repoRoot,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    this.active.set(id, child);
+
+    const tok = this.settings.get().authToken;
+    const onChunk = (stream) => (buf) => {
+      const safe = redactSecrets(buf.toString('utf8'), [tok]);
+      this.logs.append(id, stream, safe);
+      this.state.emit(id, 'log', { runId: id, stream, chunk: safe });
+    };
+    child.stdout.on('data', onChunk('stdout'));
+    child.stderr.on('data', onChunk('stderr'));
+
+    child.on('error', (err) => {
+      const msg = redactSecrets(`spawn error: ${err.message}\n`, [tok]);
+      this.logs.append(id, 'stderr', msg);
+      this.state.emit(id, 'log', { runId: id, stream: 'stderr', chunk: msg });
+    });
+
+    child.on('close', (code) => {
+      this.active.delete(id);
+      this.state.finishRun(id, code);
+      this.logs.close(id);
+      this.state.emit(id, 'exit', { runId: id, code });
+    });
+
+    return id;
+  }
+
+  stop(runId) {
+    const child = this.active.get(runId);
+    if (!child) return false;
+    try { child.kill('SIGTERM'); } catch { /* ignore */ }
+    setTimeout(() => {
+      const c = this.active.get(runId);
+      if (c) { try { c.kill('SIGKILL'); } catch { /* ignore */ } }
+    }, 3000).unref();
+    return true;
+  }
+}

--- a/tools/local-control/safety.mjs
+++ b/tools/local-control/safety.mjs
@@ -1,0 +1,60 @@
+// safety.mjs — secret redaction + sensitive-path detection.
+
+const SECRET_PATTERNS = [
+  /\bgh[pousr]_[A-Za-z0-9]{20,}\b/g,
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bASIA[0-9A-Z]{16}\b/g,
+  /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/g,
+  /\bAIza[0-9A-Za-z_-]{20,}\b/g,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+  /\bBearer\s+[A-Za-z0-9._-]{16,}\b/gi,
+];
+
+const ENV_KEY_RE = /\b([A-Z][A-Z0-9_]{2,}(?:TOKEN|SECRET|KEY|PASSWORD|PASS|API_KEY))\s*=\s*([^\s'"]+)/g;
+
+export function redactSecrets(input, extraTokens = []) {
+  if (input == null) return '';
+  let out = String(input);
+  for (const tok of extraTokens) {
+    if (!tok || tok.length < 8) continue;
+    const re = new RegExp(escapeRegex(tok), 'g');
+    out = out.replace(re, '[REDACTED]');
+  }
+  for (const re of SECRET_PATTERNS) out = out.replace(re, '[REDACTED]');
+  out = out.replace(ENV_KEY_RE, (_, k) => `${k}=[REDACTED]`);
+  return out;
+}
+
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const SENSITIVE_PATH_PATTERNS = [
+  /^apps\/api\/(src\/)?db\//i,
+  /^apps\/api\/src\/lib\/(api-key-cipher|sessions|sentry)/i,
+  /^apps\/api\/src\/(auth|billing)/i,
+  /(^|\/)\.env(\..+)?$/i,
+  /^infra\//i,
+  /^\.github\/workflows\//i,
+  /(^|\/)package\.json$/i,
+  /(^|\/)pnpm-lock\.yaml$/i,
+  /(^|\/)pnpm-workspace\.yaml$/i,
+  /(^|\/)Dockerfile$/i,
+  /(^|\/)docker-compose.*\.ya?ml$/i,
+  /(^|\/)turbo\.json$/i,
+];
+
+export function isSensitivePath(p) {
+  return SENSITIVE_PATH_PATTERNS.some((re) => re.test(p));
+}
+
+export function classifyPaths(paths) {
+  const sensitive = [];
+  const safe = [];
+  for (const p of paths) {
+    if (isSensitivePath(p)) sensitive.push(p);
+    else safe.push(p);
+  }
+  return { sensitive, safe };
+}

--- a/tools/local-control/safety.test.mjs
+++ b/tools/local-control/safety.test.mjs
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { redactSecrets, isSensitivePath, classifyPaths } from './safety.mjs';
+
+test('redacts GitHub token pattern', () => {
+  const out = redactSecrets('token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345');
+  assert.match(out, /\[REDACTED\]/);
+  assert.doesNotMatch(out, /ghp_ABCDEF/);
+});
+
+test('redacts OpenAI key pattern', () => {
+  const out = redactSecrets('key=sk-AAAAAAAAAAAAAAAAAAAA');
+  assert.match(out, /\[REDACTED\]/);
+});
+
+test('redacts AWS access key', () => {
+  const out = redactSecrets('AKIAABCDEFGHIJKLMNOP');
+  assert.match(out, /\[REDACTED\]/);
+});
+
+test('redacts custom token via extraTokens', () => {
+  const tok = 'a'.repeat(64);
+  const out = redactSecrets(`auth ${tok} end`, [tok]);
+  assert.match(out, /\[REDACTED\]/);
+  assert.doesNotMatch(out, /aaaa/);
+});
+
+test('skips short extra tokens', () => {
+  const out = redactSecrets('hello short', ['ab']);
+  assert.equal(out, 'hello short');
+});
+
+test('redacts ENV-style secret assignment', () => {
+  const out = redactSecrets('MY_SECRET=topsecretvalue');
+  assert.match(out, /MY_SECRET=\[REDACTED\]/);
+});
+
+test('isSensitivePath flags db migrations and env', () => {
+  assert.equal(isSensitivePath('apps/api/db/migrations/0001.sql'), true);
+  assert.equal(isSensitivePath('.env'), true);
+  assert.equal(isSensitivePath('apps/api/.env.production'), true);
+  assert.equal(isSensitivePath('infra/main.tf'), true);
+  assert.equal(isSensitivePath('.github/workflows/ci.yml'), true);
+  assert.equal(isSensitivePath('package.json'), true);
+});
+
+test('isSensitivePath ignores normal source files', () => {
+  assert.equal(isSensitivePath('apps/web/src/app/page.tsx'), false);
+  assert.equal(isSensitivePath('tools/local-control/server.mjs'), false);
+});
+
+test('classifyPaths splits sensitive vs safe', () => {
+  const r = classifyPaths(['package.json', 'apps/web/page.tsx', '.env']);
+  assert.deepEqual(r.sensitive.sort(), ['.env', 'package.json']);
+  assert.deepEqual(r.safe, ['apps/web/page.tsx']);
+});

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -1,0 +1,399 @@
+import { createServer } from 'node:http';
+import { existsSync, readFileSync, statSync, readdirSync } from 'node:fs';
+import { dirname, resolve, extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { SettingsStore } from './settings.mjs';
+import { isAuthenticated, extractToken, constantTimeEqual } from './auth.mjs';
+import { LogStore, StateStore } from './logs.mjs';
+import { Runner } from './runner.mjs';
+import { resolveCommand, COMMANDS } from './commands.mjs';
+import { redactSecrets } from './safety.mjs';
+import {
+  fetchPrContext, fetchIssueLabels, fetchBranchProtection,
+  runTaskGuard, evaluateAutoMerge, applyAutoMerge,
+} from './automerge.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT_DEFAULT = resolve(__dirname, '..', '..');
+const VERSION = '1.0.0';
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+  '.png':  'image/png',
+  '.ico':  'image/x-icon',
+  '.txt':  'text/plain; charset=utf-8',
+};
+
+function repoNameWithOwner(repoRoot) {
+  const r = spawnSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+    cwd: repoRoot, encoding: 'utf8',
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+function gitInfo(repoRoot) {
+  const branchR = spawnSync('git', ['branch', '--show-current'], { cwd: repoRoot, encoding: 'utf8' });
+  const dirtyR  = spawnSync('git', ['status', '--porcelain'], { cwd: repoRoot, encoding: 'utf8' });
+  return {
+    branch: branchR.status === 0 ? branchR.stdout.trim() : null,
+    dirty: dirtyR.status === 0 ? dirtyR.stdout.trim().length > 0 : false,
+  };
+}
+
+export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
+  const settings = new SettingsStore(repoRoot);
+  settings.load();
+  const state = new StateStore();
+  const logs = new LogStore(repoRoot);
+  const runner = new Runner({ logs, state, settings, repoRoot });
+  const startedAt = Date.now();
+
+  function authOk(req) { return isAuthenticated(req, settings.get().authToken); }
+  function send(res, code, body, extraHeaders = {}) {
+    const json = typeof body === 'string' ? body : JSON.stringify(body);
+    res.writeHead(code, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', ...extraHeaders });
+    res.end(json);
+  }
+  function sendErr(res, code, message) { send(res, code, { error: message }); }
+
+  async function readBody(req, max = 1_000_000) {
+    return await new Promise((resolveP, rejectP) => {
+      let total = 0;
+      const chunks = [];
+      req.on('data', (c) => {
+        total += c.length;
+        if (total > max) { rejectP(new Error('body too large')); req.destroy(); return; }
+        chunks.push(c);
+      });
+      req.on('end', () => {
+        const buf = Buffer.concat(chunks).toString('utf8');
+        if (!buf) return resolveP({});
+        try { resolveP(JSON.parse(buf)); } catch { rejectP(new Error('invalid JSON body')); }
+      });
+      req.on('error', rejectP);
+    });
+  }
+
+  function serveStatic(req, res) {
+    const pubDir = resolve(__dirname, 'public');
+    if (!existsSync(pubDir)) return false;
+    const url = new URL(req.url, 'http://localhost');
+    let p = url.pathname === '/' ? '/index.html' : url.pathname;
+    const target = normalize(join(pubDir, p));
+    if (!target.startsWith(pubDir)) return false;
+    if (!existsSync(target) || !statSync(target).isFile()) return false;
+    const ext = extname(target).toLowerCase();
+    res.writeHead(200, { 'content-type': MIME[ext] ?? 'application/octet-stream', 'cache-control': 'no-store' });
+    res.end(readFileSync(target));
+    return true;
+  }
+
+  async function handleApi(req, res, url) {
+    if (!authOk(req)) return sendErr(res, 401, 'unauthorized');
+    const path = url.pathname;
+    const method = req.method;
+
+    if (method === 'GET' && (path === '/api/status' || path === '/api/health')) {
+      const info = gitInfo(repoRoot);
+      return send(res, 200, {
+        ok: true, version: VERSION, branch: info.branch, dirty: info.dirty,
+        activeRunId: runner.activeIds()[0] ?? null,
+        uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
+        uptimeSec: Math.floor((Date.now() - startedAt) / 1000),
+      });
+    }
+    if (method === 'GET' && path === '/api/dashboard') {
+      const info = gitInfo(repoRoot);
+      const active = runner.activeIds()[0] ?? null;
+      const last = state.list(1)[0] ?? null;
+      return send(res, 200, {
+        branch: info.branch,
+        gitStatus: { clean: !info.dirty, ahead: 0, behind: 0, files: [] },
+        doctor: { ok: null, phase: null, blockers: [], checkedAt: null },
+        mainProtection: { enabled: null, type: 'unknown', checks: [] },
+        phaseGates: { phase1: 'unknown', phase2: 'unknown', phase3: 'unknown' },
+        openIssues: null,
+        autonomousTasks: null,
+        pendingQuestions: null,
+        latestRun: last
+          ? { id: last.id, status: last.exitCode == null ? 'running' : (last.exitCode === 0 ? 'done' : 'error'), startedAt: last.startedAt, endedAt: last.finishedAt }
+          : { id: null, status: 'idle', startedAt: null, endedAt: null },
+        activeRunId: active,
+      });
+    }
+    if (method === 'GET' && path === '/api/settings') return send(res, 200, settings.redactedCopy());
+    if (method === 'POST' && path === '/api/settings') {
+      try {
+        const body = await readBody(req);
+        const next = settings.patch(body);
+        const copy = { ...next }; delete copy.authToken;
+        return send(res, 200, copy);
+      } catch (e) { return sendErr(res, 422, e.message); }
+    }
+
+    if (method === 'POST' && path === '/api/command') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const r = resolveCommand(body?.name, Array.isArray(body?.args) ? body.args : []);
+      if (r.error) return sendErr(res, 422, r.error);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id, name: r.name, args: r.args });
+    }
+
+    if (method === 'POST' && path === '/api/run/plan') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const issue = Number(body?.issue);
+      if (!Number.isInteger(issue) || issue <= 0) return sendErr(res, 422, 'invalid issue');
+      const r = resolveCommand('task:run:plan', [`--issue=${issue}`]);
+      if (r.error) return sendErr(res, 500, r.error);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id });
+    }
+
+    if (method === 'POST' && path === '/api/run/start') {
+      const s = settings.get();
+      if (!s.allowExec) return sendErr(res, 403, 'allowExec disabled');
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const issue = Number(body?.issue);
+      if (!Number.isInteger(issue) || issue <= 0) return sendErr(res, 422, 'invalid issue');
+      const dryRun = body?.dryRun ?? s.dryRunDefault;
+      if (dryRun !== false) {
+        const r = resolveCommand('task:run:plan', [`--issue=${issue}`]);
+        if (r.error) return sendErr(res, 500, r.error);
+        if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+        const id = runner.start(r);
+        return send(res, 200, { runId: id, dryRun: true });
+      }
+      return sendErr(res, 403, 'real execution not yet wired; use dryRun=true');
+    }
+
+    if (method === 'POST' && (path === '/api/run/stop' || path === '/api/runner/stop')) {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const id = String(body?.runId ?? runner.activeIds()[0] ?? '');
+      const ok = runner.stop(id);
+      return send(res, 200, { ok, stopped: ok });
+    }
+
+    if (method === 'POST' && path === '/api/runner/start') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const mode = String(body?.mode ?? 'plan');
+      const issue = Number(body?.issue);
+      if (!Number.isInteger(issue) || issue <= 0) return sendErr(res, 422, 'invalid issue');
+      const s = settings.get();
+      if (mode !== 'plan' && !s.allowExec) return sendErr(res, 403, 'allowExec disabled');
+      if (mode === 'loop' && !s.allowLoop) return sendErr(res, 403, 'allowLoop disabled');
+      const r = resolveCommand('task:run:plan', [`--issue=${issue}`]);
+      if (r.error) return sendErr(res, 500, r.error);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id, mode: mode === 'plan' ? 'plan' : 'plan-fallback' });
+    }
+
+    if (method === 'POST' && path === '/api/doctor/run') {
+      const r = resolveCommand('task:doctor', []);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id });
+    }
+
+    if (method === 'POST' && path === '/api/prompt') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const preset = body?.preset;
+      const allowed = ['plan-next', 'run-one-safe', 'loop-safe', 'resume-after-answer', 'analyze-blockage'];
+      if (preset != null && !allowed.includes(preset)) return sendErr(res, 422, 'invalid preset');
+      const r = resolveCommand('task:queue', []);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id, preset: preset ?? null });
+    }
+
+    if (method === 'GET' && path === '/api/tasks') {
+      const r = spawnSync('pnpm', ['task:queue'], { cwd: repoRoot, encoding: 'utf8' });
+      const tok = settings.get().authToken;
+      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'queue failed', [tok]));
+      let items = [];
+      try {
+        const parsed = JSON.parse(r.stdout);
+        items = Array.isArray(parsed) ? parsed : (parsed.items ?? []);
+      } catch { items = []; }
+      return send(res, 200, { items });
+    }
+
+    if (method === 'POST' && /^\/api\/tasks\/\d+\/plan$/.test(path)) {
+      const issue = Number(path.split('/')[3]);
+      const r = resolveCommand('task:run:plan', [`--issue=${issue}`]);
+      if (r.error) return sendErr(res, 422, r.error);
+      if (runner.hasActive()) return sendErr(res, 409, 'a run is already active');
+      const id = runner.start(r);
+      return send(res, 200, { runId: id });
+    }
+
+    if (method === 'POST' && /^\/api\/questions\/[A-Za-z0-9_\-:]+\/answer$/.test(path)) {
+      const id = decodeURIComponent(path.split('/')[3]);
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const answer = String(body?.answer ?? '');
+      if (!answer || answer.length > 8000) return sendErr(res, 422, 'invalid answer');
+      const r = spawnSync('pnpm', ['task:questions', 'answer', '--id', id, '--answer', answer], {
+        cwd: repoRoot, encoding: 'utf8',
+      });
+      const tok = settings.get().authToken;
+      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'answer failed', [tok]));
+      return send(res, 200, { ok: true });
+    }
+
+    if (method === 'PUT' && path === '/api/settings') {
+      try {
+        const body = await readBody(req);
+        const next = settings.patch(body);
+        const copy = { ...next }; delete copy.authToken;
+        return send(res, 200, { ok: true, settings: copy });
+      } catch (e) { return sendErr(res, 422, e.message); }
+    }
+
+    if (method === 'GET' && path === '/api/runs') return send(res, 200, { items: state.list() });
+
+    if (method === 'GET' && /^\/api\/runs\/[A-Za-z0-9-]+\/events$/.test(path)) {
+      const runId = path.split('/')[3];
+      return streamLogs(req, res, runId);
+    }
+    if (method === 'GET' && /^\/api\/runs\/[A-Za-z0-9-]+$/.test(path)) {
+      const runId = path.split('/')[3];
+      const run = state.get(runId);
+      if (!run) return sendErr(res, 404, 'run not found');
+      const hist = logs.getHistory(runId);
+      const stdout = hist.filter((h) => h.stream === 'stdout').map((h) => h.chunk).join('');
+      const stderr = hist.filter((h) => h.stream === 'stderr').map((h) => h.chunk).join('');
+      return send(res, 200, { id: run.id, status: run.exitCode == null ? 'running' : (run.exitCode === 0 ? 'done' : 'error'), stdout, stderr, exitCode: run.exitCode });
+    }
+
+    if (method === 'GET' && path.startsWith('/api/logs/')) {
+      const runId = decodeURIComponent(path.slice('/api/logs/'.length));
+      return streamLogs(req, res, runId);
+    }
+
+    if (method === 'GET' && path === '/api/questions') {
+      const r = spawnSync('pnpm', ['task:questions:list', '--json'], { cwd: repoRoot, encoding: 'utf8' });
+      const tok = settings.get().authToken;
+      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'questions failed', [tok]));
+      try { return send(res, 200, JSON.parse(r.stdout)); }
+      catch { return send(res, 200, []); }
+    }
+
+    if (method === 'POST' && path === '/api/questions/answer') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const id = String(body?.id ?? '');
+      const answer = String(body?.answer ?? '');
+      if (!/^[A-Za-z0-9_\-:]+$/.test(id)) return sendErr(res, 422, 'invalid question id');
+      if (!answer || answer.length > 8000) return sendErr(res, 422, 'invalid answer');
+      const r = spawnSync('pnpm', ['task:questions', 'answer', '--id', id, '--answer', answer], {
+        cwd: repoRoot, encoding: 'utf8',
+      });
+      const tok = settings.get().authToken;
+      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'answer failed', [tok]));
+      return send(res, 200, { ok: true, runId: null });
+    }
+
+    if (method === 'POST' && path === '/api/automerge/check') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const pr = Number(body?.pr);
+      if (!Number.isInteger(pr) || pr <= 0) return sendErr(res, 422, 'invalid pr');
+      const report = checkAutoMerge(pr);
+      return send(res, 200, report);
+    }
+
+    if (method === 'POST' && path === '/api/automerge/apply') {
+      const s = settings.get();
+      if (!s.allowAutoMerge) return sendErr(res, 403, 'allowAutoMerge disabled');
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const pr = Number(body?.pr);
+      if (!Number.isInteger(pr) || pr <= 0) return sendErr(res, 422, 'invalid pr');
+      const report = checkAutoMerge(pr);
+      if (!report.eligible) return send(res, 200, report);
+      const m = applyAutoMerge(pr);
+      report.applied = m.ok;
+      if (!m.ok) report.reasons.push(`merge command failed: ${redactSecrets(m.stderr, [s.authToken])}`);
+      return send(res, 200, report);
+    }
+
+    return sendErr(res, 404, 'not found');
+  }
+
+  function checkAutoMerge(pr) {
+    const s = settings.get();
+    const prData = fetchPrContext(pr);
+    const linked = Array.isArray(prData?.closingIssuesReferences) ? prData.closingIssuesReferences[0] : null;
+    const issueLabels = linked?.number ? fetchIssueLabels(linked.number) : null;
+    const repo = repoNameWithOwner(repoRoot);
+    const baseBranch = prData?.baseRefName ?? 'main';
+    const branchProtection = repo ? fetchBranchProtection(repo, baseBranch) : { protected: false };
+    const guardResult = runTaskGuard(repoRoot, prData?.headRefName);
+    return evaluateAutoMerge({ pr, settings: s, prData, issueLabels, branchProtection, guardResult });
+  }
+
+  function streamLogs(req, res, runId) {
+    res.writeHead(200, {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-store',
+      connection: 'keep-alive',
+    });
+    const send = (event, payload) => {
+      res.write(`event: ${event}\n`);
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+    };
+    for (const h of logs.getHistory(runId)) send('log', { runId, stream: h.stream, chunk: h.chunk });
+    const run = state.get(runId);
+    if (run?.exitCode != null) { send('exit', { runId, code: run.exitCode }); res.end(); return; }
+    const unsub = state.subscribe(runId, (event, payload) => {
+      send(event, payload);
+      if (event === 'exit') { unsub(); res.end(); }
+    });
+    req.on('close', () => unsub());
+  }
+
+  const handler = async (req, res) => {
+    try {
+      const url = new URL(req.url, 'http://localhost');
+      if (url.pathname.startsWith('/api/')) return handleApi(req, res, url);
+      if (req.method === 'GET' && serveStatic(req, res)) return;
+      if (req.method === 'GET' && url.pathname === '/') {
+        res.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' });
+        return res.end(`local-control v${VERSION}\nAPI at /api/*. UI not bundled.\n`);
+      }
+      sendErr(res, 404, 'not found');
+    } catch (e) {
+      sendErr(res, 500, 'internal error');
+    }
+  };
+
+  return { handler, settings, state, logs, runner, repoRoot };
+}
+
+export function startServer({ port = 8787, lan = false, repoRoot = REPO_ROOT_DEFAULT } = {}) {
+  const app = buildApp({ repoRoot });
+  const settings = app.settings.get();
+  const wantLan = lan && settings.lanEnabled;
+  if (lan && !settings.lanEnabled) {
+    console.error('[local-control] --lan ignored: settings.lanEnabled is false');
+  }
+  const host = wantLan ? '0.0.0.0' : '127.0.0.1';
+  const server = createServer(app.handler);
+  server.listen(port, host, () => {
+    console.log(`[local-control] http://${host}:${port}`);
+    console.log(`[local-control] auth token in .local-control/settings.json (chmod 600)`);
+  });
+  return { server, app };
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
+if (isMain) {
+  const args = process.argv.slice(2);
+  const lan = args.includes('--lan');
+  const portArg = args.find((a) => a.startsWith('--port='));
+  const port = portArg ? Number(portArg.slice(7)) : 8787;
+  startServer({ port, lan });
+}

--- a/tools/local-control/server.test.mjs
+++ b/tools/local-control/server.test.mjs
@@ -1,0 +1,168 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { createServer } from 'node:http';
+import { buildApp } from './server.mjs';
+
+function mkroot() {
+  const root = mkdtempSync(resolve(tmpdir(), 'lc-server-'));
+  mkdirSync(resolve(root, '.git'), { recursive: true });
+  writeFileSync(resolve(root, '.git', 'HEAD'), 'ref: refs/heads/test\n');
+  return root;
+}
+
+async function listenApp(handler) {
+  const server = createServer(handler);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const { port } = server.address();
+  return { server, base: `http://127.0.0.1:${port}` };
+}
+
+async function close(server) { await new Promise((r) => server.close(r)); }
+
+test('rejects unauthenticated /api/status', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/status`);
+    assert.equal(r.status, 401);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('accepts Bearer token for /api/status', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/status`, { headers: { authorization: `Bearer ${tok}` } });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/settings never exposes authToken', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/settings`, { headers: { authorization: `Bearer ${tok}` } });
+    const j = await r.json();
+    assert.equal(j.authToken, undefined);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/command rejects non-whitelisted', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/command`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${tok}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'rm', args: ['-rf', '/'] }),
+    });
+    assert.equal(r.status, 422);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/run/start refused when allowExec false', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/run/start`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${tok}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ issue: 1, dryRun: false }),
+    });
+    assert.equal(r.status, 403);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/automerge/apply refused when allowAutoMerge false', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/automerge/apply`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${tok}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ pr: 1 }),
+    });
+    assert.equal(r.status, 403);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('PUT /api/settings updates and never echoes token', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/settings`, {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${tok}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ maxPrsPerRun: 5 }),
+    });
+    const j = await r.json();
+    assert.equal(j.ok, true);
+    assert.equal(j.settings.maxPrsPerRun, 5);
+    assert.equal(j.settings.authToken, undefined);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/health alias works', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/health`, { headers: { authorization: `Bearer ${tok}` } });
+    assert.equal(r.status, 200);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('SSE endpoint requires token via query', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/logs/nope`);
+    assert.equal(r.status, 401);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('runner stop is idempotent for unknown id', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/run/stop`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${tok}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ runId: 'does-not-exist' }),
+    });
+    const j = await r.json();
+    assert.equal(j.ok, false);
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/tools/local-control/settings.mjs
+++ b/tools/local-control/settings.mjs
@@ -1,0 +1,108 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+export const DEFAULT_SETTINGS = Object.freeze({
+  maxPrsPerRun: 3,
+  maxMinutes: 60,
+  dryRunDefault: true,
+  allowExec: false,
+  allowLoop: false,
+  allowAutoMerge: false,
+  allowedRisk: ['safe'],
+  allowedAutonomy: ['autonomous'],
+  staleDays: 7,
+  preferredIssue: null,
+  lanEnabled: false,
+});
+
+const VALIDATORS = {
+  maxPrsPerRun: (v) => Number.isInteger(v) && v >= 1 && v <= 10,
+  maxMinutes: (v) => Number.isInteger(v) && v >= 1 && v <= 240,
+  dryRunDefault: (v) => typeof v === 'boolean',
+  allowExec: (v) => typeof v === 'boolean',
+  allowLoop: (v) => typeof v === 'boolean',
+  allowAutoMerge: (v) => typeof v === 'boolean',
+  allowedRisk: (v) => Array.isArray(v) && v.every((s) => typeof s === 'string'),
+  allowedAutonomy: (v) => Array.isArray(v) && v.every((s) => typeof s === 'string'),
+  staleDays: (v) => Number.isInteger(v) && v >= 0 && v <= 365,
+  preferredIssue: (v) => v === null || (Number.isInteger(v) && v > 0),
+  lanEnabled: (v) => typeof v === 'boolean',
+};
+
+export function validatePatch(patch) {
+  const errors = [];
+  const clean = {};
+  for (const [k, v] of Object.entries(patch || {})) {
+    if (k === 'authToken') continue;
+    if (!(k in VALIDATORS)) {
+      errors.push(`unknown setting: ${k}`);
+      continue;
+    }
+    if (!VALIDATORS[k](v)) {
+      errors.push(`invalid value for ${k}`);
+      continue;
+    }
+    clean[k] = v;
+  }
+  return { errors, clean };
+}
+
+export function newToken() {
+  return randomBytes(32).toString('hex');
+}
+
+export class SettingsStore {
+  constructor(rootDir) {
+    this.dir = resolve(rootDir, '.local-control');
+    this.file = resolve(this.dir, 'settings.json');
+    this._cache = null;
+  }
+  ensureDir() {
+    if (!existsSync(this.dir)) mkdirSync(this.dir, { recursive: true });
+  }
+  load() {
+    this.ensureDir();
+    let raw = null;
+    if (existsSync(this.file)) {
+      try { raw = JSON.parse(readFileSync(this.file, 'utf8')); } catch { raw = null; }
+    }
+    let dirty = false;
+    if (!raw || typeof raw !== 'object') { raw = {}; dirty = true; }
+    if (typeof raw.authToken !== 'string' || raw.authToken.length < 32) {
+      raw.authToken = newToken();
+      dirty = true;
+    }
+    const merged = { ...DEFAULT_SETTINGS, ...raw };
+    for (const k of Object.keys(DEFAULT_SETTINGS)) {
+      if (!VALIDATORS[k](merged[k])) {
+        merged[k] = DEFAULT_SETTINGS[k];
+        dirty = true;
+      }
+    }
+    merged.authToken = raw.authToken;
+    if (dirty) this._writeRaw(merged);
+    this._cache = merged;
+    return merged;
+  }
+  get() { return this._cache ?? this.load(); }
+  patch(p) {
+    const { errors, clean } = validatePatch(p);
+    if (errors.length) throw new Error(`invalid settings: ${errors.join('; ')}`);
+    const cur = this.get();
+    const next = { ...cur, ...clean };
+    this._writeRaw(next);
+    this._cache = next;
+    return next;
+  }
+  redactedCopy() {
+    const s = { ...this.get() };
+    delete s.authToken;
+    return s;
+  }
+  _writeRaw(obj) {
+    this.ensureDir();
+    writeFileSync(this.file, JSON.stringify(obj, null, 2));
+    try { chmodSync(this.file, 0o600); } catch { /* best-effort */ }
+  }
+}

--- a/tools/local-control/settings.test.mjs
+++ b/tools/local-control/settings.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { SettingsStore, validatePatch, DEFAULT_SETTINGS } from './settings.mjs';
+
+function mkroot() { return mkdtempSync(resolve(tmpdir(), 'lc-settings-')); }
+
+test('load creates settings file with auth token if missing', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root);
+    const v = s.load();
+    assert.equal(typeof v.authToken, 'string');
+    assert.ok(v.authToken.length >= 32);
+    assert.equal(v.allowExec, false);
+    assert.equal(v.allowAutoMerge, false);
+    const path = resolve(root, '.local-control/settings.json');
+    assert.ok(existsSync(path));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('redactedCopy never includes authToken', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root); s.load();
+    const r = s.redactedCopy();
+    assert.equal(r.authToken, undefined);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('patch validates and merges', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root); s.load();
+    const next = s.patch({ maxPrsPerRun: 5, allowExec: true });
+    assert.equal(next.maxPrsPerRun, 5);
+    assert.equal(next.allowExec, true);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('patch rejects unknown key', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root); s.load();
+    assert.throws(() => s.patch({ wat: 1 }), /unknown setting/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('patch rejects authToken update via patch', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root); s.load();
+    const before = s.get().authToken;
+    s.patch({ authToken: 'leaked' });
+    assert.equal(s.get().authToken, before);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('patch rejects out-of-range maxPrsPerRun', () => {
+  const root = mkroot();
+  try {
+    const s = new SettingsStore(root); s.load();
+    assert.throws(() => s.patch({ maxPrsPerRun: 999 }), /invalid value/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('validatePatch returns clean and errors', () => {
+  const r = validatePatch({ maxMinutes: 30, allowLoop: 'nope' });
+  assert.deepEqual(r.clean, { maxMinutes: 30 });
+  assert.equal(r.errors.length, 1);
+});
+
+test('DEFAULT_SETTINGS lock the secure defaults', () => {
+  assert.equal(DEFAULT_SETTINGS.allowExec, false);
+  assert.equal(DEFAULT_SETTINGS.allowAutoMerge, false);
+  assert.equal(DEFAULT_SETTINGS.allowLoop, false);
+  assert.equal(DEFAULT_SETTINGS.lanEnabled, false);
+  assert.equal(DEFAULT_SETTINGS.dryRunDefault, true);
+});

--- a/tools/local-control/tests/api.test.mjs
+++ b/tools/local-control/tests/api.test.mjs
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../public/lib/api.js";
+
+function mockFetch(handler) {
+  return (url, init = {}) => {
+    const res = handler(url, init);
+    return Promise.resolve({
+      ok: res.ok ?? true,
+      status: res.status ?? 200,
+      statusText: res.statusText ?? "OK",
+      headers: { get: (k) => (res.headers || {})[k.toLowerCase()] || null },
+      json: async () => res.json,
+      text: async () => res.text || "",
+    });
+  };
+}
+
+test("get sends Accept JSON and resolves body", async () => {
+  globalThis.fetch = mockFetch(() => ({ headers: { "content-type": "application/json" }, json: { ok: true } }));
+  const api = new ApiClient({ baseUrl: "" });
+  const r = await api.get("/api/health");
+  assert.deepEqual(r, { ok: true });
+});
+
+test("post serializes body and includes content-type", async () => {
+  let captured;
+  globalThis.fetch = mockFetch((url, init) => { captured = init; return { headers: { "content-type": "application/json" }, json: { runId: "abc" } }; });
+  const api = new ApiClient({ baseUrl: "" });
+  const r = await api.post("/api/runner/start", { mode: "plan" });
+  assert.equal(r.runId, "abc");
+  assert.equal(captured.method, "POST");
+  assert.equal(JSON.parse(captured.body).mode, "plan");
+});
+
+test("includes bearer header when token set", async () => {
+  let captured;
+  globalThis.fetch = mockFetch((url, init) => { captured = init; return { headers: { "content-type": "application/json" }, json: {} }; });
+  const api = new ApiClient({ baseUrl: "", token: "tok123" });
+  await api.get("/api/health");
+  assert.match(captured.headers.authorization, /^Bearer tok123$/);
+});
+
+test("throws on non-ok response", async () => {
+  globalThis.fetch = mockFetch(() => ({ ok: false, status: 500, statusText: "Internal", headers: { "content-type": "text/plain" }, text: "boom" }));
+  const api = new ApiClient({ baseUrl: "" });
+  await assert.rejects(() => api.get("/x"), /500/);
+});
+
+test("401 without prompt rejects (no window in node)", async () => {
+  globalThis.fetch = mockFetch(() => ({ ok: false, status: 401, statusText: "Unauthorized", headers: { "content-type": "text/plain" }, text: "no" }));
+  const api = new ApiClient({ baseUrl: "" });
+  await assert.rejects(() => api.get("/x"), /401/);
+});

--- a/tools/local-control/tests/redact.test.mjs
+++ b/tools/local-control/tests/redact.test.mjs
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { redact } from "../public/lib/redact.js";
+
+test("redacts bearer tokens", () => {
+  const s = "Authorization: Bearer abcdef1234567890";
+  const out = redact(s);
+  assert.ok(!out.includes("abcdef1234567890"));
+  assert.match(out, /REDACTED/);
+});
+
+test("redacts env-style assignments", () => {
+  const out = redact("GITHUB_TOKEN=ghp_abcdefghijklmnopqrst1234567890");
+  assert.ok(!out.includes("ghp_abcdefghijklmnopqrst1234567890"));
+});
+
+test("redacts openai-style sk- keys", () => {
+  const out = redact('"key":"sk-proj-abcdefghijklmnopqrstuvwxyz"');
+  assert.ok(!out.includes("sk-proj-abcdefghijklmnopqrstuvwxyz"));
+});
+
+test("leaves harmless strings alone", () => {
+  const s = "Hello world, this is fine.";
+  assert.equal(redact(s), s);
+});
+
+test("handles non-string input", () => {
+  assert.equal(redact(null), null);
+  assert.equal(typeof redact({ a: 1 }), "string");
+});

--- a/tools/local-control/tests/validate.test.mjs
+++ b/tools/local-control/tests/validate.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateRunnerForm, validateSettings, parseCsv } from "../public/lib/validate.js";
+
+test("plan dry-run passes", () => {
+  assert.equal(validateRunnerForm({ mode: "plan", maxPRs: 3, maxMinutes: 20, dryRun: true, allowExec: false, allowLoop: false, allowAutoMerge: false, issue: null }), null);
+});
+
+test("exec without allowExec and not dry-run blocks", () => {
+  const err = validateRunnerForm({ mode: "exec", maxPRs: 3, maxMinutes: 20, dryRun: false, allowExec: false, allowLoop: false, allowAutoMerge: false, issue: 41 });
+  assert.match(err, /allowExec/);
+});
+
+test("loop without allowLoop blocks", () => {
+  const err = validateRunnerForm({ mode: "loop", maxPRs: 3, maxMinutes: 20, dryRun: true, allowExec: false, allowLoop: false, allowAutoMerge: false, issue: null });
+  assert.match(err, /loop/);
+});
+
+test("auto-merge incompatible with dry-run", () => {
+  const err = validateRunnerForm({ mode: "exec", maxPRs: 3, maxMinutes: 20, dryRun: true, allowExec: true, allowLoop: false, allowAutoMerge: true, issue: 41 });
+  assert.match(err, /auto-merge/);
+});
+
+test("rejects out-of-range maxPRs", () => {
+  const err = validateRunnerForm({ mode: "plan", maxPRs: 999, maxMinutes: 20, dryRun: true, allowExec: false, allowLoop: false, allowAutoMerge: false, issue: null });
+  assert.match(err, /maxPRs/);
+});
+
+test("settings rejects bad staleDays", () => {
+  assert.match(validateSettings({ staleDays: -1 }), /staleDays/);
+  assert.match(validateSettings({ staleDays: 999 }), /staleDays/);
+});
+
+test("settings rejects bad maxPrsPerRun", () => {
+  assert.match(validateSettings({ maxPrsPerRun: 0 }), /maxPrsPerRun/);
+  assert.match(validateSettings({ maxPrsPerRun: 11 }), /maxPrsPerRun/);
+});
+
+test("parseCsv splits and trims", () => {
+  assert.deepEqual(parseCsv(" a, b ,c, "), ["a", "b", "c"]);
+  assert.deepEqual(parseCsv(""), []);
+});


### PR DESCRIPTION
## Summary

Adds a secure local cockpit for piloting the semi-autonomous task system.

Includes:
- local backend control server
- responsive cockpit UI
- authenticated API
- command whitelist
- live logs
- local settings
- LAN mode
- auto-merge safety scaffold
- Notion/WhatsApp docs

## Validation

- pnpm local:control:test — 50/50
- pnpm local:control:ui:test — 18/18
- pnpm task:test — 76/76
- pnpm typecheck
- pnpm lint
- pnpm test — 516/516
- pnpm build

## Safety

- no secrets committed
- .local-control/ gitignored
- .claude/ excluded
- localhost by default
- token auth required
- LAN requires explicit enablement
- command whitelist only
- no free shell
- no real loop by default
- no auto-merge by default