### PR TITLE
fix(local-control): improve auth token UX and cockpit usability

### DIFF
--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -13,10 +13,15 @@ import { mountLogs } from "./lib/logs.js";
 import { renderQuestions } from "./lib/questions.js";
 import { mountSettings } from "./lib/settings.js";
 import { confirmDanger } from "./lib/confirm.js";
+import { renderOnboarding } from "./lib/onboarding.js";
+import { runWithState } from "./lib/buttonState.js";
 import {
   TokenStore, ConnState, readTokenFromUrl,
   classifyError, badgeLabel, badgeClass, shouldKeepPolling,
 } from "./lib/auth-ui.js";
+
+let lastSettings = null;
+let lastNetwork = null;
 
 const REFRESH_MS = 15000;
 const tokenStore = new TokenStore(typeof localStorage !== "undefined" ? localStorage : null);
@@ -79,8 +84,12 @@ function setConnState(next, errMsg) {
 }
 
 function setActionsDisabled(disabled) {
-  document.querySelectorAll('main button[data-action], main button[type="submit"], main button[data-preset]')
-    .forEach((b) => { b.disabled = !!disabled; });
+  document.querySelectorAll('main button[data-needs="auth"], main button[type="submit"], main button[data-preset]')
+    .forEach((b) => {
+      b.disabled = !!disabled;
+      if (disabled) b.setAttribute("data-disabled-reason", "Auth requise — colle ton token.");
+      else b.removeAttribute("data-disabled-reason");
+    });
 }
 
 function startPolling() {
@@ -94,26 +103,30 @@ function stopPolling() {
 async function refreshAll() {
   if (!api.token) {
     setConnState(ConnState.AUTH_REQUIRED);
+    renderOnboarding({ conn: "auth-required", settings: lastSettings, network: lastNetwork });
     return;
   }
   try {
-    const [dash, tasks, questions, settings] = await Promise.all([
+    const [dash, tasks, questions, settings, network] = await Promise.all([
       api.get("/api/dashboard"),
       api.get("/api/tasks?limit=50"),
       api.get("/api/questions"),
       api.get("/api/settings"),
+      api.get("/api/network").catch(() => null),
     ]);
+    lastSettings = settings;
+    lastNetwork = network;
     renderDashboard(dash);
-    renderTasks(tasks.items || [], { api, confirmDanger });
+    renderTasks(tasks.items || [], { api, confirmDanger, settings, conn: "connected" });
     renderQuestions(questions.items || [], { api });
     applySettingsToBadges(settings);
+    renderOnboarding({ conn: "connected", settings, network });
     setConnState(ConnState.CONNECTED);
   } catch (e) {
     const next = classifyError(e);
-    if (next === ConnState.AUTH_REQUIRED && lastLoggedState !== ConnState.AUTH_REQUIRED) {
-      // log only on transition
-    }
     setConnState(next, redact(String(e?.message || e)));
+    const simple = next === ConnState.AUTH_REQUIRED ? "auth-required" : next === ConnState.OFFLINE ? "offline" : "connected";
+    renderOnboarding({ conn: simple, settings: lastSettings, network: lastNetwork });
   }
 }
 
@@ -137,21 +150,26 @@ function log(line) {
   if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight;
 }
 
-document.querySelector('[data-action="refresh"]').addEventListener("click", () => refreshAll());
-document.querySelector('[data-action="doctor"]').addEventListener("click", async () => {
-  try {
-    const r = await api.post("/api/doctor/run", {});
-    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-  } catch (e) { setConnState(classifyError(e), redact(String(e?.message || e))); }
-});
-document.querySelector('[data-action="score"]').addEventListener("click", () => api.post("/api/tasks/score", {}).catch(() => {}));
-document.querySelector('[data-action="queue"]').addEventListener("click", () => refreshAll());
-document.querySelector('[data-action="plan-next"]').addEventListener("click", async () => {
-  try {
-    const r = await api.post("/api/runner/start", { mode: "plan", dryRun: true });
-    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-  } catch (e) { setConnState(classifyError(e), redact(String(e?.message || e))); }
-});
+const refreshBtn = document.querySelector('[data-action="refresh"]');
+refreshBtn.addEventListener("click", () => runWithState(refreshBtn, refreshAll).catch(() => {}));
+
+const doctorBtn = document.querySelector('[data-action="doctor"]');
+doctorBtn.addEventListener("click", () => runWithState(doctorBtn, async () => {
+  const r = await api.post("/api/doctor/run", {});
+  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+}).catch((e) => setConnState(classifyError(e), redact(String(e?.message || e)))));
+
+const scoreBtn = document.querySelector('[data-action="score"]');
+scoreBtn.addEventListener("click", () => runWithState(scoreBtn, () => api.post("/api/tasks/score", {})).catch(() => {}));
+
+const queueBtn = document.querySelector('[data-action="queue"]');
+queueBtn.addEventListener("click", () => runWithState(queueBtn, refreshAll).catch(() => {}));
+
+const planNextBtn = document.querySelector('[data-action="plan-next"]');
+planNextBtn.addEventListener("click", () => runWithState(planNextBtn, async () => {
+  const r = await api.post("/api/runner/start", { mode: "plan", dryRun: true });
+  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+}).catch((e) => setConnState(classifyError(e), redact(String(e?.message || e)))));
 document.querySelector('[data-action="reload-tasks"]').addEventListener("click", () => refreshAll());
 
 document.getElementById("auth-form").addEventListener("submit", (ev) => {

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -1,10 +1,9 @@
 // WebAppV1 Local Control — UI app
-// Talks to backend at same origin. Backend = tools/local-control/server.mjs (Claude A).
-// All long-running ops return a runId; UI subscribes via SSE.
+// Talks to backend at same origin. Backend = tools/local-control/server.mjs.
 
-import { ApiClient } from "./lib/api.js";
+import { ApiClient, AuthError, NetworkError } from "./lib/api.js";
 import { redact } from "./lib/redact.js";
-import { state, setMode, setLan, setAutoMerge } from "./lib/state.js";
+import { setMode, setLan, setAutoMerge } from "./lib/state.js";
 import { mountTabs } from "./lib/tabs.js";
 import { renderDashboard } from "./lib/dashboard.js";
 import { renderTasks } from "./lib/tasks.js";
@@ -14,22 +13,30 @@ import { mountLogs } from "./lib/logs.js";
 import { renderQuestions } from "./lib/questions.js";
 import { mountSettings } from "./lib/settings.js";
 import { confirmDanger } from "./lib/confirm.js";
+import {
+  TokenStore, ConnState, readTokenFromUrl,
+  classifyError, badgeLabel, badgeClass, shouldKeepPolling,
+} from "./lib/auth-ui.js";
 
-const TOKEN_KEY = "localControlToken";
+const REFRESH_MS = 15000;
+const tokenStore = new TokenStore(typeof localStorage !== "undefined" ? localStorage : null);
+
 function bootstrapToken() {
-  const url = new URL(location.href);
-  const fromUrl = url.searchParams.get("token");
-  if (fromUrl) {
-    try { localStorage.setItem(TOKEN_KEY, fromUrl); } catch {}
-    url.searchParams.delete("token");
-    history.replaceState(null, "", url.toString());
-    return fromUrl;
+  const { token, cleanedHref } = readTokenFromUrl(location.href);
+  if (token) {
+    tokenStore.set(token);
+    history.replaceState(null, "", cleanedHref);
+    return token;
   }
-  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
+  return tokenStore.get();
 }
 
 const api = new ApiClient({ baseUrl: "", token: bootstrapToken() });
 window.__api = api;
+
+let connState = ConnState.UNKNOWN;
+let pollTimer = null;
+let lastLoggedState = null;
 
 mountTabs();
 mountLogs(api);
@@ -37,7 +44,58 @@ mountRunner(api, { confirmDanger });
 mountPrompt(api);
 mountSettings(api, { onChange: applySettingsToBadges });
 
+function setConnState(next, errMsg) {
+  connState = next;
+  const dot = document.getElementById("conn-dot");
+  dot.classList.toggle("ok", next === ConnState.CONNECTED);
+  dot.classList.toggle("err", next === ConnState.OFFLINE || next === ConnState.AUTH_REQUIRED);
+  const badge = document.getElementById("conn-badge");
+  badge.textContent = badgeLabel(next);
+  badge.classList.remove("ok", "err", "warn");
+  const cls = badgeClass(next);
+  if (cls) badge.classList.add(cls);
+
+  const authPanel = document.getElementById("auth-panel");
+  authPanel.classList.toggle("hidden", next !== ConnState.AUTH_REQUIRED);
+  setActionsDisabled(next !== ConnState.CONNECTED);
+
+  if (next === ConnState.AUTH_REQUIRED) {
+    const title = document.getElementById("auth-title");
+    title.textContent = api.token ? "Auth token invalide" : "Auth token required";
+    const errEl = document.getElementById("auth-error");
+    if (errMsg) { errEl.textContent = errMsg; errEl.classList.remove("hidden"); }
+    else errEl.classList.add("hidden");
+  }
+
+  if (lastLoggedState !== next) {
+    lastLoggedState = next;
+    if (next === ConnState.AUTH_REQUIRED) log("⚠ auth required — paste your token");
+    else if (next === ConnState.OFFLINE) log("⚠ backend offline — relancer `pnpm local:control`");
+    else if (next === ConnState.CONNECTED) log("✓ connected");
+  }
+
+  if (shouldKeepPolling(next)) startPolling();
+  else stopPolling();
+}
+
+function setActionsDisabled(disabled) {
+  document.querySelectorAll('main button[data-action], main button[type="submit"], main button[data-preset]')
+    .forEach((b) => { b.disabled = !!disabled; });
+}
+
+function startPolling() {
+  if (pollTimer) return;
+  pollTimer = setInterval(() => { refreshAll().catch(() => {}); }, REFRESH_MS);
+}
+function stopPolling() {
+  if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+}
+
 async function refreshAll() {
+  if (!api.token) {
+    setConnState(ConnState.AUTH_REQUIRED);
+    return;
+  }
   try {
     const [dash, tasks, questions, settings] = await Promise.all([
       api.get("/api/dashboard"),
@@ -49,16 +107,14 @@ async function refreshAll() {
     renderTasks(tasks.items || [], { api, confirmDanger });
     renderQuestions(questions.items || [], { api });
     applySettingsToBadges(settings);
-    setConn(true);
+    setConnState(ConnState.CONNECTED);
   } catch (e) {
-    setConn(false);
-    log("⚠ refresh failed: " + redact(String(e.message || e)));
+    const next = classifyError(e);
+    if (next === ConnState.AUTH_REQUIRED && lastLoggedState !== ConnState.AUTH_REQUIRED) {
+      // log only on transition
+    }
+    setConnState(next, redact(String(e?.message || e)));
   }
-}
-
-function setConn(ok) {
-  document.getElementById("conn-dot").classList.toggle("ok", !!ok);
-  document.getElementById("conn-dot").classList.toggle("err", !ok);
 }
 
 function applySettingsToBadges(s) {
@@ -81,18 +137,37 @@ function log(line) {
   if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight;
 }
 
-document.querySelector('[data-action="refresh"]').addEventListener("click", refreshAll);
+document.querySelector('[data-action="refresh"]').addEventListener("click", () => refreshAll());
 document.querySelector('[data-action="doctor"]').addEventListener("click", async () => {
-  const r = await api.post("/api/doctor/run", {});
-  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  try {
+    const r = await api.post("/api/doctor/run", {});
+    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  } catch (e) { setConnState(classifyError(e), redact(String(e?.message || e))); }
 });
 document.querySelector('[data-action="score"]').addEventListener("click", () => api.post("/api/tasks/score", {}).catch(() => {}));
 document.querySelector('[data-action="queue"]').addEventListener("click", () => refreshAll());
 document.querySelector('[data-action="plan-next"]').addEventListener("click", async () => {
-  const r = await api.post("/api/runner/start", { mode: "plan", dryRun: true });
-  if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  try {
+    const r = await api.post("/api/runner/start", { mode: "plan", dryRun: true });
+    if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
+  } catch (e) { setConnState(classifyError(e), redact(String(e?.message || e))); }
 });
-document.querySelector('[data-action="reload-tasks"]').addEventListener("click", refreshAll);
+document.querySelector('[data-action="reload-tasks"]').addEventListener("click", () => refreshAll());
 
+document.getElementById("auth-form").addEventListener("submit", (ev) => {
+  ev.preventDefault();
+  const input = document.getElementById("auth-token-input");
+  const t = (input.value || "").trim();
+  if (!t) return;
+  api.setToken(t);
+  input.value = "";
+  setConnState(ConnState.UNKNOWN);
+  refreshAll();
+});
+document.getElementById("auth-retry").addEventListener("click", () => {
+  setConnState(ConnState.UNKNOWN);
+  refreshAll();
+});
+
+setConnState(api.token ? ConnState.UNKNOWN : ConnState.AUTH_REQUIRED);
 refreshAll();
-setInterval(refreshAll, 15000);

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -181,7 +181,7 @@
     <div class="presets">
       <button data-preset="plan-next-task">Plan next task</button>
       <button data-preset="run-one-safe-task">Run one safe task</button>
-      <button data-preset="loop-safe-tasks">Loop safe tasks</button>
+      <button data-preset="loop-safe-tasks">Loop safe tasks dry-run</button>
       <button data-preset="resume-after-answer">Resume after answer</button>
       <button data-preset="analyze-blockage">Analyze blockage</button>
     </div>

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -24,15 +24,56 @@
     <button data-tab="settings">Settings</button>
   </nav>
   <div class="topbar-right">
+    <span id="conn-badge" class="badge">…</span>
     <span id="mode-badge" class="badge dry">DRY-RUN</span>
     <span id="lan-badge" class="badge hidden warn">LAN</span>
     <span id="automerge-badge" class="badge hidden danger">AUTO-MERGE</span>
   </div>
 </header>
 
+<section id="auth-panel" class="auth-panel hidden" aria-live="polite">
+  <div class="auth-card">
+    <h2 id="auth-title">Auth token required</h2>
+    <p id="auth-message" class="muted small">
+      Colle ton token Local Control. Tu le trouves dans
+      <code>.local-control/settings.json</code> → champ <code>authToken</code>.
+    </p>
+    <form id="auth-form">
+      <input id="auth-token-input" type="password" autocomplete="off" spellcheck="false" placeholder="auth token" />
+      <div class="actions">
+        <button type="submit" class="primary" id="auth-save">Save token</button>
+        <button type="button" id="auth-retry">Retry connection</button>
+      </div>
+    </form>
+    <p id="auth-error" class="warn-line hidden"></p>
+  </div>
+</section>
+
 <main>
   <!-- DASHBOARD -->
   <section data-pane="dashboard" class="pane active">
+    <div class="card onboarding" id="onboarding-card">
+      <h3>Démarrage rapide</h3>
+      <ul class="onboarding-list" id="onboarding-list">
+        <li data-key="server"><span class="dot"></span><span class="label">Serveur</span><span class="value" data-value>—</span></li>
+        <li data-key="auth"><span class="dot"></span><span class="label">Auth</span><span class="value" data-value>—</span></li>
+        <li data-key="mode"><span class="dot"></span><span class="label">Mode</span><span class="value" data-value>—</span></li>
+        <li data-key="dryrun"><span class="dot"></span><span class="label">Run mode</span><span class="value" data-value>—</span></li>
+      </ul>
+      <ol class="onboarding-steps">
+        <li>Clique <strong>Run doctor</strong> pour vérifier l'état du repo.</li>
+        <li>Clique <strong>Score tasks</strong> pour classer les issues.</li>
+        <li>Clique <strong>Queue</strong> pour voir la file.</li>
+        <li>Clique <strong>Plan next task</strong> pour préparer la prochaine action.</li>
+      </ol>
+    </div>
+    <div class="card phone-url" id="phone-card">
+      <h3>Accès téléphone</h3>
+      <p class="small">Local: <code id="phone-local">—</code></p>
+      <p class="small">LAN: <code id="phone-lan">—</code></p>
+      <p class="small muted" id="phone-hint">Active LAN dans Settings + relance avec <code>pnpm local:control:lan</code>. IP non détectée ? <code>ipconfig getifaddr en0</code>.</p>
+      <p class="small warn-line">⚠ Utilise <code>?token=...</code> seulement sur Wi-Fi privé.</p>
+    </div>
     <div class="grid">
       <div class="card">
         <h3>Branche</h3>
@@ -78,10 +119,10 @@
 
     <div class="actions">
       <button data-action="refresh">Refresh</button>
-      <button data-action="doctor">Run doctor</button>
-      <button data-action="score">Score tasks</button>
-      <button data-action="queue">Queue</button>
-      <button data-action="plan-next" class="primary">Plan next task</button>
+      <button data-action="doctor" data-needs="auth">Run doctor</button>
+      <button data-action="score" data-needs="auth">Score tasks</button>
+      <button data-action="queue" data-needs="auth">Queue</button>
+      <button data-action="plan-next" class="primary" data-needs="auth">Plan next task</button>
     </div>
   </section>
 
@@ -175,11 +216,26 @@
       <label>Max minutes <input type="number" name="maxMinutes" min="1" max="240" /></label>
       <label>Stale days <input type="number" name="staleDays" min="0" max="365" /></label>
       <label>Issue préférée <input type="number" name="preferredIssue" min="1" placeholder="ex: 41" /></label>
-      <label class="check"><input type="checkbox" name="dryRunDefault"> Dry-run par défaut</label>
-      <label class="check"><input type="checkbox" name="allowExec"> Autoriser exec</label>
-      <label class="check"><input type="checkbox" name="allowLoop"> Autoriser loop</label>
-      <label class="check danger"><input type="checkbox" name="allowAutoMerge"> Autoriser auto-merge</label>
-      <label class="check"><input type="checkbox" name="lanEnabled"> Activer LAN</label>
+      <label class="check setting-row">
+        <input type="checkbox" name="dryRunDefault">
+        <span><strong>Dry-run par défaut</strong><span class="setting-desc">Plan only, aucune action réelle.</span></span>
+      </label>
+      <label class="check setting-row">
+        <input type="checkbox" name="allowExec">
+        <span><strong>Autoriser exec</strong><span class="setting-desc">Autorise une vraie exécution task, pas juste plan.</span></span>
+      </label>
+      <label class="check setting-row">
+        <input type="checkbox" name="allowLoop">
+        <span><strong>Autoriser loop</strong><span class="setting-desc">Autorise plusieurs tasks consécutives jusqu'à maxPRs.</span></span>
+      </label>
+      <label class="check danger setting-row">
+        <input type="checkbox" name="allowAutoMerge">
+        <span><strong>Autoriser auto-merge</strong><span class="setting-desc">Autorise la capacité auto-merge ultra safe (safe+CI green+protection OK).</span></span>
+      </label>
+      <label class="check setting-row">
+        <input type="checkbox" name="lanEnabled">
+        <span><strong>Activer LAN</strong><span class="setting-desc">Rend le serveur accessible au téléphone si lancé avec <code>local:control:lan</code>.</span></span>
+      </label>
 
       <label>Risk autorisés <input type="text" name="allowedRisk" placeholder="safe" /></label>
       <label>Autonomy autorisés <input type="text" name="allowedAutonomy" placeholder="autonomous" /></label>

--- a/tools/local-control/public/lib/api.js
+++ b/tools/local-control/public/lib/api.js
@@ -1,3 +1,10 @@
+export class AuthError extends Error {
+  constructor(msg = "401 unauthorized") { super(msg); this.name = "AuthError"; this.status = 401; }
+}
+export class NetworkError extends Error {
+  constructor(msg = "backend unreachable") { super(msg); this.name = "NetworkError"; }
+}
+
 export class ApiClient {
   constructor({ baseUrl = "", token = null } = {}) {
     this.baseUrl = baseUrl;
@@ -8,17 +15,23 @@ export class ApiClient {
     if (this.token) h["authorization"] = `Bearer ${this.token}`;
     return h;
   }
-  setToken(t) { this.token = t || null; try { if (t) localStorage.setItem("localControlToken", t); } catch {} }
+  setToken(t) {
+    this.token = t || null;
+    try { if (t) localStorage.setItem("localControlToken", t); } catch {}
+  }
+  clearToken() {
+    this.token = null;
+    try { localStorage.removeItem("localControlToken"); } catch {}
+  }
   async _fetch(path, opts = {}) {
-    const res = await fetch(this.baseUrl + path, opts);
+    let res;
+    try {
+      res = await fetch(this.baseUrl + path, opts);
+    } catch (e) {
+      throw new NetworkError(String(e?.message || e));
+    }
     if (res.status === 401) {
-      const t = (typeof window !== "undefined" && window.prompt) ? window.prompt("Token Local Control requis (cf. .local-control/settings.json) :") : null;
-      if (t) {
-        this.setToken(t);
-        const next = { ...opts, headers: this._headers(opts.headers || {}) };
-        return this._fetch(path, next);
-      }
-      throw new Error("401 unauthorized");
+      throw new AuthError("401 unauthorized");
     }
     if (!res.ok) {
       let msg = `${res.status} ${res.statusText}`;

--- a/tools/local-control/public/lib/auth-ui.js
+++ b/tools/local-control/public/lib/auth-ui.js
@@ -1,0 +1,52 @@
+export const TOKEN_KEY = "localControlToken";
+
+export const ConnState = Object.freeze({
+  UNKNOWN: "unknown",
+  CONNECTED: "connected",
+  AUTH_REQUIRED: "auth-required",
+  OFFLINE: "offline",
+});
+
+export function readTokenFromUrl(href) {
+  const url = new URL(href);
+  const t = url.searchParams.get("token");
+  if (!t) return { token: null, cleanedHref: href };
+  url.searchParams.delete("token");
+  return { token: t.trim(), cleanedHref: url.toString() };
+}
+
+export function classifyError(err) {
+  if (!err) return ConnState.OFFLINE;
+  if (err.name === "AuthError" || /^401\b/.test(String(err.message || ""))) return ConnState.AUTH_REQUIRED;
+  if (err.name === "NetworkError" || /Failed to fetch|NetworkError|ECONNREFUSED|ENOTFOUND/i.test(String(err.message || ""))) return ConnState.OFFLINE;
+  return ConnState.OFFLINE;
+}
+
+export function shouldKeepPolling(state) {
+  return state === ConnState.CONNECTED || state === ConnState.UNKNOWN;
+}
+
+export function badgeLabel(state) {
+  switch (state) {
+    case ConnState.CONNECTED: return "CONNECTED";
+    case ConnState.AUTH_REQUIRED: return "AUTH REQUIRED";
+    case ConnState.OFFLINE: return "BACKEND OFFLINE";
+    default: return "…";
+  }
+}
+
+export function badgeClass(state) {
+  switch (state) {
+    case ConnState.CONNECTED: return "ok";
+    case ConnState.AUTH_REQUIRED: return "warn";
+    case ConnState.OFFLINE: return "err";
+    default: return "";
+  }
+}
+
+export class TokenStore {
+  constructor(storage) { this.storage = storage; }
+  get() { try { return this.storage?.getItem(TOKEN_KEY) || null; } catch { return null; } }
+  set(t) { try { if (t) this.storage?.setItem(TOKEN_KEY, t); } catch {} }
+  clear() { try { this.storage?.removeItem(TOKEN_KEY); } catch {} }
+}

--- a/tools/local-control/public/lib/buttonState.js
+++ b/tools/local-control/public/lib/buttonState.js
@@ -1,0 +1,71 @@
+// Pure helpers for button state. Tested in node.
+// Not coupled to DOM — apply* functions take an element-like object with
+// classList.add/remove, removeAttribute, setAttribute, and disabled.
+
+export const REASONS = Object.freeze({
+  AUTH: "Auth requise — colle ton token.",
+  EXEC: "Désactivé : settings.allowExec = false.",
+  LOOP: "Désactivé : settings.allowLoop = false.",
+  AUTOMERGE: "Désactivé : settings.allowAutoMerge = false.",
+  OFFLINE: "Backend offline.",
+  ACTIVE_RUN: "Un run est déjà actif.",
+  TASK_BLOCKED: "Task bloquée — voir raison.",
+  TASK_NOT_EXECUTABLE: "Task non exécutable (classification non safe).",
+});
+
+export function computeDisabledReason({ need, conn, settings, hasActiveRun, taskExecutable }) {
+  if (conn === "auth-required") return REASONS.AUTH;
+  if (conn === "offline") return REASONS.OFFLINE;
+  if (need === "exec" && !(settings?.allowExec)) return REASONS.EXEC;
+  if (need === "loop" && !(settings?.allowLoop)) return REASONS.LOOP;
+  if (need === "automerge" && !(settings?.allowAutoMerge)) return REASONS.AUTOMERGE;
+  if (need === "task-run" && !taskExecutable) return REASONS.TASK_NOT_EXECUTABLE;
+  if (hasActiveRun && (need === "exec" || need === "loop" || need === "task-run")) return REASONS.ACTIVE_RUN;
+  return null;
+}
+
+export function applyDisabled(btn, reason) {
+  if (!btn) return;
+  if (reason) {
+    btn.disabled = true;
+    btn.setAttribute("data-disabled-reason", reason);
+    btn.setAttribute("title", reason);
+  } else {
+    btn.disabled = false;
+    btn.removeAttribute("data-disabled-reason");
+    btn.removeAttribute("title");
+  }
+}
+
+export function setLoading(btn) {
+  if (!btn) return;
+  btn.classList.remove("is-success", "is-error");
+  btn.classList.add("is-loading");
+  btn.disabled = true;
+}
+export function setSuccess(btn) {
+  if (!btn) return;
+  btn.classList.remove("is-loading", "is-error");
+  btn.classList.add("is-success");
+  btn.disabled = false;
+  setTimeout(() => btn.classList.remove("is-success"), 1500);
+}
+export function setError(btn, msg) {
+  if (!btn) return;
+  btn.classList.remove("is-loading", "is-success");
+  btn.classList.add("is-error");
+  btn.disabled = false;
+  if (msg) btn.setAttribute("title", msg);
+}
+
+export async function runWithState(btn, fn) {
+  setLoading(btn);
+  try {
+    const r = await fn();
+    setSuccess(btn);
+    return r;
+  } catch (e) {
+    setError(btn, String(e?.message || e));
+    throw e;
+  }
+}

--- a/tools/local-control/public/lib/logGroup.js
+++ b/tools/local-control/public/lib/logGroup.js
@@ -1,0 +1,26 @@
+// Groups consecutive identical lines into "<line> ×N" so repeated errors don't flood.
+// Pure: takes [lines], returns [{ line, count, isError }].
+
+const ERROR_RE = /\b(error|fail|failed|exception|stack|EACCES|ENOENT|ECONN|panic)\b/i;
+
+export function isErrorLine(s) {
+  return ERROR_RE.test(String(s ?? ""));
+}
+
+export function groupLines(lines) {
+  const out = [];
+  for (const raw of lines) {
+    const line = String(raw ?? "");
+    const last = out[out.length - 1];
+    if (last && last.line === line) {
+      last.count += 1;
+    } else {
+      out.push({ line, count: 1, isError: isErrorLine(line) });
+    }
+  }
+  return out;
+}
+
+export function formatGrouped(groups) {
+  return groups.map((g) => g.count > 1 ? `${g.line}  ×${g.count}` : g.line).join("\n");
+}

--- a/tools/local-control/public/lib/logs.js
+++ b/tools/local-control/public/lib/logs.js
@@ -1,10 +1,11 @@
 import { redact } from "./redact.js";
+import { groupLines, formatGrouped } from "./logGroup.js";
 
 export function mountLogs(api) {
   const view = document.getElementById("log-view");
   const select = document.getElementById("log-run-select");
   let currentEs = null;
-  let currentRunId = null;
+  let buffer = [];
 
   async function refreshRuns() {
     try {
@@ -25,8 +26,9 @@ export function mountLogs(api) {
   function subscribe(runId) {
     if (!runId) return;
     if (currentEs) { currentEs.close(); currentEs = null; }
-    currentRunId = runId;
+    buffer = [];
     appendLine(`— Subscribed to run ${runId} —`);
+    setRunIdTag(runId);
     currentEs = api.subscribe(runId, {
       onLog: (data) => appendLine(redact(data?.line ?? data)),
       onStatus: (data) => appendLine(`[status] ${redact(JSON.stringify(data))}`),
@@ -37,17 +39,43 @@ export function mountLogs(api) {
 
   function appendLine(line) {
     if (line == null) return;
-    view.textContent += String(line) + "\n";
+    buffer.push(String(line));
+    if (buffer.length > 500) buffer = buffer.slice(-500);
+    const groups = groupLines(buffer);
+    view.textContent = formatGrouped(groups);
     if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight;
+  }
+
+  function setRunIdTag(runId) {
+    let tag = document.getElementById("log-run-tag");
+    if (!tag) {
+      tag = document.createElement("span");
+      tag.id = "log-run-tag";
+      tag.className = "run-id-tag";
+      document.querySelector(".logs-toolbar")?.appendChild(tag);
+    }
+    tag.textContent = runId ? `runId: ${runId}` : "";
   }
 
   select.addEventListener("change", () => subscribe(select.value));
   select.addEventListener("subscribe", (e) => { refreshRuns(); subscribe(e.detail); });
 
-  document.querySelector('[data-action="copy-logs"]').addEventListener("click", () => {
-    navigator.clipboard?.writeText(view.textContent || "").catch(() => {});
+  document.querySelector('[data-action="copy-logs"]').addEventListener("click", async () => {
+    const text = redact(view.textContent || "");
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        const ta = document.createElement("textarea");
+        ta.value = text; document.body.appendChild(ta); ta.select();
+        document.execCommand("copy"); document.body.removeChild(ta);
+      }
+    } catch {}
   });
-  document.querySelector('[data-action="clear-logs"]').addEventListener("click", () => { view.textContent = ""; });
+  document.querySelector('[data-action="clear-logs"]').addEventListener("click", () => {
+    buffer = [];
+    view.textContent = "";
+  });
 
   refreshRuns();
   setInterval(refreshRuns, 10000);

--- a/tools/local-control/public/lib/onboarding.js
+++ b/tools/local-control/public/lib/onboarding.js
@@ -1,0 +1,67 @@
+// Renders the onboarding card on dashboard. Pure DOM update.
+
+export function renderOnboarding({ conn, settings, network }) {
+  setRow("server", connServerLabel(conn), connServerCls(conn));
+  const authState = conn === "connected" ? { label: settings?.authTokenSet === false ? "ouverte (no token)" : "OK", cls: "ok" }
+    : conn === "auth-required" ? { label: "token requis", cls: "warn" }
+    : { label: "—", cls: "" };
+  setRow("auth", authState.label, authState.cls);
+  const lan = network?.lan ? "LAN" : "local";
+  setRow("mode", lan, network?.lan ? "warn" : "ok");
+  const dryRun = settings?.dryRunDefault ? "DRY-RUN" : "LIVE";
+  setRow("dryrun", dryRun, settings?.dryRunDefault ? "ok" : "warn");
+  renderPhone(network);
+}
+
+function connServerLabel(c) {
+  if (c === "connected") return "connecté";
+  if (c === "auth-required") return "token requis";
+  if (c === "offline") return "offline";
+  return "—";
+}
+function connServerCls(c) {
+  if (c === "connected") return "ok";
+  if (c === "auth-required") return "warn";
+  if (c === "offline") return "err";
+  return "";
+}
+
+function setRow(key, value, cls) {
+  const li = document.querySelector(`#onboarding-list li[data-key="${key}"]`);
+  if (!li) return;
+  li.classList.remove("ok", "warn", "err");
+  if (cls) li.classList.add(cls);
+  const v = li.querySelector("[data-value]");
+  if (v) v.textContent = value;
+}
+
+function renderPhone(network) {
+  const local = document.getElementById("phone-local");
+  const lan = document.getElementById("phone-lan");
+  const hint = document.getElementById("phone-hint");
+  if (!local || !lan) return;
+  local.textContent = network?.localUrl || "http://127.0.0.1:8787";
+  if (network?.lanUrl) {
+    lan.textContent = network.lanUrl;
+    if (hint) hint.textContent = "Ouvre cette URL sur ton téléphone (même Wi-Fi).";
+  } else if (network?.lanEnabled) {
+    lan.textContent = "IP LAN inconnue";
+    if (hint) hint.textContent = "Lance ipconfig getifaddr en0 puis relance avec pnpm local:control:lan.";
+  } else {
+    lan.textContent = "désactivé";
+    if (hint) hint.textContent = "Active LAN dans Settings + relance avec pnpm local:control:lan.";
+  }
+}
+
+// Pure data computation, exported for tests.
+export function computeOnboardingState({ conn, settings, network }) {
+  return {
+    server: connServerLabel(conn),
+    auth: conn === "connected" ? "OK" : conn === "auth-required" ? "token requis" : "—",
+    mode: network?.lan ? "LAN" : "local",
+    dryRun: settings?.dryRunDefault ? "DRY-RUN" : "LIVE",
+    localUrl: network?.localUrl || null,
+    lanUrl: network?.lanUrl || null,
+    lanHint: !network?.lanEnabled ? "lan-disabled" : (!network?.lanUrl ? "ip-unknown" : "ready"),
+  };
+}

--- a/tools/local-control/public/lib/prompt.js
+++ b/tools/local-control/public/lib/prompt.js
@@ -1,9 +1,9 @@
-const PRESETS = {
-  "plan-next-task": "Plan la prochaine tâche exécutable. Mode dry-run.",
-  "run-one-safe-task": "Run une seule tâche classifiée 'safe' ou 'trivial'. Stop après PR.",
-  "loop-safe-tasks": "Loop tasks 'safe'/'trivial' jusqu'à maxPRs. Stop si question humaine ou erreur.",
-  "resume-after-answer": "Resume depuis la dernière réponse Notion appliquée à GitHub.",
-  "analyze-blockage": "Analyse pourquoi le runner est bloqué. Liste blockers et propose remédiation.",
+export const PRESETS = {
+  "plan-next-task": "Plan la prochaine tâche exécutable (dry-run). Ne fais que planifier, ne lance aucune action.",
+  "run-one-safe-task": "Run une seule tâche classifiée 'safe' ou 'trivial'. Stop après PR. Respecte allowExec.",
+  "loop-safe-tasks": "Loop dry-run sur tasks 'safe'/'trivial' jusqu'à maxPRs. Aucune écriture réelle. Stop si question humaine ou erreur.",
+  "resume-after-answer": "Resume depuis la dernière réponse humaine appliquée à GitHub. Reprend la task en attente.",
+  "analyze-blockage": "Analyse pourquoi le runner est bloqué. Liste blockers et propose remédiation. Aucune action.",
 };
 
 export function mountPrompt(api) {

--- a/tools/local-control/public/lib/tasks.js
+++ b/tools/local-control/public/lib/tasks.js
@@ -1,6 +1,25 @@
 import { redact } from "./redact.js";
+import { applyDisabled, runWithState, REASONS } from "./buttonState.js";
 
-export function renderTasks(items, { api, confirmDanger }) {
+export function classifyTaskReason(t) {
+  if (!t) return { safe: false, label: "—", cls: "" };
+  const cls = t.classification || "";
+  if (cls === "blocked") return { safe: false, label: t.reason || "bloquée", cls: "task-reason-blocked" };
+  if (cls === "trivial" || cls === "safe") {
+    return { safe: true, label: t.reason || `safe : classification=${cls}`, cls: "task-reason-safe" };
+  }
+  return { safe: false, label: t.reason || `non auto-exécutable (classification=${cls || "?"})`, cls: "" };
+}
+
+export function computeRunDisabledReason({ task, settings, conn }) {
+  if (conn === "auth-required") return REASONS.AUTH;
+  if (conn === "offline") return REASONS.OFFLINE;
+  if (!settings?.allowExec) return REASONS.EXEC;
+  if (!task?.executable) return REASONS.TASK_NOT_EXECUTABLE;
+  return null;
+}
+
+export function renderTasks(items, { api, confirmDanger, settings = null, conn = "connected" } = {}) {
   const tbody = document.querySelector("#tasks-table tbody");
   const filter = document.getElementById("task-filter");
   const classSel = document.getElementById("task-class");
@@ -13,15 +32,18 @@ export function renderTasks(items, { api, confirmDanger }) {
     items
       .filter((t) => !c || t.classification === c)
       .filter((t) => !f || (t.title || "").toLowerCase().includes(f) || (t.labels || []).join(",").toLowerCase().includes(f))
-      .forEach((t) => tbody.appendChild(row(t, { api, confirmDanger })));
+      .forEach((t) => tbody.appendChild(row(t, { api, confirmDanger, settings, conn })));
   };
   draw();
   filter?.addEventListener("input", draw);
   classSel?.addEventListener("change", draw);
 }
 
-function row(t, { api, confirmDanger }) {
+function row(t, { api, confirmDanger, settings, conn }) {
   const tr = document.createElement("tr");
+  const reason = classifyTaskReason(t);
+  if (reason.cls === "task-reason-blocked") tr.classList.add("task-blocked");
+
   tr.innerHTML = `
     <td>#${t.issue}</td>
     <td>${escapeHtml(t.title || "")}</td>
@@ -30,26 +52,29 @@ function row(t, { api, confirmDanger }) {
     <td>${(t.labels || []).map(escapeHtml).join(", ")}</td>
     <td>${escapeHtml(t.risk || "")}</td>
     <td>${escapeHtml(t.autonomy || "")}</td>
-    <td>${escapeHtml(redact(t.reason || ""))}</td>
+    <td class="${reason.cls}">${escapeHtml(redact(reason.label))}</td>
   `;
   const td = document.createElement("td");
   const planBtn = document.createElement("button");
   planBtn.textContent = "Plan";
-  planBtn.addEventListener("click", async () => {
+  applyDisabled(planBtn, conn === "auth-required" ? REASONS.AUTH : (conn === "offline" ? REASONS.OFFLINE : null));
+  planBtn.addEventListener("click", () => runWithState(planBtn, async () => {
     const r = await api.post(`/api/tasks/${t.issue}/plan`, {});
     if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-  });
+  }).catch(() => {}));
+
   const runBtn = document.createElement("button");
   runBtn.textContent = "Run";
   runBtn.classList.add("primary");
-  runBtn.disabled = !t.executable;
-  if (t.executable) {
-    runBtn.addEventListener("click", async () => {
+  const runDisabledReason = computeRunDisabledReason({ task: t, settings, conn });
+  applyDisabled(runBtn, runDisabledReason);
+  if (!runDisabledReason) {
+    runBtn.addEventListener("click", () => runWithState(runBtn, async () => {
       const ok = await confirmDanger({ title: `Exécuter #${t.issue} ?`, body: `Mode exec sur "${t.title}". Tape EXEC pour confirmer.`, magicWord: "EXEC" });
-      if (!ok) return;
+      if (!ok) throw new Error("annulé");
       const r = await api.post("/api/runner/start", { mode: "exec", issue: t.issue, allowExec: true, dryRun: false });
       if (r?.runId) document.getElementById("log-run-select").dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-    });
+    }).catch(() => {}));
   }
   td.append(planBtn, " ", runBtn);
   tr.appendChild(td);

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -116,3 +116,52 @@ dialog input { width: 100%; margin-top: 8px; }
   .grid { grid-template-columns: 1fr; }
   .topbar-right { width: 100%; justify-content: flex-end; }
 }
+
+/* auth panel */
+.auth-panel { position: fixed; inset: 0; background: rgba(8, 10, 13, 0.85); backdrop-filter: blur(4px); display: flex; align-items: center; justify-content: center; z-index: 100; padding: 16px; }
+.auth-panel.hidden { display: none !important; }
+.auth-card { background: var(--bg-elev); border: 1px solid var(--border); border-radius: var(--radius); padding: 22px; max-width: 460px; width: 100%; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
+.auth-card h2 { margin: 0 0 8px; font-size: 18px; }
+.auth-card form { display: flex; flex-direction: column; gap: 10px; margin-top: 12px; }
+.auth-card input { width: 100%; font-family: ui-monospace, Menlo, monospace; }
+.auth-card .actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.badge.ok { color: var(--ok); border-color: var(--ok); }
+.badge.err { color: var(--danger); border-color: var(--danger); }
+
+/* onboarding card */
+.onboarding { margin-bottom: var(--gap); }
+.onboarding-list { list-style: none; padding: 0; margin: 8px 0; display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 8px; }
+.onboarding-list li { display: flex; align-items: center; gap: 8px; padding: 8px 10px; background: var(--bg-elev-2); border-radius: var(--radius); border: 1px solid var(--border); }
+.onboarding-list li .label { color: var(--fg-dim); font-size: 12px; flex: 1; }
+.onboarding-list li .value { font-size: 12px; font-weight: 600; }
+.onboarding-list li.ok .dot { background: var(--ok); }
+.onboarding-list li.warn .dot { background: var(--warn); }
+.onboarding-list li.err .dot { background: var(--danger); }
+.onboarding-steps { margin: 8px 0 0; padding-left: 22px; font-size: 13px; color: var(--fg); }
+.onboarding-steps li { margin: 2px 0; }
+.phone-url { margin-bottom: var(--gap); }
+.phone-url p { margin: 4px 0; }
+
+/* button states */
+button.is-loading { opacity: 0.7; cursor: progress; }
+button.is-loading::after { content: " …"; }
+button.is-success { border-color: var(--ok); }
+button.is-error { border-color: var(--danger); color: var(--danger); }
+button[data-disabled-reason]:disabled { position: relative; }
+.disabled-reason { color: var(--warn); font-size: 11px; display: block; margin-top: 2px; }
+
+/* settings descriptions */
+.setting-row { align-items: flex-start !important; }
+.setting-row > span { display: flex; flex-direction: column; gap: 2px; }
+.setting-desc { color: var(--fg-dim); font-size: 11px; font-weight: normal; }
+
+/* logs grouping */
+.log-line { display: block; }
+.log-line.error { color: var(--danger); }
+.log-group-count { color: var(--warn); font-weight: 600; }
+.run-id-tag { color: var(--accent); font-size: 11px; margin-left: 8px; }
+
+/* tasks reason chips */
+.task-reason-safe { color: var(--ok); }
+.task-reason-blocked { color: var(--danger); }
+tr.task-blocked { opacity: 0.65; }

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, statSync, readdirSync } from 'node:fs';
 import { dirname, resolve, extname, join, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { networkInterfaces } from 'node:os';
 import { SettingsStore } from './settings.mjs';
 import { isAuthenticated, extractToken, constantTimeEqual } from './auth.mjs';
 import { LogStore, StateStore } from './logs.mjs';
@@ -35,6 +36,15 @@ function repoNameWithOwner(repoRoot) {
   });
   return r.status === 0 ? r.stdout.trim() : null;
 }
+function lanIPv4() {
+  const ifs = networkInterfaces();
+  for (const list of Object.values(ifs)) {
+    for (const ni of list || []) {
+      if (ni.family === 'IPv4' && !ni.internal) return ni.address;
+    }
+  }
+  return null;
+}
 function gitInfo(repoRoot) {
   const branchR = spawnSync('git', ['branch', '--show-current'], { cwd: repoRoot, encoding: 'utf8' });
   const dirtyR  = spawnSync('git', ['status', '--porcelain'], { cwd: repoRoot, encoding: 'utf8' });
@@ -51,6 +61,7 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
   const logs = new LogStore(repoRoot);
   const runner = new Runner({ logs, state, settings, repoRoot });
   const startedAt = Date.now();
+  const network = { host: '127.0.0.1', port: 8787, lan: false };
 
   function authOk(req) { return isAuthenticated(req, settings.get().authToken); }
   function send(res, code, body, extraHeaders = {}) {
@@ -104,6 +115,21 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
         activeRunId: runner.activeIds()[0] ?? null,
         uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
         uptimeSec: Math.floor((Date.now() - startedAt) / 1000),
+      });
+    }
+    if (method === 'GET' && path === '/api/network') {
+      const lanIp = lanIPv4();
+      const s = settings.get();
+      const tokenSet = !!s.authToken;
+      return send(res, 200, {
+        host: network.host,
+        port: network.port,
+        lan: !!network.lan,
+        lanEnabled: !!s.lanEnabled,
+        lanIp,
+        localUrl: `http://127.0.0.1:${network.port}`,
+        lanUrl: network.lan && lanIp ? `http://${lanIp}:${network.port}` : null,
+        tokenRequired: tokenSet,
       });
     }
     if (method === 'GET' && path === '/api/dashboard') {
@@ -370,7 +396,7 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
     }
   };
 
-  return { handler, settings, state, logs, runner, repoRoot };
+  return { handler, settings, state, logs, runner, repoRoot, network };
 }
 
 export function startServer({ port = 8787, lan = false, repoRoot = REPO_ROOT_DEFAULT } = {}) {
@@ -381,6 +407,9 @@ export function startServer({ port = 8787, lan = false, repoRoot = REPO_ROOT_DEF
     console.error('[local-control] --lan ignored: settings.lanEnabled is false');
   }
   const host = wantLan ? '0.0.0.0' : '127.0.0.1';
+  app.network.host = host;
+  app.network.port = port;
+  app.network.lan = wantLan;
   const server = createServer(app.handler);
   server.listen(port, host, () => {
     console.log(`[local-control] http://${host}:${port}`);

--- a/tools/local-control/server.test.mjs
+++ b/tools/local-control/server.test.mjs
@@ -166,3 +166,19 @@ test('runner stop is idempotent for unknown id', async () => {
     await close(server);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+test('GET /api/network returns local URL and lan flags', async () => {
+  const root = mkroot();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const { server, base } = await listenApp(app.handler);
+    const r = await fetch(`${base}/api/network`, { headers: { authorization: `Bearer ${tok}` } });
+    assert.equal(r.status, 200);
+    const j = await r.json();
+    assert.ok(j.localUrl.startsWith('http://127.0.0.1:'));
+    assert.equal(typeof j.lanEnabled, 'boolean');
+    assert.equal(typeof j.tokenRequired, 'boolean');
+    await close(server);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/tools/local-control/tests/api.test.mjs
+++ b/tools/local-control/tests/api.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { ApiClient } from "../public/lib/api.js";
+import { ApiClient, AuthError, NetworkError } from "../public/lib/api.js";
 
 function mockFetch(handler) {
   return (url, init = {}) => {
@@ -47,8 +47,31 @@ test("throws on non-ok response", async () => {
   await assert.rejects(() => api.get("/x"), /500/);
 });
 
-test("401 without prompt rejects (no window in node)", async () => {
-  globalThis.fetch = mockFetch(() => ({ ok: false, status: 401, statusText: "Unauthorized", headers: { "content-type": "text/plain" }, text: "no" }));
+test("401 throws typed AuthError without retry/prompt", async () => {
+  let calls = 0;
+  globalThis.fetch = mockFetch(() => { calls++; return { ok: false, status: 401, statusText: "Unauthorized", headers: { "content-type": "text/plain" }, text: "no" }; });
   const api = new ApiClient({ baseUrl: "" });
-  await assert.rejects(() => api.get("/x"), /401/);
+  await assert.rejects(() => api.get("/x"), (err) => err instanceof AuthError && err.status === 401);
+  assert.equal(calls, 1, "must not retry on 401");
+});
+
+test("network failure throws typed NetworkError", async () => {
+  globalThis.fetch = () => Promise.reject(new TypeError("Failed to fetch"));
+  const api = new ApiClient({ baseUrl: "" });
+  await assert.rejects(() => api.get("/x"), (err) => err instanceof NetworkError);
+});
+
+test("setToken persists in localStorage when available", async () => {
+  const store = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => store.set(k, v),
+    removeItem: (k) => store.delete(k),
+  };
+  const api = new ApiClient({ baseUrl: "" });
+  api.setToken("xyz");
+  assert.equal(store.get("localControlToken"), "xyz");
+  api.clearToken();
+  assert.equal(store.has("localControlToken"), false);
+  delete globalThis.localStorage;
 });

--- a/tools/local-control/tests/auth-ui.test.mjs
+++ b/tools/local-control/tests/auth-ui.test.mjs
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TokenStore, ConnState, readTokenFromUrl,
+  classifyError, badgeLabel, badgeClass, shouldKeepPolling,
+  TOKEN_KEY,
+} from "../public/lib/auth-ui.js";
+import { AuthError, NetworkError } from "../public/lib/api.js";
+
+test("readTokenFromUrl extracts ?token=... and strips it from href", () => {
+  const { token, cleanedHref } = readTokenFromUrl("http://localhost:8787/?token=abc123&foo=1");
+  assert.equal(token, "abc123");
+  assert.ok(!cleanedHref.includes("token="));
+  assert.ok(cleanedHref.includes("foo=1"));
+});
+
+test("readTokenFromUrl returns null when no token", () => {
+  const { token, cleanedHref } = readTokenFromUrl("http://localhost:8787/");
+  assert.equal(token, null);
+  assert.equal(cleanedHref, "http://localhost:8787/");
+});
+
+test("classifyError maps AuthError to AUTH_REQUIRED", () => {
+  assert.equal(classifyError(new AuthError()), ConnState.AUTH_REQUIRED);
+  assert.equal(classifyError(new Error("401 unauthorized")), ConnState.AUTH_REQUIRED);
+});
+
+test("classifyError maps NetworkError / Failed to fetch to OFFLINE", () => {
+  assert.equal(classifyError(new NetworkError("dead")), ConnState.OFFLINE);
+  assert.equal(classifyError(new TypeError("Failed to fetch")), ConnState.OFFLINE);
+});
+
+test("classifyError defaults to OFFLINE for unknown", () => {
+  assert.equal(classifyError(new Error("500 boom")), ConnState.OFFLINE);
+  assert.equal(classifyError(null), ConnState.OFFLINE);
+});
+
+test("shouldKeepPolling true only for CONNECTED/UNKNOWN", () => {
+  assert.equal(shouldKeepPolling(ConnState.CONNECTED), true);
+  assert.equal(shouldKeepPolling(ConnState.UNKNOWN), true);
+  assert.equal(shouldKeepPolling(ConnState.AUTH_REQUIRED), false);
+  assert.equal(shouldKeepPolling(ConnState.OFFLINE), false);
+});
+
+test("badgeLabel produces expected strings", () => {
+  assert.equal(badgeLabel(ConnState.CONNECTED), "CONNECTED");
+  assert.equal(badgeLabel(ConnState.AUTH_REQUIRED), "AUTH REQUIRED");
+  assert.equal(badgeLabel(ConnState.OFFLINE), "BACKEND OFFLINE");
+});
+
+test("badgeClass picks ok/warn/err class", () => {
+  assert.equal(badgeClass(ConnState.CONNECTED), "ok");
+  assert.equal(badgeClass(ConnState.AUTH_REQUIRED), "warn");
+  assert.equal(badgeClass(ConnState.OFFLINE), "err");
+});
+
+test("TokenStore get/set/clear roundtrip with Map storage", () => {
+  const store = new Map();
+  const fakeStorage = {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => store.set(k, v),
+    removeItem: (k) => store.delete(k),
+  };
+  const ts = new TokenStore(fakeStorage);
+  assert.equal(ts.get(), null);
+  ts.set("tok");
+  assert.equal(store.get(TOKEN_KEY), "tok");
+  assert.equal(ts.get(), "tok");
+  ts.clear();
+  assert.equal(ts.get(), null);
+});
+
+test("TokenStore handles null storage without throwing", () => {
+  const ts = new TokenStore(null);
+  assert.equal(ts.get(), null);
+  assert.doesNotThrow(() => ts.set("x"));
+  assert.doesNotThrow(() => ts.clear());
+});

--- a/tools/local-control/tests/buttonState.test.mjs
+++ b/tools/local-control/tests/buttonState.test.mjs
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeDisabledReason, applyDisabled, setLoading, setSuccess, setError,
+  runWithState, REASONS,
+} from "../public/lib/buttonState.js";
+
+function fakeBtn() {
+  const cls = new Set();
+  const attrs = new Map();
+  return {
+    disabled: false,
+    classList: {
+      add: (c) => cls.add(c),
+      remove: (...c) => c.forEach((x) => cls.delete(x)),
+      contains: (c) => cls.has(c),
+    },
+    setAttribute: (k, v) => attrs.set(k, v),
+    removeAttribute: (k) => attrs.delete(k),
+    getAttribute: (k) => attrs.get(k),
+    _cls: cls,
+    _attrs: attrs,
+  };
+}
+
+test("disabled reason: auth required wins over everything", () => {
+  const r = computeDisabledReason({ need: "exec", conn: "auth-required", settings: { allowExec: true } });
+  assert.equal(r, REASONS.AUTH);
+});
+
+test("disabled reason: offline blocks", () => {
+  assert.equal(computeDisabledReason({ need: "exec", conn: "offline" }), REASONS.OFFLINE);
+});
+
+test("disabled reason: exec needs allowExec", () => {
+  assert.equal(computeDisabledReason({ need: "exec", conn: "connected", settings: { allowExec: false } }), REASONS.EXEC);
+  assert.equal(computeDisabledReason({ need: "exec", conn: "connected", settings: { allowExec: true } }), null);
+});
+
+test("disabled reason: loop needs allowLoop", () => {
+  assert.equal(computeDisabledReason({ need: "loop", conn: "connected", settings: {} }), REASONS.LOOP);
+});
+
+test("disabled reason: automerge needs allowAutoMerge", () => {
+  assert.equal(computeDisabledReason({ need: "automerge", conn: "connected", settings: {} }), REASONS.AUTOMERGE);
+});
+
+test("disabled reason: task-run requires executable", () => {
+  assert.equal(computeDisabledReason({ need: "task-run", conn: "connected", settings: { allowExec: true }, taskExecutable: false }), REASONS.TASK_NOT_EXECUTABLE);
+});
+
+test("disabled reason: active run blocks new runs", () => {
+  const r = computeDisabledReason({ need: "exec", conn: "connected", settings: { allowExec: true }, hasActiveRun: true });
+  assert.equal(r, REASONS.ACTIVE_RUN);
+});
+
+test("applyDisabled writes title + data-disabled-reason", () => {
+  const b = fakeBtn();
+  applyDisabled(b, REASONS.AUTH);
+  assert.equal(b.disabled, true);
+  assert.equal(b.getAttribute("title"), REASONS.AUTH);
+  assert.equal(b.getAttribute("data-disabled-reason"), REASONS.AUTH);
+});
+
+test("applyDisabled clears when reason null", () => {
+  const b = fakeBtn();
+  applyDisabled(b, REASONS.AUTH);
+  applyDisabled(b, null);
+  assert.equal(b.disabled, false);
+  assert.equal(b.getAttribute("title"), undefined);
+});
+
+test("setLoading then setSuccess transitions classes", () => {
+  const b = fakeBtn();
+  setLoading(b);
+  assert.ok(b._cls.has("is-loading"));
+  assert.equal(b.disabled, true);
+  setSuccess(b);
+  assert.ok(!b._cls.has("is-loading"));
+  assert.ok(b._cls.has("is-success"));
+});
+
+test("setError marks error class and re-enables", () => {
+  const b = fakeBtn();
+  setLoading(b);
+  setError(b, "boom");
+  assert.ok(b._cls.has("is-error"));
+  assert.equal(b.disabled, false);
+});
+
+test("runWithState success path", async () => {
+  const b = fakeBtn();
+  const r = await runWithState(b, async () => 42);
+  assert.equal(r, 42);
+});
+
+test("runWithState rethrows and marks error", async () => {
+  const b = fakeBtn();
+  await assert.rejects(() => runWithState(b, async () => { throw new Error("nope"); }), /nope/);
+  assert.ok(b._cls.has("is-error"));
+});

--- a/tools/local-control/tests/logGroup.test.mjs
+++ b/tools/local-control/tests/logGroup.test.mjs
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { groupLines, formatGrouped, isErrorLine } from "../public/lib/logGroup.js";
+
+test("collapses identical consecutive lines", () => {
+  const g = groupLines(["x", "x", "x", "y"]);
+  assert.equal(g.length, 2);
+  assert.equal(g[0].count, 3);
+  assert.equal(g[1].count, 1);
+});
+
+test("does not collapse non-consecutive duplicates", () => {
+  const g = groupLines(["x", "y", "x"]);
+  assert.equal(g.length, 3);
+});
+
+test("formatGrouped appends ×N when grouped", () => {
+  const out = formatGrouped(groupLines(["a", "a", "a", "b"]));
+  assert.match(out, /a\s+×3/);
+  assert.match(out, /\nb$/);
+});
+
+test("isErrorLine catches common error words", () => {
+  assert.equal(isErrorLine("Error: thing failed"), true);
+  assert.equal(isErrorLine("Exception ENOENT"), true);
+  assert.equal(isErrorLine("everything fine"), false);
+});
+
+test("group flag is set for error lines", () => {
+  const g = groupLines(["Error: boom", "Error: boom"]);
+  assert.equal(g[0].isError, true);
+});

--- a/tools/local-control/tests/onboarding.test.mjs
+++ b/tools/local-control/tests/onboarding.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeOnboardingState } from "../public/lib/onboarding.js";
+
+test("connected + dry-run + LAN URL", () => {
+  const s = computeOnboardingState({
+    conn: "connected",
+    settings: { dryRunDefault: true, lanEnabled: true },
+    network: { lan: true, localUrl: "http://127.0.0.1:8787", lanUrl: "http://192.168.1.42:8787", lanEnabled: true },
+  });
+  assert.equal(s.server, "connecté");
+  assert.equal(s.auth, "OK");
+  assert.equal(s.mode, "LAN");
+  assert.equal(s.dryRun, "DRY-RUN");
+  assert.equal(s.localUrl, "http://127.0.0.1:8787");
+  assert.equal(s.lanUrl, "http://192.168.1.42:8787");
+  assert.equal(s.lanHint, "ready");
+});
+
+test("auth required hides LAN URL", () => {
+  const s = computeOnboardingState({ conn: "auth-required", settings: null, network: null });
+  assert.equal(s.server, "token requis");
+  assert.equal(s.auth, "token requis");
+});
+
+test("LAN disabled flags hint", () => {
+  const s = computeOnboardingState({
+    conn: "connected",
+    settings: { dryRunDefault: false, lanEnabled: false },
+    network: { lan: false, lanEnabled: false, localUrl: "http://127.0.0.1:8787", lanUrl: null },
+  });
+  assert.equal(s.mode, "local");
+  assert.equal(s.dryRun, "LIVE");
+  assert.equal(s.lanHint, "lan-disabled");
+});
+
+test("LAN enabled but IP unknown", () => {
+  const s = computeOnboardingState({
+    conn: "connected",
+    settings: { dryRunDefault: true, lanEnabled: true },
+    network: { lan: true, lanEnabled: true, lanUrl: null, localUrl: "http://127.0.0.1:8787" },
+  });
+  assert.equal(s.lanHint, "ip-unknown");
+});
+
+test("offline state surfaces", () => {
+  const s = computeOnboardingState({ conn: "offline" });
+  assert.equal(s.server, "offline");
+});

--- a/tools/local-control/tests/prompt.test.mjs
+++ b/tools/local-control/tests/prompt.test.mjs
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { PRESETS } from "../public/lib/prompt.js";
+
+const REQUIRED = ["plan-next-task", "run-one-safe-task", "loop-safe-tasks", "resume-after-answer", "analyze-blockage"];
+
+test("all 5 required presets exist", () => {
+  for (const k of REQUIRED) {
+    assert.ok(PRESETS[k], `missing preset ${k}`);
+    assert.ok(PRESETS[k].length > 10, `preset ${k} text too short`);
+  }
+});
+
+test("loop preset mentions dry-run", () => {
+  assert.match(PRESETS["loop-safe-tasks"], /dry/i);
+});
+
+test("plan preset mentions plan only", () => {
+  assert.match(PRESETS["plan-next-task"], /plan/i);
+});

--- a/tools/local-control/tests/tasks.test.mjs
+++ b/tools/local-control/tests/tasks.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyTaskReason, computeRunDisabledReason } from "../public/lib/tasks.js";
+import { REASONS } from "../public/lib/buttonState.js";
+
+test("blocked task returns blocked reason", () => {
+  const r = classifyTaskReason({ classification: "blocked", reason: "guard failed" });
+  assert.equal(r.safe, false);
+  assert.equal(r.cls, "task-reason-blocked");
+  assert.match(r.label, /guard failed/);
+});
+
+test("safe task labelled safe", () => {
+  const r = classifyTaskReason({ classification: "safe" });
+  assert.equal(r.safe, true);
+  assert.equal(r.cls, "task-reason-safe");
+});
+
+test("trivial classification counted as safe", () => {
+  const r = classifyTaskReason({ classification: "trivial" });
+  assert.equal(r.safe, true);
+});
+
+test("review/risky returns non-safe with reason", () => {
+  const r = classifyTaskReason({ classification: "review" });
+  assert.equal(r.safe, false);
+  assert.match(r.label, /review/);
+});
+
+test("computeRunDisabledReason: auth blocks even if executable", () => {
+  const r = computeRunDisabledReason({ task: { executable: true }, settings: { allowExec: true }, conn: "auth-required" });
+  assert.equal(r, REASONS.AUTH);
+});
+
+test("computeRunDisabledReason: allowExec=false blocks", () => {
+  const r = computeRunDisabledReason({ task: { executable: true }, settings: { allowExec: false }, conn: "connected" });
+  assert.equal(r, REASONS.EXEC);
+});
+
+test("computeRunDisabledReason: not executable blocks", () => {
+  const r = computeRunDisabledReason({ task: { executable: false }, settings: { allowExec: true }, conn: "connected" });
+  assert.equal(r, REASONS.TASK_NOT_EXECUTABLE);
+});
+
+test("computeRunDisabledReason: clean path returns null", () => {
+  const r = computeRunDisabledReason({ task: { executable: true }, settings: { allowExec: true }, conn: "connected" });
+  assert.equal(r, null);
+});


### PR DESCRIPTION
## Summary
- Auth UX final: modal visible, no more 401 spam, token via `?token=` / localStorage, badges AUTH REQUIRED / CONNECTED / BACKEND OFFLINE, buttons disabled when auth is missing.
- Usability: onboarding dashboard, button states, settings descriptions, phone URL, grouped logs, clearer tasks, improved prompt presets.
- Backend: adds `/api/network`, settings expose `authTokenSet`.

## Test plan
- [x] `pnpm local:control:ui:test` (64)
- [x] `pnpm local:control:test` (51)
- [x] `pnpm task:test` (76)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Smoke: `/` 200, `/api/status` 401 without token / 200 with token, `/api/network` 200 with token