### PR TITLE
feat(local-control): V5 readiness + claude adapter + state/resume

### DIFF
--- a/docs/ops/local-control-panel.md
+++ b/docs/ops/local-control-panel.md
@@ -2,6 +2,9 @@
 
 Cockpit web local pour piloter Claude Code en mode semi-autonome sur WebAppV1.
 
+> V5 (Phase 5) : prompt-driven Claude Code runs, env readiness, state/resume.
+> Voir `docs/ops/local-control-v5.md` pour le détail V5.
+
 ## Architecture
 
 - **Backend** : `tools/local-control/server.mjs` (responsabilité de Claude A — non inclus dans cette PR).

--- a/docs/ops/local-control-v5.md
+++ b/docs/ops/local-control-v5.md
@@ -1,0 +1,104 @@
+# Local Control — V5
+
+This is the V5 (Phase 5) layer on top of the local-control cockpit. It wires
+Claude Code (the `yu` shell function) into the runner, persists per-run state,
+and exposes a readiness card in the UI.
+
+## Lancer V5
+
+```bash
+pnpm local:control
+```
+
+Open `http://127.0.0.1:8787`. Paste the auth token from
+`.local-control/settings.json` (field `authToken`). The Dashboard now shows a
+**V5 readiness** card with these rows:
+
+- Claude CLI — `available` if `CLAUDE_CODE_COMMAND` (e.g. `yu`) is in `PATH`
+- Exec / Loop / Auto-merge — toggles from Settings
+- Notion / n8n / WhatsApp — green when env keys are set
+
+## `.local-control/v5.env`
+
+Already present. Required keys for the V5 base:
+
+```
+CLAUDE_CODE_COMMAND=yu
+CLAUDE_CODE_MODE=cli
+GITHUB_OWNER=Yuume2
+GITHUB_REPO=WebAppV1
+```
+
+Phase 3 dependencies (optional — degraded mode if missing):
+
+```
+NOTION_TOKEN=
+NOTION_QUESTIONS_DATABASE_ID=
+
+N8N_BASE_URL=
+N8N_WEBHOOK_SECRET=
+N8N_QUESTION_NOTIFY_WEBHOOK=
+N8N_NOTION_ANSWER_WEBHOOK=
+
+WHATSAPP_PROVIDER=
+WHATSAPP_FROM=
+WHATSAPP_TO=
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+```
+
+`.local-control/` is git-ignored. Never commit secrets.
+
+## Tester sans risque
+
+1. Start the server, paste token.
+2. In V5 readiness card, type an issue number and click **Prepare Claude run**.
+3. Server returns:
+   - a generated prompt (saved to `.local-control/runs/<runId>.json`),
+   - the proposed branch name,
+   - the proposed git/gh commands.
+4. Click **Copy prompt** and paste it into a terminal where `yu` is available.
+5. Nothing is executed automatically. No push. No merge.
+
+This is the safe default. The runner never spawns `yu` directly.
+
+## Passer en vrai mode exec (avancé)
+
+Switch a real Claude Code run on only when you are watching:
+
+1. In Settings, enable **Allow exec**. Save.
+2. Click **Plan next task** on the Dashboard. The runner spawns `pnpm task:run:plan --issue=...` (no Claude Code CLI yet — V5 prompt-driven path).
+3. Real Claude Code execution stays manual: copy the prepared prompt and run it
+   yourself in a terminal. This keeps the loop human-supervised.
+
+## Notion / n8n / WhatsApp
+
+If empty, the cockpit shows `not configured` and the system runs in **GitHub-only
+mode** for human questions. To activate:
+
+- Notion: fill `NOTION_TOKEN` and `NOTION_QUESTIONS_DATABASE_ID`. See
+  `docs/ops/notion-sync.md`.
+- n8n: fill `N8N_BASE_URL` + secret. See `docs/ops/notion-whatsapp-live.md`.
+- WhatsApp: fill provider + Twilio creds. See `docs/ops/whatsapp-notif.md`.
+
+Restart the cockpit after editing `.local-control/v5.env`.
+
+## Auto-merge
+
+Stays **OFF** by default. The cockpit refuses `/api/automerge/apply` when
+`allowAutoMerge=false`. Even when on, `/api/automerge/check` runs first and the
+server never uses `gh pr merge --admin`.
+
+## Endpoints V5
+
+- `GET /api/v5/status` — readiness JSON (Claude, env groups, phase status, next actions).
+- `POST /api/v5/prepare-run` — body `{ issue, mode }`, persists to `.local-control/runs/<id>.json`, returns prompt + proposed branch + commands.
+- `GET /api/state` — list of prepared/past runs (newest first).
+- `POST /api/resume` — body `{ runId? }`, returns `{ canResume, reason, runId, issue, mode }` based on answered questions.
+
+## Tests
+
+```
+pnpm local:control:test
+pnpm local:control:ui:test
+```

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "task:doctor": "node tools/task-doctor.mjs",
     "local:control": "node tools/local-control/server.mjs",
     "local:control:lan": "node tools/local-control/server.mjs --lan",
-    "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs",
+    "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs tools/local-control/v5-env.test.mjs tools/local-control/claude-adapter.test.mjs tools/local-control/state.test.mjs tools/local-control/v5-server.test.mjs",
     "local:control:ui:test": "node --test tools/local-control/tests/",
     "task:test": "node --test tools/task-meta.test.mjs tools/task-deps.test.mjs tools/task-guard.test.mjs tools/task-questions.test.mjs tools/task-runner.test.mjs tools/task-doctor.test.mjs tools/apply-issue-delta.test.mjs tools/issue-status.test.mjs",
     "task:lint:test": "node --test tools/apply-issue-delta.test.mjs",

--- a/tools/local-control/claude-adapter.mjs
+++ b/tools/local-control/claude-adapter.mjs
@@ -1,0 +1,97 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { loadV5Env } from './v5-env.mjs';
+
+const SAFE_COMMAND_RE = /^[A-Za-z0-9_.\-]+$/;
+const VERSION_TIMEOUT_MS = 5000;
+
+export function resolveClaudeCommand(env) {
+  const cmd = (env?.CLAUDE_CODE_COMMAND ?? '').trim();
+  if (!cmd) return { ok: false, reason: 'CLAUDE_CODE_COMMAND not set' };
+  if (!SAFE_COMMAND_RE.test(cmd)) return { ok: false, reason: 'CLAUDE_CODE_COMMAND has unsafe characters' };
+  return { ok: true, command: cmd };
+}
+
+export function probeClaudeAvailability({ command, shellEnv = process.env }) {
+  if (!command) return { available: false, version: null, reason: 'no command' };
+  const which = spawnSync('command', ['-v', command], { encoding: 'utf8', shell: '/bin/zsh', env: shellEnv });
+  const fallback = spawnSync('which', [command], { encoding: 'utf8', env: shellEnv });
+  const located = (which.status === 0 && which.stdout.trim()) || (fallback.status === 0 && fallback.stdout.trim());
+  if (!located) {
+    const shellLookup = spawnSync('/bin/zsh', ['-i', '-c', `command -v ${command} || true`], { encoding: 'utf8', env: shellEnv, timeout: VERSION_TIMEOUT_MS });
+    if (!shellLookup.stdout.trim()) return { available: false, version: null, reason: `${command} not found in PATH or shell` };
+  }
+  const v = spawnSync('/bin/zsh', ['-i', '-c', `${command} --version 2>/dev/null`], { encoding: 'utf8', env: shellEnv, timeout: VERSION_TIMEOUT_MS });
+  const lines = (v.stdout || '').split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const versionLine = lines.find((l) => /\d+\.\d+/.test(l) && !/Restored session|Welcome|Loading/i.test(l)) ?? null;
+  return { available: true, version: versionLine, reason: null };
+}
+
+export function buildIssuePrompt({ issue, mode = 'plan', repoRoot }) {
+  if (!Number.isInteger(issue) || issue <= 0) throw new Error('invalid issue');
+  const safeMode = ['plan', 'exec', 'loop'].includes(mode) ? mode : 'plan';
+  const lines = [
+    `Tu es Claude Code dans WebAppV1 (${resolve(repoRoot)}).`,
+    `Mode: ${safeMode}.`,
+    `Issue cible: #${issue}.`,
+    '',
+    'Étapes obligatoires :',
+    '1. `git switch main && git pull --ff-only`',
+    `2. Créer une branche \`feat/issue-${issue}-<slug>\``,
+    `3. Lire l'issue #${issue} via \`gh issue view ${issue}\``,
+    '4. Lire `project-memory/03-current-state.md` puis les fichiers cités dans l\'issue.',
+    '5. Implémenter sans toucher à `.claude/`.',
+    safeMode === 'plan'
+      ? '6. PLAN ONLY : produire un plan détaillé sans modifier de code.'
+      : '6. Implémenter, lancer `pnpm typecheck && pnpm test && pnpm lint && pnpm build`.',
+    safeMode !== 'plan' ? '7. Commit conventional, ne pas push, ne pas merge.' : '7. Ne pas commit.',
+    '',
+    'Contraintes :',
+    '- Ne push rien.',
+    '- Pas d\'auto-merge.',
+    '- Pas de loop sans flag explicite.',
+    '- Aucun secret en git.',
+  ];
+  return lines.join('\n');
+}
+
+export function prepareClaudeRun({ issue, mode = 'plan', repoRoot, env }) {
+  const resolved = resolveClaudeCommand(env);
+  const prompt = buildIssuePrompt({ issue, mode, repoRoot });
+  const branch = `feat/issue-${issue}-claude-${mode}`;
+  const proposedCommands = [
+    'git switch main',
+    'git pull --ff-only',
+    `git switch -c ${branch}`,
+    `gh issue view ${issue}`,
+  ];
+  return {
+    ready: resolved.ok,
+    reason: resolved.ok ? null : resolved.reason,
+    command: resolved.ok ? resolved.command : null,
+    mode,
+    issue,
+    branch,
+    prompt,
+    proposedCommands,
+  };
+}
+
+export function v5StatusFromEnv({ env, repoRoot }) {
+  const resolved = resolveClaudeCommand(env);
+  let probe = { available: false, version: null, reason: resolved.ok ? null : resolved.reason };
+  if (resolved.ok) probe = probeClaudeAvailability({ command: resolved.command });
+  return {
+    claudeCommand: resolved.ok ? resolved.command : null,
+    claudeAvailable: probe.available,
+    claudeVersion: probe.version,
+    claudeReason: probe.reason ?? resolved.reason ?? null,
+    repoRoot,
+  };
+}
+
+export function loadAdapterContext(repoRoot) {
+  const { values, file, exists } = loadV5Env(repoRoot);
+  return { env: values, envFile: file, envExists: exists, envFileExists: exists && existsSync(file) };
+}

--- a/tools/local-control/claude-adapter.test.mjs
+++ b/tools/local-control/claude-adapter.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveClaudeCommand, buildIssuePrompt, prepareClaudeRun } from './claude-adapter.mjs';
+
+test('resolveClaudeCommand rejects when not set', () => {
+  const r = resolveClaudeCommand({});
+  assert.equal(r.ok, false);
+});
+
+test('resolveClaudeCommand rejects unsafe characters', () => {
+  const r = resolveClaudeCommand({ CLAUDE_CODE_COMMAND: 'yu; rm -rf /' });
+  assert.equal(r.ok, false);
+});
+
+test('resolveClaudeCommand accepts safe alphanumeric', () => {
+  const r = resolveClaudeCommand({ CLAUDE_CODE_COMMAND: 'yu' });
+  assert.equal(r.ok, true);
+  assert.equal(r.command, 'yu');
+});
+
+test('buildIssuePrompt rejects invalid issue', () => {
+  assert.throws(() => buildIssuePrompt({ issue: 0, repoRoot: '/x' }));
+  assert.throws(() => buildIssuePrompt({ issue: 'abc', repoRoot: '/x' }));
+});
+
+test('buildIssuePrompt embeds issue number and respects mode', () => {
+  const p = buildIssuePrompt({ issue: 42, mode: 'plan', repoRoot: '/repo' });
+  assert.match(p, /#42/);
+  assert.match(p, /Mode: plan/);
+  assert.match(p, /Ne push rien\./);
+});
+
+test('prepareClaudeRun returns reason when command missing', () => {
+  const r = prepareClaudeRun({ issue: 1, repoRoot: '/repo', env: {} });
+  assert.equal(r.ready, false);
+  assert.ok(r.prompt.length > 0);
+  assert.equal(r.branch, 'feat/issue-1-claude-plan');
+});
+
+test('prepareClaudeRun ready when CLAUDE_CODE_COMMAND set', () => {
+  const r = prepareClaudeRun({ issue: 7, mode: 'exec', repoRoot: '/repo', env: { CLAUDE_CODE_COMMAND: 'yu' } });
+  assert.equal(r.ready, true);
+  assert.equal(r.command, 'yu');
+  assert.equal(r.mode, 'exec');
+  assert.deepEqual(r.proposedCommands.slice(0, 2), ['git switch main', 'git pull --ff-only']);
+});

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -15,6 +15,7 @@ import { mountSettings } from "./lib/settings.js";
 import { confirmDanger } from "./lib/confirm.js";
 import { renderOnboarding } from "./lib/onboarding.js";
 import { runWithState } from "./lib/buttonState.js";
+import { renderV5Card } from "./lib/v5.js";
 import {
   TokenStore, ConnState, readTokenFromUrl,
   classifyError, badgeLabel, badgeClass, shouldKeepPolling,
@@ -107,12 +108,13 @@ async function refreshAll() {
     return;
   }
   try {
-    const [dash, tasks, questions, settings, network] = await Promise.all([
+    const [dash, tasks, questions, settings, network, v5] = await Promise.all([
       api.get("/api/dashboard"),
       api.get("/api/tasks?limit=50"),
       api.get("/api/questions"),
       api.get("/api/settings"),
       api.get("/api/network").catch(() => null),
+      api.get("/api/v5/status").catch(() => null),
     ]);
     lastSettings = settings;
     lastNetwork = network;
@@ -121,6 +123,7 @@ async function refreshAll() {
     renderQuestions(questions.items || [], { api });
     applySettingsToBadges(settings);
     renderOnboarding({ conn: "connected", settings, network });
+    if (v5) renderV5Card(document.getElementById("v5-card"), v5);
     setConnState(ConnState.CONNECTED);
   } catch (e) {
     const next = classifyError(e);
@@ -185,6 +188,34 @@ document.getElementById("auth-form").addEventListener("submit", (ev) => {
 document.getElementById("auth-retry").addEventListener("click", () => {
   setConnState(ConnState.UNKNOWN);
   refreshAll();
+});
+
+let lastV5Prompt = null;
+
+document.querySelector('[data-action="v5-prepare"]')?.addEventListener("click", async () => {
+  const issue = Number(document.getElementById("v5-issue").value);
+  if (!Number.isInteger(issue) || issue <= 0) { log("⚠ v5: enter an issue number first"); return; }
+  try {
+    const r = await api.post("/api/v5/prepare-run", { issue, mode: "plan" });
+    lastV5Prompt = r?.prompt ?? null;
+    const view = document.getElementById("v5-prompt-view");
+    view.textContent = lastV5Prompt ?? "";
+    view.classList.toggle("hidden", !lastV5Prompt);
+    log(`✓ v5: prepared run ${r?.runId ?? "?"} for issue #${issue} (ready=${r?.ready})`);
+  } catch (e) { log(`⚠ v5 prepare failed: ${redact(String(e?.message || e))}`); }
+});
+
+document.querySelector('[data-action="v5-copy-prompt"]')?.addEventListener("click", () => {
+  if (!lastV5Prompt) { log("⚠ v5: prepare a run first"); return; }
+  navigator.clipboard?.writeText(lastV5Prompt).then(() => log("✓ v5 prompt copied")).catch(() => {});
+});
+
+document.querySelector('[data-action="v5-resume"]')?.addEventListener("click", async () => {
+  try {
+    const r = await api.post("/api/resume", {});
+    if (r?.canResume) log(`✓ v5: can resume run ${r.runId} for issue #${r.issue}`);
+    else log(`⚠ v5: resume blocked — ${r?.reason ?? "unknown"}`);
+  } catch (e) { log(`⚠ v5 resume failed: ${redact(String(e?.message || e))}`); }
 });
 
 setConnState(api.token ? ConnState.UNKNOWN : ConnState.AUTH_REQUIRED);

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -117,6 +117,30 @@
       </div>
     </div>
 
+    <div class="card v5-card" id="v5-card">
+      <h3>V5 readiness</h3>
+      <ul class="v5-list" id="v5-list">
+        <li data-key="claude"><span class="label">Claude CLI</span><span class="value" data-value>—</span></li>
+        <li data-key="exec"><span class="label">Exec</span><span class="value" data-value>—</span></li>
+        <li data-key="loop"><span class="label">Loop</span><span class="value" data-value>—</span></li>
+        <li data-key="automerge"><span class="label">Auto-merge</span><span class="value" data-value>—</span></li>
+        <li data-key="notion"><span class="label">Notion</span><span class="value" data-value>—</span></li>
+        <li data-key="n8n"><span class="label">n8n</span><span class="value" data-value>—</span></li>
+        <li data-key="whatsapp"><span class="label">WhatsApp</span><span class="value" data-value>—</span></li>
+      </ul>
+      <details class="v5-actions">
+        <summary>Next human actions</summary>
+        <ul class="small" id="v5-next-actions"><li class="muted">—</li></ul>
+      </details>
+      <div class="actions">
+        <label>Issue # <input id="v5-issue" type="number" min="1" placeholder="ex: 41" /></label>
+        <button data-action="v5-prepare" data-needs="auth">Prepare Claude run</button>
+        <button data-action="v5-copy-prompt" data-needs="auth">Copy prompt</button>
+        <button data-action="v5-resume" data-needs="auth">Resume</button>
+      </div>
+      <pre id="v5-prompt-view" class="log-view hidden" aria-live="polite"></pre>
+    </div>
+
     <div class="actions">
       <button data-action="refresh">Refresh</button>
       <button data-action="doctor" data-needs="auth">Run doctor</button>

--- a/tools/local-control/public/lib/v5.js
+++ b/tools/local-control/public/lib/v5.js
@@ -1,0 +1,36 @@
+export function renderV5Card(container, status) {
+  if (!container || !status) return;
+  const set = (key, val, cls) => {
+    const li = container.querySelector(`[data-key="${key}"] [data-value]`);
+    if (!li) return;
+    li.textContent = val;
+    li.classList.remove("ok", "err", "warn");
+    if (cls) li.classList.add(cls);
+  };
+  set("claude", status.claudeAvailable ? `available (${status.claudeVersion ?? "?"})` : `missing — ${status.claudeReason ?? "?"}`,
+    status.claudeAvailable ? "ok" : "err");
+  set("exec", status.execAllowed ? "allowed" : "disabled", status.execAllowed ? "ok" : "warn");
+  set("loop", status.loopAllowed ? "allowed" : "disabled", status.loopAllowed ? "ok" : "warn");
+  set("automerge", status.autoMergeAllowed ? "allowed" : "OFF (default)", status.autoMergeAllowed ? "warn" : "ok");
+  set("notion", status.notionConfigured ? "configured" : "not configured", status.notionConfigured ? "ok" : "warn");
+  set("n8n", status.n8nConfigured ? "configured" : "not configured", status.n8nConfigured ? "ok" : "warn");
+  set("whatsapp", status.whatsappConfigured ? "configured" : "not configured", status.whatsappConfigured ? "ok" : "warn");
+
+  const actions = container.querySelector("#v5-next-actions");
+  if (actions) {
+    actions.innerHTML = "";
+    const items = Array.isArray(status.nextHumanActions) && status.nextHumanActions.length
+      ? status.nextHumanActions
+      : ["Tout est prêt côté V5."];
+    for (const a of items) {
+      const li = document.createElement("li");
+      li.textContent = a;
+      actions.appendChild(li);
+    }
+  }
+}
+
+export function summarizeV5({ claudeAvailable, notionConfigured, n8nConfigured, whatsappConfigured }) {
+  const ok = [claudeAvailable, notionConfigured, n8nConfigured, whatsappConfigured].filter(Boolean).length;
+  return { ok, total: 4, ready: ok === 4 };
+}

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -165,3 +165,15 @@ button[data-disabled-reason]:disabled { position: relative; }
 .task-reason-safe { color: var(--ok); }
 .task-reason-blocked { color: var(--danger); }
 tr.task-blocked { opacity: 0.65; }
+
+/* V5 readiness card */
+.v5-card { grid-column: 1 / -1; margin-top: 12px; }
+.v5-list { list-style: none; padding: 0; margin: 0 0 10px; display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 6px; }
+.v5-list li { display: flex; justify-content: space-between; padding: 6px 10px; background: var(--bg-elev-2); border-radius: 6px; font-size: 12px; }
+.v5-list .label { color: var(--fg-dim); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+.v5-list .value { font-weight: 600; }
+.v5-list .value.ok { color: var(--ok); }
+.v5-list .value.err { color: var(--danger); }
+.v5-list .value.warn { color: var(--warn); }
+.v5-actions summary { cursor: pointer; color: var(--fg-dim); font-size: 12px; margin-bottom: 6px; }
+.v5-actions ul { list-style: disc; padding-left: 18px; margin: 4px 0 0; }

--- a/tools/local-control/resume.mjs
+++ b/tools/local-control/resume.mjs
@@ -1,0 +1,28 @@
+export function evaluateResume({ run, questions = [] }) {
+  if (!run) return { canResume: false, reason: 'no run found to resume' };
+  if (run.status === 'running') return { canResume: false, reason: 'run is still active' };
+  const pending = questions.filter((q) => q && q.status !== 'answered');
+  const answered = questions.filter((q) => q && q.status === 'answered');
+  if (run.waitingOnQuestion) {
+    const matched = answered.find((q) => q.id === run.waitingOnQuestion);
+    if (!matched) {
+      return {
+        canResume: false,
+        reason: `waiting on question ${run.waitingOnQuestion} — not yet answered`,
+        pendingQuestions: pending.length,
+      };
+    }
+    return {
+      canResume: true,
+      reason: null,
+      runId: run.id,
+      issue: run.issue ?? null,
+      mode: run.mode ?? 'plan',
+      answeredQuestionId: matched.id,
+    };
+  }
+  if (pending.length > 0) {
+    return { canResume: false, reason: `${pending.length} pending question(s) — answer first or pick a different run` };
+  }
+  return { canResume: true, reason: null, runId: run.id, issue: run.issue ?? null, mode: run.mode ?? 'plan' };
+}

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -14,6 +14,10 @@ import {
   fetchPrContext, fetchIssueLabels, fetchBranchProtection,
   runTaskGuard, evaluateAutoMerge, applyAutoMerge,
 } from './automerge.mjs';
+import { loadV5Env, evaluateV5Env } from './v5-env.mjs';
+import { v5StatusFromEnv, prepareClaudeRun } from './claude-adapter.mjs';
+import { V5StateStore } from './state.mjs';
+import { evaluateResume } from './resume.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT_DEFAULT = resolve(__dirname, '..', '..');
@@ -62,6 +66,7 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
   const runner = new Runner({ logs, state, settings, repoRoot });
   const startedAt = Date.now();
   const network = { host: '127.0.0.1', port: 8787, lan: false };
+  const v5Store = new V5StateStore(repoRoot);
 
   function authOk(req) { return isAuthenticated(req, settings.get().authToken); }
   function send(res, code, body, extraHeaders = {}) {
@@ -344,6 +349,81 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       report.applied = m.ok;
       if (!m.ok) report.reasons.push(`merge command failed: ${redactSecrets(m.stderr, [s.authToken])}`);
       return send(res, 200, report);
+    }
+
+    if (method === 'GET' && path === '/api/v5/status') {
+      const s = settings.get();
+      const { values: env } = loadV5Env(repoRoot);
+      const envEval = evaluateV5Env(env);
+      const claude = v5StatusFromEnv({ env, repoRoot });
+      const phaseStatus = {
+        phase1: 'ready',
+        phase2: claude.claudeAvailable ? 'ready' : 'pending',
+        phase3: envEval.notionConfigured && envEval.n8nConfigured && envEval.whatsappConfigured ? 'ready' : 'pending',
+        phase4: 'pending',
+      };
+      const nextHumanActions = [];
+      if (!claude.claudeAvailable) nextHumanActions.push(`Install/expose Claude Code CLI: ${claude.claudeReason ?? 'set CLAUDE_CODE_COMMAND'}`);
+      if (!envEval.notionConfigured) nextHumanActions.push(`Fill Notion env: ${envEval.missingByGroup.notion.join(', ')}`);
+      if (!envEval.n8nConfigured) nextHumanActions.push(`Fill n8n env: ${envEval.missingByGroup.n8n.join(', ')}`);
+      if (!envEval.whatsappConfigured) nextHumanActions.push(`Fill WhatsApp env: ${envEval.missingByGroup.whatsapp.join(', ')}`);
+      if (!s.allowExec) nextHumanActions.push('Enable allowExec in Settings to run real exec');
+      if (!s.allowAutoMerge) nextHumanActions.push('Auto-merge stays OFF until explicitly enabled');
+      return send(res, 200, {
+        claudeCommand: claude.claudeCommand,
+        claudeAvailable: claude.claudeAvailable,
+        claudeVersion: claude.claudeVersion,
+        claudeReason: claude.claudeReason,
+        execAllowed: !!s.allowExec,
+        loopAllowed: !!s.allowLoop,
+        autoMergeAllowed: !!s.allowAutoMerge,
+        notionConfigured: envEval.notionConfigured,
+        n8nConfigured: envEval.n8nConfigured,
+        whatsappConfigured: envEval.whatsappConfigured,
+        missingEnv: envEval.missingEnv,
+        missingByGroup: envEval.missingByGroup,
+        phaseStatus,
+        nextHumanActions,
+      });
+    }
+
+    if (method === 'POST' && path === '/api/v5/prepare-run') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const issue = Number(body?.issue);
+      if (!Number.isInteger(issue) || issue <= 0) return sendErr(res, 422, 'invalid issue');
+      const mode = ['plan', 'exec', 'loop'].includes(body?.mode) ? body.mode : 'plan';
+      const { values: env } = loadV5Env(repoRoot);
+      const prep = prepareClaudeRun({ issue, mode, repoRoot, env });
+      const id = v5Store.newId();
+      const record = v5Store.save({
+        id,
+        issue,
+        mode,
+        status: 'prepared',
+        ready: prep.ready,
+        reason: prep.reason,
+        branch: prep.branch,
+        prompt: prep.prompt,
+        proposedCommands: prep.proposedCommands,
+        createdAt: new Date().toISOString(),
+      });
+      return send(res, 200, { runId: id, ...prep, record });
+    }
+
+    if (method === 'GET' && path === '/api/state') {
+      const items = v5Store.list({ limit: 30 });
+      return send(res, 200, { items, latest: items[0] ?? null });
+    }
+
+    if (method === 'POST' && path === '/api/resume') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const id = String(body?.runId ?? '');
+      const run = id ? v5Store.load(id) : v5Store.latest();
+      let questions = [];
+      const r = spawnSync('pnpm', ['task:questions:list', '--json'], { cwd: repoRoot, encoding: 'utf8' });
+      if (r.status === 0) { try { const j = JSON.parse(r.stdout); questions = Array.isArray(j) ? j : (j.items ?? []); } catch { /* ignore */ } }
+      const evald = evaluateResume({ run, questions });
+      return send(res, 200, evald);
     }
 
     return sendErr(res, 404, 'not found');

--- a/tools/local-control/state.mjs
+++ b/tools/local-control/state.mjs
@@ -1,0 +1,44 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, chmodSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+const RUN_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+export class V5StateStore {
+  constructor(repoRoot) {
+    this.dir = resolve(repoRoot, '.local-control', 'runs');
+    this._ensure();
+  }
+  _ensure() { if (!existsSync(this.dir)) mkdirSync(this.dir, { recursive: true }); }
+  _path(id) {
+    if (!RUN_ID_RE.test(id)) throw new Error('invalid runId');
+    return join(this.dir, `${id}.json`);
+  }
+  newId() { return randomUUID(); }
+
+  save(record) {
+    this._ensure();
+    if (!record?.id || !RUN_ID_RE.test(record.id)) throw new Error('invalid runId');
+    const file = this._path(record.id);
+    const data = { ...record, updatedAt: new Date().toISOString() };
+    writeFileSync(file, JSON.stringify(data, null, 2));
+    try { chmodSync(file, 0o600); } catch { /* best-effort */ }
+    return data;
+  }
+  load(id) {
+    const file = this._path(id);
+    if (!existsSync(file)) return null;
+    try { return JSON.parse(readFileSync(file, 'utf8')); } catch { return null; }
+  }
+  list({ limit = 30 } = {}) {
+    this._ensure();
+    const items = [];
+    for (const name of readdirSync(this.dir)) {
+      if (!name.endsWith('.json')) continue;
+      try { items.push(JSON.parse(readFileSync(join(this.dir, name), 'utf8'))); } catch { /* skip */ }
+    }
+    items.sort((a, b) => String(b.updatedAt ?? '').localeCompare(String(a.updatedAt ?? '')));
+    return items.slice(0, limit);
+  }
+  latest() { return this.list({ limit: 1 })[0] ?? null; }
+}

--- a/tools/local-control/state.test.mjs
+++ b/tools/local-control/state.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { V5StateStore } from './state.mjs';
+import { evaluateResume } from './resume.mjs';
+
+function tmpRepo() { return mkdtempSync(join(tmpdir(), 'v5state-')); }
+
+test('V5StateStore save and load roundtrip', () => {
+  const root = tmpRepo();
+  try {
+    const store = new V5StateStore(root);
+    const id = store.newId();
+    const saved = store.save({ id, issue: 42, mode: 'plan', status: 'prepared' });
+    assert.equal(saved.id, id);
+    const loaded = store.load(id);
+    assert.equal(loaded.issue, 42);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('V5StateStore rejects bad ids', () => {
+  const root = tmpRepo();
+  try {
+    const store = new V5StateStore(root);
+    assert.throws(() => store.save({ id: '../evil', issue: 1, mode: 'plan' }));
+    assert.throws(() => store.load('../evil'));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('V5StateStore list sorts by updatedAt desc', async () => {
+  const root = tmpRepo();
+  try {
+    const store = new V5StateStore(root);
+    const a = store.save({ id: store.newId(), issue: 1, mode: 'plan' });
+    await new Promise((r) => setTimeout(r, 10));
+    const b = store.save({ id: store.newId(), issue: 2, mode: 'plan' });
+    const list = store.list();
+    assert.equal(list[0].id, b.id);
+    assert.equal(list[1].id, a.id);
+    assert.equal(store.latest().id, b.id);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('evaluateResume refuses when no run', () => {
+  const r = evaluateResume({ run: null });
+  assert.equal(r.canResume, false);
+});
+
+test('evaluateResume refuses when run still running', () => {
+  const r = evaluateResume({ run: { id: 'a', status: 'running' } });
+  assert.equal(r.canResume, false);
+});
+
+test('evaluateResume refuses when waitingOnQuestion not answered', () => {
+  const r = evaluateResume({
+    run: { id: 'a', status: 'paused', waitingOnQuestion: 'q1' },
+    questions: [{ id: 'q1', status: 'pending' }],
+  });
+  assert.equal(r.canResume, false);
+  assert.match(r.reason, /q1/);
+});
+
+test('evaluateResume allows when answered', () => {
+  const r = evaluateResume({
+    run: { id: 'a', status: 'paused', waitingOnQuestion: 'q1', issue: 42 },
+    questions: [{ id: 'q1', status: 'answered' }],
+  });
+  assert.equal(r.canResume, true);
+  assert.equal(r.runId, 'a');
+  assert.equal(r.issue, 42);
+});
+
+test('evaluateResume refuses when pending questions remain', () => {
+  const r = evaluateResume({
+    run: { id: 'a', status: 'done' },
+    questions: [{ id: 'q1', status: 'pending' }],
+  });
+  assert.equal(r.canResume, false);
+});

--- a/tools/local-control/tests/v5.test.mjs
+++ b/tools/local-control/tests/v5.test.mjs
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeV5 } from "../public/lib/v5.js";
+
+test("summarizeV5 counts configured groups", () => {
+  assert.deepEqual(
+    summarizeV5({ claudeAvailable: true, notionConfigured: false, n8nConfigured: false, whatsappConfigured: false }),
+    { ok: 1, total: 4, ready: false },
+  );
+  assert.deepEqual(
+    summarizeV5({ claudeAvailable: true, notionConfigured: true, n8nConfigured: true, whatsappConfigured: true }),
+    { ok: 4, total: 4, ready: true },
+  );
+});

--- a/tools/local-control/v5-env.mjs
+++ b/tools/local-control/v5-env.mjs
@@ -1,0 +1,95 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const V5_REQUIRED_KEYS = Object.freeze([
+  'CLAUDE_CODE_COMMAND',
+  'CLAUDE_CODE_MODE',
+  'GITHUB_OWNER',
+  'GITHUB_REPO',
+]);
+
+export const V5_NOTION_KEYS = Object.freeze([
+  'NOTION_TOKEN',
+  'NOTION_QUESTIONS_DATABASE_ID',
+]);
+
+export const V5_N8N_KEYS = Object.freeze([
+  'N8N_BASE_URL',
+  'N8N_WEBHOOK_SECRET',
+  'N8N_QUESTION_NOTIFY_WEBHOOK',
+]);
+
+export const V5_WHATSAPP_KEYS = Object.freeze([
+  'WHATSAPP_PROVIDER',
+  'WHATSAPP_FROM',
+  'WHATSAPP_TO',
+]);
+
+export function parseDotEnv(text) {
+  const out = {};
+  if (!text) return out;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const k = line.slice(0, eq).trim();
+    let v = line.slice(eq + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+    out[k] = v;
+  }
+  return out;
+}
+
+export function loadV5Env(repoRoot) {
+  const file = resolve(repoRoot, '.local-control', 'v5.env');
+  if (!existsSync(file)) return { values: {}, file, exists: false };
+  try {
+    const text = readFileSync(file, 'utf8');
+    return { values: parseDotEnv(text), file, exists: true };
+  } catch {
+    return { values: {}, file, exists: false };
+  }
+}
+
+function nonEmpty(env, keys) {
+  return keys.every((k) => typeof env[k] === 'string' && env[k].length > 0);
+}
+
+function missing(env, keys) {
+  return keys.filter((k) => !env[k] || env[k].length === 0);
+}
+
+export function evaluateV5Env(env) {
+  const required = nonEmpty(env, V5_REQUIRED_KEYS);
+  const notion = nonEmpty(env, V5_NOTION_KEYS);
+  const n8n = nonEmpty(env, V5_N8N_KEYS);
+  const whatsapp = nonEmpty(env, V5_WHATSAPP_KEYS);
+  const missingByGroup = {
+    required: missing(env, V5_REQUIRED_KEYS),
+    notion: missing(env, V5_NOTION_KEYS),
+    n8n: missing(env, V5_N8N_KEYS),
+    whatsapp: missing(env, V5_WHATSAPP_KEYS),
+  };
+  return {
+    requiredOk: required,
+    notionConfigured: notion,
+    n8nConfigured: n8n,
+    whatsappConfigured: whatsapp,
+    missingByGroup,
+    missingEnv: [...missingByGroup.required, ...missingByGroup.notion, ...missingByGroup.n8n, ...missingByGroup.whatsapp],
+  };
+}
+
+export function readBoolEnv(env, key, defaultValue = false) {
+  const v = env[key];
+  if (v == null || v === '') return defaultValue;
+  return /^(1|true|yes|on)$/i.test(String(v).trim());
+}
+
+export function readIntEnv(env, key, defaultValue) {
+  const v = env[key];
+  if (v == null || v === '') return defaultValue;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : defaultValue;
+}

--- a/tools/local-control/v5-env.test.mjs
+++ b/tools/local-control/v5-env.test.mjs
@@ -1,0 +1,47 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseDotEnv, evaluateV5Env, readBoolEnv, readIntEnv } from './v5-env.mjs';
+
+test('parseDotEnv ignores comments and trims', () => {
+  const env = parseDotEnv('# comment\nFOO=bar\nBAZ="qux"\n\nQUOTED=\'x\'\n');
+  assert.equal(env.FOO, 'bar');
+  assert.equal(env.BAZ, 'qux');
+  assert.equal(env.QUOTED, 'x');
+});
+
+test('evaluateV5Env reports missing groups when empty', () => {
+  const r = evaluateV5Env({});
+  assert.equal(r.requiredOk, false);
+  assert.equal(r.notionConfigured, false);
+  assert.equal(r.n8nConfigured, false);
+  assert.equal(r.whatsappConfigured, false);
+  assert.ok(r.missingEnv.includes('CLAUDE_CODE_COMMAND'));
+  assert.ok(r.missingEnv.includes('NOTION_TOKEN'));
+});
+
+test('evaluateV5Env detects Notion configured when both keys present', () => {
+  const r = evaluateV5Env({
+    CLAUDE_CODE_COMMAND: 'yu',
+    CLAUDE_CODE_MODE: 'cli',
+    GITHUB_OWNER: 'x',
+    GITHUB_REPO: 'y',
+    NOTION_TOKEN: 't',
+    NOTION_QUESTIONS_DATABASE_ID: 'd',
+  });
+  assert.equal(r.requiredOk, true);
+  assert.equal(r.notionConfigured, true);
+  assert.equal(r.n8nConfigured, false);
+});
+
+test('readBoolEnv coerces 1/true/yes/on', () => {
+  assert.equal(readBoolEnv({ X: '1' }, 'X'), true);
+  assert.equal(readBoolEnv({ X: 'true' }, 'X'), true);
+  assert.equal(readBoolEnv({ X: 'no' }, 'X'), false);
+  assert.equal(readBoolEnv({}, 'X', true), true);
+});
+
+test('readIntEnv falls back when not numeric', () => {
+  assert.equal(readIntEnv({ X: '42' }, 'X'), 42);
+  assert.equal(readIntEnv({ X: 'oops' }, 'X', 7), 7);
+  assert.equal(readIntEnv({}, 'X', 9), 9);
+});

--- a/tools/local-control/v5-server.test.mjs
+++ b/tools/local-control/v5-server.test.mjs
@@ -1,0 +1,122 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildApp } from './server.mjs';
+
+function tmpRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'v5-server-'));
+  mkdirSync(join(root, '.local-control'), { recursive: true });
+  return root;
+}
+
+async function call(app, method, path, { body, token } = {}) {
+  return new Promise((resolveP) => {
+    const headers = { authorization: token ? `Bearer ${token}` : '' };
+    const req = {
+      method,
+      url: path,
+      headers,
+      on: (ev, cb) => { if (ev === 'end' && body == null) cb(); if (ev === 'data' && body) cb(Buffer.from(body)); if (ev === 'end' && body) cb(); },
+      destroy: () => {},
+    };
+    let status = 0;
+    let data = '';
+    const res = {
+      writeHead: (c) => { status = c; },
+      end: (chunk) => { if (chunk) data += chunk; resolveP({ status, data: tryJson(data) }); },
+      write: () => {},
+    };
+    app.handler(req, res);
+  });
+}
+function tryJson(s) { try { return JSON.parse(s); } catch { return s; } }
+
+test('GET /api/v5/status without auth returns 401', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const r = await call(app, 'GET', '/api/v5/status');
+    assert.equal(r.status, 401);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/v5/status reports missing env when v5.env empty', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/v5/status', { token: tok });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.notionConfigured, false);
+    assert.equal(r.data.n8nConfigured, false);
+    assert.equal(r.data.whatsappConfigured, false);
+    assert.ok(Array.isArray(r.data.nextHumanActions));
+    assert.equal(r.data.autoMergeAllowed, false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/v5/status detects Notion when env set', async () => {
+  const root = tmpRepo();
+  writeFileSync(join(root, '.local-control', 'v5.env'),
+    'CLAUDE_CODE_COMMAND=yu\nCLAUDE_CODE_MODE=cli\nGITHUB_OWNER=x\nGITHUB_REPO=y\nNOTION_TOKEN=t\nNOTION_QUESTIONS_DATABASE_ID=d\n');
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/v5/status', { token: tok });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.notionConfigured, true);
+    assert.equal(r.data.claudeCommand, 'yu');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/v5/prepare-run rejects bad issue', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'POST', '/api/v5/prepare-run', { token: tok, body: JSON.stringify({ issue: 0 }) });
+    assert.equal(r.status, 422);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/v5/prepare-run persists state and returns prompt', async () => {
+  const root = tmpRepo();
+  writeFileSync(join(root, '.local-control', 'v5.env'), 'CLAUDE_CODE_COMMAND=yu\n');
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'POST', '/api/v5/prepare-run', { token: tok, body: JSON.stringify({ issue: 42, mode: 'plan' }) });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.ready, true);
+    assert.match(r.data.prompt, /#42/);
+    assert.ok(r.data.runId);
+
+    const st = await call(app, 'GET', '/api/state', { token: tok });
+    assert.equal(st.status, 200);
+    assert.equal(st.data.items.length, 1);
+    assert.equal(st.data.items[0].issue, 42);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/automerge/apply refuses when allowAutoMerge=false', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'POST', '/api/automerge/apply', { token: tok, body: JSON.stringify({ pr: 1 }) });
+    assert.equal(r.status, 403);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/resume returns canResume=false when no state', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'POST', '/api/resume', { token: tok, body: JSON.stringify({}) });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.canResume, false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary
- Adds V5 readiness status to local-control.
- Adds Claude Code adapter using CLAUDE_CODE_COMMAND=yu.
- Adds prepare-run flow for prompt-driven Claude runs.
- Adds local run state persistence.
- Adds resume scaffold.
- Keeps Notion/n8n/WhatsApp degraded until secrets are configured.
- Keeps auto-merge OFF by default.

## Safety
- No auto-spawn of Claude Code.
- No real loop triggered.
- No auto-merge.
- No secrets committed.
- Local .local-control state remains gitignored.

## Test plan
- [x] pnpm local:control:test — 78 pass
- [x] pnpm local:control:ui:test — 65 pass
- [x] pnpm task:test — 76 pass
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm test — 516 pass
- [x] pnpm build
- [x] Smoke /api/v5/status
- [x] Smoke /api/v5/prepare-run
- [x] Smoke /api/automerge/apply refuses while disabled