### PR TITLE
feat(local-control): complete V5 autopilot cockpit

### DIFF
--- a/docs/ops/automerge-policy.md
+++ b/docs/ops/automerge-policy.md
@@ -1,0 +1,43 @@
+# Auto-merge Policy
+
+Auto-merge is **OFF by default** and stays OFF until a human flips
+`allowAutoMerge=true` in cockpit settings. Even when ON, every merge is
+gated by the checks below. If any single check fails, the merge is refused
+and the cockpit reports the reason.
+
+## Required for a PR to be auto-mergeable
+
+- `allowAutoMerge=true` in `.local-control/settings.json`.
+- PR is OPEN and not draft.
+- All status checks green (`statusCheckRollup` has no FAILURE/CANCELLED/PENDING).
+- PR has a linked issue (`closingIssuesReferences`).
+- Linked issue carries both `ai:autonomous` and `risk:safe` labels.
+- Branch protection on `main` is active (classic protection or ruleset).
+- `task:guard` returns ALLOW for the PR diff.
+- Diff is ≤ 25 files and ≤ 400 lines added+deleted.
+- No sensitive paths (`.env`, `apps/api/db/`, `apps/api/auth/`, `infra/`,
+  `package.json`, `pnpm-lock.yaml`, `Dockerfile`, GitHub workflows…).
+- No reviewer requested changes.
+
+## Always refused
+
+- `risk:destructive` or `risk:review-required` labels.
+- `ai:human-checkpoint` label.
+- Any `.env*` or secret-bearing path.
+- Database migrations that drop or rename columns.
+- Billing or auth/security disablement.
+- Anything requiring `--admin` to merge.
+- CI red or pending.
+
+## How to enable
+
+1. Settings → flip `allowAutoMerge` to true.
+2. Test on one PR via cockpit Advanced → Auto-merge check.
+3. Inspect the report's `reasons` array. Empty array = eligible.
+4. Click Auto-merge apply only if you've read the diff yourself.
+
+## Endpoints
+
+- `POST /api/automerge/check` — dry-run, returns `eligible` and `reasons`.
+- `POST /api/automerge/apply` — refuses if `allowAutoMerge=false` or any
+  check fails.

--- a/docs/ops/autopilot.md
+++ b/docs/ops/autopilot.md
@@ -1,0 +1,72 @@
+# Local-Control Autopilot
+
+The Autopilot is the V5 orchestration loop that drives Claude Code from the
+local cockpit. It picks the safest open task, builds the prompt, hands off
+work to Claude (via `yu`), and stops as soon as a guard fails.
+
+## What Autopilot does
+
+1. Preflight: repo clean, on `main`, env loaded, Claude CLI available.
+2. Pick a safe task from the GitHub queue (filters `risk:destructive`,
+   `risk:review-required`, `ai:human-checkpoint`; requires `ai:autonomous` +
+   `risk:safe`).
+3. Build a structured prompt for the issue (no secrets, no shell injection).
+4. Either:
+   - **Plan mode** (default, `allowExec=false`): produce the prompt, surface
+     it in the cockpit. Yume copies and runs `yu` manually.
+   - **Exec mode** (`allowExec=true`): launch `yu` via login zsh, stream
+     stdout/stderr back, watch stop conditions.
+5. Stop on any of: dirty repo, guard BLOCK, 3 errors, time budget, PR budget,
+   pending human question, missing secret, push to main, `--admin`.
+
+## Stop conditions
+
+| Reason | Trigger |
+|---|---|
+| `repo-dirty` | uncommitted changes detected at start |
+| `no-safe-task` | queue empty or all filtered out |
+| `guard-block` | `task:guard` returned BLOCK |
+| `human-question` | Claude posted a `claude-question` comment |
+| `error-budget-exceeded` | 3 consecutive errors |
+| `time-budget-exceeded` | run duration > `maxMinutes` (default 60) |
+| `pr-budget-reached` | `prsCreated >= maxPrsPerRun` (default 3) |
+| `secret-missing` | required env var empty |
+| `claude-unavailable` | `yu` not found in `$PATH` |
+| `exec-disabled` | `allowExec=false` and mode != plan |
+
+## Endpoints
+
+- `POST /api/autopilot/start` — body `{ mode, issue? }`. mode in
+  `plan|exec|loop`. Returns the run summary and the prompt.
+- `POST /api/autopilot/stop` — terminates the active run.
+- `POST /api/autopilot/resume` — resumes after a question is answered.
+- `GET  /api/autopilot/status` — current run summary or null.
+- `GET  /api/v5/status` — global readiness (Claude / Notion / n8n / WhatsApp).
+
+## Settings that gate Autopilot
+
+- `allowExec` — false by default. Required for any mode beyond `plan`.
+- `allowLoop` — false by default. Required for `mode=loop`.
+- `allowAutoMerge` — false by default. Auto-merge stays OFF unless flipped.
+- `maxMinutes` — 60 default, capped at 240.
+- `maxPrsPerRun` — 3 default, capped at 10.
+
+## First safe run (recipe)
+
+1. Verify `pnpm task:doctor` is fully green (no PENDING blockers you can fix).
+2. `pnpm local:control` and open `http://127.0.0.1:8787`.
+3. Paste the auth token from `.local-control/settings.json`.
+4. On the dashboard, leave Issue blank. Click **Start Autopilot**.
+5. Read the prompt the cockpit generates. If it looks right, copy it and run
+   `yu -p "<prompt>"` in another terminal.
+6. Watch the PR appear. Resume with **Resume** if Claude asked a question.
+7. Auto-merge stays OFF. Use the Advanced controls → Auto-merge check to
+   evaluate eligibility, then flip `allowAutoMerge` deliberately.
+
+## Why exec mode is restricted by default
+
+`yu` is wired to the real Claude Code CLI on this machine. Running it from a
+backend means real edits, real commits, real pushes. We default to dry-run
+(`allowExec=false`) so the cockpit only produces a prompt and Yume runs Claude
+in a terminal. Flip `allowExec=true` only when you trust the queue, the guard,
+and the branch-protection ruleset on `main`.

--- a/docs/ops/local-control-v5.md
+++ b/docs/ops/local-control-v5.md
@@ -2,7 +2,13 @@
 
 This is the V5 (Phase 5) layer on top of the local-control cockpit. It wires
 Claude Code (the `yu` shell function) into the runner, persists per-run state,
-and exposes a readiness card in the UI.
+and exposes a readiness card and an **Autopilot** card in the UI.
+
+See also:
+- `docs/ops/autopilot.md` — what the Autopilot button does.
+- `docs/ops/automerge-policy.md` — when auto-merge will/won't run.
+- `docs/ops/notion-whatsapp-live.md` — Notion + WhatsApp live wiring.
+- `docs/ops/local-control-phone.md` — LAN/phone access.
 
 ## Lancer V5
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "task:doctor": "node tools/task-doctor.mjs",
     "local:control": "node tools/local-control/server.mjs",
     "local:control:lan": "node tools/local-control/server.mjs --lan",
-    "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs tools/local-control/v5-env.test.mjs tools/local-control/claude-adapter.test.mjs tools/local-control/state.test.mjs tools/local-control/v5-server.test.mjs",
+    "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs tools/local-control/v5-env.test.mjs tools/local-control/claude-adapter.test.mjs tools/local-control/state.test.mjs tools/local-control/v5-server.test.mjs tools/local-control/autopilot.test.mjs tools/local-control/integrations/integrations.test.mjs",
     "local:control:ui:test": "node --test tools/local-control/tests/",
     "task:test": "node --test tools/task-meta.test.mjs tools/task-deps.test.mjs tools/task-guard.test.mjs tools/task-questions.test.mjs tools/task-runner.test.mjs tools/task-doctor.test.mjs tools/apply-issue-delta.test.mjs tools/issue-status.test.mjs",
     "task:lint:test": "node --test tools/apply-issue-delta.test.mjs",

--- a/tools/local-control/autopilot.mjs
+++ b/tools/local-control/autopilot.mjs
@@ -1,0 +1,303 @@
+import { spawn, spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { redactSecrets } from './safety.mjs';
+
+export const AUTOPILOT_STOP_REASONS = Object.freeze({
+  COMPLETED: 'completed',
+  STOPPED: 'stopped-by-user',
+  REPO_DIRTY: 'repo-dirty',
+  NO_SAFE_TASK: 'no-safe-task',
+  GUARD_BLOCK: 'guard-block',
+  QUESTION: 'human-question',
+  ERROR_BUDGET: 'error-budget-exceeded',
+  TIME_BUDGET: 'time-budget-exceeded',
+  PR_BUDGET: 'pr-budget-reached',
+  SECRET_MISSING: 'secret-missing',
+  CLAUDE_UNAVAILABLE: 'claude-unavailable',
+  EXEC_DISABLED: 'exec-disabled',
+});
+
+export const AUTOPILOT_BLOCK_LABELS = Object.freeze([
+  'risk:destructive',
+  'risk:review-required',
+  'ai:human-checkpoint',
+]);
+
+export const AUTOPILOT_REQUIRED_LABELS = Object.freeze([
+  'ai:autonomous',
+  'risk:safe',
+]);
+
+export function chooseSafeTask({ items = [], excludeIssues = [], staleDays = 7 }) {
+  const exclude = new Set(excludeIssues.map(Number));
+  const now = Date.now();
+  const filtered = items.filter((it) => {
+    if (!it || !Number.isInteger(it.number)) return false;
+    if (exclude.has(it.number)) return false;
+    const labels = (it.labels ?? []).map((l) => (typeof l === 'string' ? l : l?.name)).filter(Boolean);
+    if (AUTOPILOT_BLOCK_LABELS.some((b) => labels.includes(b))) return false;
+    if (!AUTOPILOT_REQUIRED_LABELS.every((r) => labels.includes(r))) return false;
+    if (it.stale === true) return false;
+    if (typeof it.updatedAt === 'string') {
+      const ageMs = now - new Date(it.updatedAt).getTime();
+      if (ageMs > staleDays * 24 * 3600 * 1000) return false;
+    }
+    return true;
+  });
+  filtered.sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+  return filtered[0] ?? null;
+}
+
+export function evaluatePreflight({ gitInfo, claudeAvailable, settings, env, mode }) {
+  const reasons = [];
+  if (gitInfo?.dirty) reasons.push('repo dirty');
+  if (gitInfo?.branch && gitInfo.branch !== 'main') reasons.push(`not on main (currently ${gitInfo.branch})`);
+  if (!claudeAvailable && (mode === 'exec' || mode === 'loop')) reasons.push('Claude CLI not available');
+  if (mode !== 'plan' && !settings?.allowExec) reasons.push('allowExec disabled');
+  if (mode === 'loop' && !settings?.allowLoop) reasons.push('allowLoop disabled');
+  for (const k of ['CLAUDE_CODE_COMMAND', 'GITHUB_OWNER', 'GITHUB_REPO']) {
+    if (!env?.[k]) reasons.push(`missing env: ${k}`);
+  }
+  return { ok: reasons.length === 0, reasons };
+}
+
+export function shouldStopRun({ run, settings, now = Date.now() }) {
+  if (!run) return { stop: true, reason: AUTOPILOT_STOP_REASONS.STOPPED };
+  if (run.stopRequested) return { stop: true, reason: AUTOPILOT_STOP_REASONS.STOPPED };
+  if (run.errors >= 3) return { stop: true, reason: AUTOPILOT_STOP_REASONS.ERROR_BUDGET };
+  const minutes = (now - new Date(run.startedAt).getTime()) / 60000;
+  if (minutes > (settings?.maxMinutes ?? 60)) return { stop: true, reason: AUTOPILOT_STOP_REASONS.TIME_BUDGET };
+  if ((run.prsCreated ?? 0) >= (settings?.maxPrsPerRun ?? 3)) return { stop: true, reason: AUTOPILOT_STOP_REASONS.PR_BUDGET };
+  if (run.pendingQuestionId) return { stop: true, reason: AUTOPILOT_STOP_REASONS.QUESTION };
+  return { stop: false, reason: null };
+}
+
+export function buildAutopilotState({ id, mode, issue, branch, settingsSnapshot }) {
+  return {
+    id: id ?? randomUUID(),
+    kind: 'autopilot',
+    mode,
+    issue: issue ?? null,
+    branch: branch ?? null,
+    status: 'running',
+    currentStep: 'preflight',
+    startedAt: new Date().toISOString(),
+    stoppedAt: null,
+    stopReason: null,
+    pendingQuestionId: null,
+    prsCreated: 0,
+    issuesProcessed: [],
+    errors: 0,
+    nextAction: 'select-task',
+    lastPR: null,
+    resumeAvailable: false,
+    settingsSnapshot: settingsSnapshot ?? null,
+    log: [],
+    stopRequested: false,
+  };
+}
+
+export function runStep(run, step, info = {}) {
+  run.currentStep = step;
+  run.log.push({ at: new Date().toISOString(), step, ...info });
+  if (run.log.length > 200) run.log.splice(0, run.log.length - 200);
+  return run;
+}
+
+export function recordError(run, err) {
+  run.errors = (run.errors ?? 0) + 1;
+  run.log.push({ at: new Date().toISOString(), step: run.currentStep, error: redactSecrets(err?.message ?? String(err), []) });
+  return run;
+}
+
+export function recordPR({ run, pr }) {
+  run.prsCreated = (run.prsCreated ?? 0) + 1;
+  run.lastPR = pr;
+  return run;
+}
+
+export function markStopped(run, reason) {
+  run.status = reason === AUTOPILOT_STOP_REASONS.COMPLETED ? 'completed' : 'stopped';
+  run.stopReason = reason;
+  run.stoppedAt = new Date().toISOString();
+  run.nextAction = 'idle';
+  return run;
+}
+
+export function markWaitingOnQuestion(run, qid) {
+  run.status = 'waiting';
+  run.pendingQuestionId = qid;
+  run.resumeAvailable = true;
+  run.nextAction = `answer question ${qid}`;
+  return run;
+}
+
+export function exportRunSummary(run) {
+  if (!run) return null;
+  return {
+    id: run.id,
+    mode: run.mode,
+    status: run.status,
+    issue: run.issue,
+    branch: run.branch,
+    currentStep: run.currentStep,
+    startedAt: run.startedAt,
+    stoppedAt: run.stoppedAt,
+    stopReason: run.stopReason,
+    pendingQuestionId: run.pendingQuestionId,
+    prsCreated: run.prsCreated,
+    issuesProcessed: run.issuesProcessed,
+    errors: run.errors,
+    nextAction: run.nextAction,
+    lastPR: run.lastPR,
+    resumeAvailable: run.resumeAvailable,
+    log: run.log.slice(-30),
+  };
+}
+
+function gitClean(repoRoot) {
+  const r = spawnSync('git', ['status', '--porcelain'], { cwd: repoRoot, encoding: 'utf8' });
+  return r.status === 0 && r.stdout.trim().length === 0;
+}
+function gitBranch(repoRoot) {
+  const r = spawnSync('git', ['branch', '--show-current'], { cwd: repoRoot, encoding: 'utf8' });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+export function loadQueueItems(repoRoot) {
+  const r = spawnSync('pnpm', ['task:queue'], { cwd: repoRoot, encoding: 'utf8' });
+  if (r.status !== 0) return { ok: false, items: [], reason: r.stderr || 'queue failed' };
+  try {
+    const parsed = JSON.parse(r.stdout);
+    return { ok: true, items: Array.isArray(parsed) ? parsed : (parsed.items ?? []) };
+  } catch { return { ok: false, items: [], reason: 'queue parse error' }; }
+}
+
+export function preflightFromRepo({ repoRoot, claudeAvailable, settings, env, mode }) {
+  const gitInfo = { branch: gitBranch(repoRoot), dirty: !gitClean(repoRoot) };
+  const evaluated = evaluatePreflight({ gitInfo, claudeAvailable, settings, env, mode });
+  return { ...evaluated, gitInfo };
+}
+
+export class AutopilotEngine {
+  constructor({ repoRoot, settings, store, logs, env, claudeAdapter, dryRun = true }) {
+    this.repoRoot = repoRoot;
+    this.settings = settings;
+    this.store = store;
+    this.logs = logs;
+    this.env = env;
+    this.claudeAdapter = claudeAdapter;
+    this.dryRun = dryRun;
+    this.activeRun = null;
+    this.activeChild = null;
+    this.activeRunId = null;
+  }
+  hasActive() { return !!this.activeRun && this.activeRun.status === 'running'; }
+
+  async start({ mode = 'plan', issue = null }) {
+    if (this.activeRun && (this.activeRun.status === 'running' || this.activeRun.status === 'waiting')) {
+      return { ok: false, reason: 'autopilot already active', run: exportRunSummary(this.activeRun) };
+    }
+    const settingsSnapshot = this.settings.get();
+    const claudeAvailable = !!this.claudeAdapter?.available;
+    const pre = preflightFromRepo({
+      repoRoot: this.repoRoot,
+      claudeAvailable,
+      settings: settingsSnapshot,
+      env: this.env,
+      mode,
+    });
+    const run = buildAutopilotState({ mode, issue, settingsSnapshot });
+    this.activeRun = run;
+    this.activeRunId = run.id;
+    if (!pre.ok) {
+      runStep(run, 'preflight-failed', { reasons: pre.reasons });
+      markStopped(run, AUTOPILOT_STOP_REASONS.REPO_DIRTY);
+      this._persist();
+      return { ok: false, reason: pre.reasons.join('; '), run: exportRunSummary(run) };
+    }
+    runStep(run, 'preflight-ok');
+
+    let chosenIssue = issue;
+    if (!chosenIssue) {
+      const queue = loadQueueItems(this.repoRoot);
+      if (!queue.ok) {
+        recordError(run, new Error(queue.reason));
+        markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
+        this._persist();
+        return { ok: false, reason: queue.reason, run: exportRunSummary(run) };
+      }
+      const safe = chooseSafeTask({ items: queue.items, staleDays: settingsSnapshot.staleDays });
+      if (!safe) {
+        markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
+        this._persist();
+        return { ok: false, reason: 'no safe task available', run: exportRunSummary(run) };
+      }
+      chosenIssue = safe.number;
+      run.issue = chosenIssue;
+    }
+
+    const branch = `feat/issue-${chosenIssue}-autopilot`;
+    run.branch = branch;
+    runStep(run, 'task-selected', { issue: chosenIssue, branch });
+
+    const prep = this.claudeAdapter?.prepare?.({ issue: chosenIssue, mode, env: this.env, repoRoot: this.repoRoot })
+      ?? null;
+    run.lastPrompt = prep?.prompt ?? null;
+    runStep(run, 'prompt-ready');
+
+    if (mode === 'plan' || this.dryRun || !claudeAvailable || !settingsSnapshot.allowExec) {
+      run.nextAction = 'manual: copy prompt and run yu locally';
+      runStep(run, 'plan-only-ready', { reason: this.dryRun ? 'dry-run' : (!claudeAvailable ? 'claude unavailable' : 'exec disabled') });
+      markStopped(run, AUTOPILOT_STOP_REASONS.COMPLETED);
+      this._persist();
+      return { ok: true, run: exportRunSummary(run), prompt: prep?.prompt ?? null, branch };
+    }
+
+    runStep(run, 'launching-claude');
+    const launch = this.claudeAdapter.launch({ prompt: prep.prompt, command: prep.command, repoRoot: this.repoRoot, env: this.env });
+    if (!launch.ok) {
+      recordError(run, new Error(launch.reason ?? 'launch failed'));
+      markStopped(run, AUTOPILOT_STOP_REASONS.CLAUDE_UNAVAILABLE);
+      this._persist();
+      return { ok: false, reason: launch.reason, run: exportRunSummary(run) };
+    }
+    this.activeChild = launch.child;
+    run.nextAction = 'claude running';
+    this._persist();
+    return { ok: true, run: exportRunSummary(run), branch, launched: true };
+  }
+
+  stop() {
+    if (!this.activeRun) return { ok: false, reason: 'no active run' };
+    this.activeRun.stopRequested = true;
+    if (this.activeChild) {
+      try { this.activeChild.kill('SIGTERM'); } catch { /* ignore */ }
+    }
+    markStopped(this.activeRun, AUTOPILOT_STOP_REASONS.STOPPED);
+    this._persist();
+    return { ok: true, run: exportRunSummary(this.activeRun) };
+  }
+
+  resume({ answeredQid } = {}) {
+    const run = this.activeRun;
+    if (!run) return { ok: false, reason: 'no run to resume' };
+    if (run.status !== 'waiting') return { ok: false, reason: `cannot resume from status ${run.status}` };
+    if (run.pendingQuestionId && answeredQid !== run.pendingQuestionId) {
+      return { ok: false, reason: 'pending question not answered' };
+    }
+    run.pendingQuestionId = null;
+    run.status = 'running';
+    run.nextAction = 'continue';
+    runStep(run, 'resumed');
+    this._persist();
+    return { ok: true, run: exportRunSummary(run) };
+  }
+
+  current() { return this.activeRun ? exportRunSummary(this.activeRun) : null; }
+
+  _persist() {
+    if (!this.activeRun || !this.store) return;
+    try { this.store.save(this.activeRun); } catch { /* best-effort */ }
+  }
+}

--- a/tools/local-control/autopilot.test.mjs
+++ b/tools/local-control/autopilot.test.mjs
@@ -1,0 +1,173 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  chooseSafeTask,
+  evaluatePreflight,
+  shouldStopRun,
+  buildAutopilotState,
+  markStopped,
+  markWaitingOnQuestion,
+  recordError,
+  recordPR,
+  exportRunSummary,
+  AUTOPILOT_STOP_REASONS,
+} from './autopilot.mjs';
+
+test('chooseSafeTask filters destructive labels', () => {
+  const items = [
+    { number: 1, labels: ['ai:autonomous', 'risk:destructive'], score: 9 },
+    { number: 2, labels: ['ai:autonomous', 'risk:safe'], score: 5 },
+    { number: 3, labels: ['risk:safe'], score: 8 },
+  ];
+  const r = chooseSafeTask({ items });
+  assert.equal(r.number, 2);
+});
+
+test('chooseSafeTask requires both ai:autonomous and risk:safe', () => {
+  const items = [
+    { number: 10, labels: ['ai:autonomous'], score: 9 },
+    { number: 11, labels: ['risk:safe'], score: 9 },
+  ];
+  const r = chooseSafeTask({ items });
+  assert.equal(r, null);
+});
+
+test('chooseSafeTask excludes already processed', () => {
+  const items = [
+    { number: 1, labels: ['ai:autonomous', 'risk:safe'], score: 9 },
+    { number: 2, labels: ['ai:autonomous', 'risk:safe'], score: 5 },
+  ];
+  const r = chooseSafeTask({ items, excludeIssues: [1] });
+  assert.equal(r.number, 2);
+});
+
+test('chooseSafeTask filters review-required label', () => {
+  const items = [
+    { number: 1, labels: ['ai:autonomous', 'risk:safe', 'risk:review-required'], score: 9 },
+    { number: 2, labels: ['ai:autonomous', 'risk:safe'], score: 5 },
+  ];
+  const r = chooseSafeTask({ items });
+  assert.equal(r.number, 2);
+});
+
+test('chooseSafeTask excludes ai:human-checkpoint', () => {
+  const items = [
+    { number: 1, labels: ['ai:autonomous', 'risk:safe', 'ai:human-checkpoint'], score: 9 },
+  ];
+  assert.equal(chooseSafeTask({ items }), null);
+});
+
+test('evaluatePreflight blocks dirty repo', () => {
+  const r = evaluatePreflight({
+    gitInfo: { dirty: true, branch: 'main' }, claudeAvailable: true,
+    settings: { allowExec: true, allowLoop: true },
+    env: { CLAUDE_CODE_COMMAND: 'yu', GITHUB_OWNER: 'x', GITHUB_REPO: 'y' },
+    mode: 'exec',
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.reasons.includes('repo dirty'));
+});
+
+test('evaluatePreflight requires allowExec for exec mode', () => {
+  const r = evaluatePreflight({
+    gitInfo: { dirty: false, branch: 'main' }, claudeAvailable: true,
+    settings: { allowExec: false, allowLoop: false },
+    env: { CLAUDE_CODE_COMMAND: 'yu', GITHUB_OWNER: 'x', GITHUB_REPO: 'y' },
+    mode: 'exec',
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.reasons.includes('allowExec disabled'));
+});
+
+test('evaluatePreflight requires allowLoop for loop mode', () => {
+  const r = evaluatePreflight({
+    gitInfo: { dirty: false, branch: 'main' }, claudeAvailable: true,
+    settings: { allowExec: true, allowLoop: false },
+    env: { CLAUDE_CODE_COMMAND: 'yu', GITHUB_OWNER: 'x', GITHUB_REPO: 'y' },
+    mode: 'loop',
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.reasons.includes('allowLoop disabled'));
+});
+
+test('evaluatePreflight ok for plan mode without exec', () => {
+  const r = evaluatePreflight({
+    gitInfo: { dirty: false, branch: 'main' }, claudeAvailable: false,
+    settings: { allowExec: false, allowLoop: false },
+    env: { CLAUDE_CODE_COMMAND: 'yu', GITHUB_OWNER: 'x', GITHUB_REPO: 'y' },
+    mode: 'plan',
+  });
+  assert.equal(r.ok, true);
+});
+
+test('shouldStopRun stops on time budget', () => {
+  const startedAt = new Date(Date.now() - 90 * 60 * 1000).toISOString();
+  const run = { startedAt, errors: 0, prsCreated: 0, pendingQuestionId: null, stopRequested: false };
+  const r = shouldStopRun({ run, settings: { maxMinutes: 60, maxPrsPerRun: 3 } });
+  assert.equal(r.stop, true);
+  assert.equal(r.reason, AUTOPILOT_STOP_REASONS.TIME_BUDGET);
+});
+
+test('shouldStopRun stops at 3 errors', () => {
+  const run = { startedAt: new Date().toISOString(), errors: 3, prsCreated: 0, stopRequested: false };
+  const r = shouldStopRun({ run, settings: { maxMinutes: 60, maxPrsPerRun: 3 } });
+  assert.equal(r.stop, true);
+  assert.equal(r.reason, AUTOPILOT_STOP_REASONS.ERROR_BUDGET);
+});
+
+test('shouldStopRun stops at PR budget', () => {
+  const run = { startedAt: new Date().toISOString(), errors: 0, prsCreated: 3, stopRequested: false };
+  const r = shouldStopRun({ run, settings: { maxMinutes: 60, maxPrsPerRun: 3 } });
+  assert.equal(r.stop, true);
+  assert.equal(r.reason, AUTOPILOT_STOP_REASONS.PR_BUDGET);
+});
+
+test('shouldStopRun stops on pending question', () => {
+  const run = { startedAt: new Date().toISOString(), errors: 0, prsCreated: 0, pendingQuestionId: 'q-1', stopRequested: false };
+  const r = shouldStopRun({ run, settings: { maxMinutes: 60, maxPrsPerRun: 3 } });
+  assert.equal(r.stop, true);
+  assert.equal(r.reason, AUTOPILOT_STOP_REASONS.QUESTION);
+});
+
+test('buildAutopilotState produces a fresh run with sane defaults', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  assert.equal(run.kind, 'autopilot');
+  assert.equal(run.status, 'running');
+  assert.equal(run.errors, 0);
+  assert.equal(run.prsCreated, 0);
+});
+
+test('markStopped sets stopReason', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  markStopped(run, AUTOPILOT_STOP_REASONS.COMPLETED);
+  assert.equal(run.status, 'completed');
+  assert.equal(run.stopReason, AUTOPILOT_STOP_REASONS.COMPLETED);
+});
+
+test('markWaitingOnQuestion flags resumeAvailable', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  markWaitingOnQuestion(run, 'q-42');
+  assert.equal(run.status, 'waiting');
+  assert.equal(run.pendingQuestionId, 'q-42');
+  assert.equal(run.resumeAvailable, true);
+});
+
+test('recordError increments errors', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  recordError(run, new Error('boom'));
+  assert.equal(run.errors, 1);
+});
+
+test('recordPR sets lastPR and increments', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  recordPR({ run, pr: { number: 9, url: 'x' } });
+  assert.equal(run.prsCreated, 1);
+  assert.deepEqual(run.lastPR, { number: 9, url: 'x' });
+});
+
+test('exportRunSummary trims log to 30', () => {
+  const run = buildAutopilotState({ mode: 'plan' });
+  for (let i = 0; i < 50; i++) run.log.push({ at: new Date().toISOString(), step: 's' + i });
+  const summary = exportRunSummary(run);
+  assert.equal(summary.log.length, 30);
+});

--- a/tools/local-control/claude-adapter.mjs
+++ b/tools/local-control/claude-adapter.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { existsSync } from 'node:fs';
 import { loadV5Env } from './v5-env.mjs';
@@ -94,4 +94,43 @@ export function v5StatusFromEnv({ env, repoRoot }) {
 export function loadAdapterContext(repoRoot) {
   const { values, file, exists } = loadV5Env(repoRoot);
   return { env: values, envFile: file, envExists: exists, envFileExists: exists && existsSync(file) };
+}
+
+const SAFE_PROMPT_RE = /^[\s\S]{1,32000}$/;
+
+export function launchClaude({ prompt, command, repoRoot, env = {}, allowExec = false }) {
+  if (!allowExec) return { ok: false, reason: 'exec not allowed' };
+  if (!command || !SAFE_COMMAND_RE.test(command)) return { ok: false, reason: 'unsafe command' };
+  if (!prompt || !SAFE_PROMPT_RE.test(prompt)) return { ok: false, reason: 'invalid prompt' };
+  if (!resolve(repoRoot)) return { ok: false, reason: 'invalid repoRoot' };
+  const childEnv = { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' };
+  for (const [k, v] of Object.entries(env)) {
+    if (typeof v === 'string' && v.length) childEnv[k] = v;
+  }
+  const escaped = prompt.replace(/'/g, `'\\''`);
+  const shellCmd = `${command} -p '${escaped}'`;
+  let child;
+  try {
+    child = spawn('/bin/zsh', ['-i', '-c', shellCmd], {
+      cwd: repoRoot,
+      env: childEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    return { ok: false, reason: `spawn failed: ${err.message}` };
+  }
+  return { ok: true, child };
+}
+
+export function buildAdapter({ env = {}, repoRoot }) {
+  const resolved = resolveClaudeCommand(env);
+  const probe = resolved.ok ? probeClaudeAvailability({ command: resolved.command }) : { available: false, version: null, reason: resolved.reason };
+  return {
+    available: !!probe.available,
+    command: resolved.ok ? resolved.command : null,
+    version: probe.version,
+    reason: probe.reason,
+    prepare(args) { return prepareClaudeRun({ ...args, repoRoot, env }); },
+    launch(args) { return launchClaude({ ...args, env, allowExec: true }); },
+  };
 }

--- a/tools/local-control/integrations/integrations.test.mjs
+++ b/tools/local-control/integrations/integrations.test.mjs
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { evaluateNotionConfig, buildQuestionPage, NOTION_PROPERTIES_EXPECTED } from './notion-questions.mjs';
+import { evaluateN8nConfig, signPayload } from './n8n-webhooks.mjs';
+import { evaluateWhatsappConfig, buildQuestionMessage } from './whatsapp.mjs';
+
+test('evaluateNotionConfig flags missing token', () => {
+  const r = evaluateNotionConfig({ NOTION_QUESTIONS_DATABASE_ID: 'abc' });
+  assert.equal(r.configured, false);
+  assert.deepEqual(r.missing, ['NOTION_TOKEN']);
+});
+test('evaluateNotionConfig configured when both set', () => {
+  const r = evaluateNotionConfig({ NOTION_TOKEN: 'secret', NOTION_QUESTIONS_DATABASE_ID: 'db' });
+  assert.equal(r.configured, true);
+  assert.equal(r.token, 'secret');
+});
+test('buildQuestionPage produces required props', () => {
+  const page = buildQuestionPage({
+    databaseId: 'db1',
+    question: { id: 'q-1', issue: 42, title: 'Need help', question: 'X?', options: ['A', 'B'], recommendation: 'A', githubUrl: 'http://gh', createdAt: '2026-01-01T00:00:00Z' },
+  });
+  assert.equal(page.parent.database_id, 'db1');
+  assert.ok(page.properties['Name']);
+  assert.ok(page.properties['Question ID']);
+  assert.equal(page.properties['Issue Number'].number, 42);
+});
+test('NOTION_PROPERTIES_EXPECTED includes Status and Question ID', () => {
+  assert.ok(NOTION_PROPERTIES_EXPECTED.includes('Status'));
+  assert.ok(NOTION_PROPERTIES_EXPECTED.includes('Question ID'));
+});
+
+test('evaluateN8nConfig requires base + secret', () => {
+  const r = evaluateN8nConfig({ N8N_BASE_URL: 'https://x', N8N_WEBHOOK_SECRET: '' });
+  assert.equal(r.baseConfigured, false);
+});
+test('evaluateN8nConfig flags missing webhooks', () => {
+  const r = evaluateN8nConfig({
+    N8N_BASE_URL: 'https://x', N8N_WEBHOOK_SECRET: 'k',
+  });
+  assert.equal(r.baseConfigured, true);
+  assert.deepEqual(r.missingWebhooks.sort(), ['N8N_NOTION_ANSWER_WEBHOOK', 'N8N_QUESTION_NOTIFY_WEBHOOK'].sort());
+});
+test('signPayload deterministic hex', () => {
+  const sig = signPayload('s', '{"a":1}');
+  assert.match(sig, /^[a-f0-9]{64}$/);
+  assert.equal(signPayload('s', '{"a":1}'), sig);
+});
+
+test('evaluateWhatsappConfig flags missing provider', () => {
+  const r = evaluateWhatsappConfig({});
+  assert.equal(r.configured, false);
+  assert.ok(r.missing.includes('WHATSAPP_PROVIDER'));
+});
+test('evaluateWhatsappConfig configured for n8n provider', () => {
+  const r = evaluateWhatsappConfig({ WHATSAPP_PROVIDER: 'n8n', WHATSAPP_FROM: 'me', WHATSAPP_TO: 'you' });
+  assert.equal(r.configured, true);
+  assert.equal(r.via, 'n8n');
+});
+test('evaluateWhatsappConfig requires twilio creds for twilio provider', () => {
+  const r = evaluateWhatsappConfig({ WHATSAPP_PROVIDER: 'twilio', WHATSAPP_FROM: 'a', WHATSAPP_TO: 'b' });
+  assert.equal(r.configured, false);
+});
+test('buildQuestionMessage includes options and recommendation', () => {
+  const msg = buildQuestionMessage({ issue: 7, question: 'Pick one', options: ['A', 'B'], recommendation: 'A' });
+  assert.match(msg, /#7/);
+  assert.match(msg, /Options/);
+  assert.match(msg, /A/);
+  assert.match(msg, /Claude recommends/);
+});

--- a/tools/local-control/integrations/n8n-webhooks.mjs
+++ b/tools/local-control/integrations/n8n-webhooks.mjs
@@ -1,0 +1,72 @@
+import { createHmac } from 'node:crypto';
+import { request } from 'node:https';
+import { request as httpRequest } from 'node:http';
+import { URL } from 'node:url';
+
+export function evaluateN8nConfig(env) {
+  const baseUrl = (env.N8N_BASE_URL ?? '').trim();
+  const secret = (env.N8N_WEBHOOK_SECRET ?? '').trim();
+  const questionWh = (env.N8N_QUESTION_NOTIFY_WEBHOOK ?? '').trim();
+  const answerWh = (env.N8N_NOTION_ANSWER_WEBHOOK ?? '').trim();
+  const baseConfigured = !!(baseUrl && secret);
+  return {
+    baseConfigured,
+    baseUrl: baseConfigured ? baseUrl : null,
+    secret: baseConfigured ? secret : null,
+    questionWebhook: questionWh || null,
+    answerWebhook: answerWh || null,
+    questionWebhookConfigured: !!questionWh,
+    answerWebhookConfigured: !!answerWh,
+    missing: [
+      !baseUrl ? 'N8N_BASE_URL' : null,
+      !secret ? 'N8N_WEBHOOK_SECRET' : null,
+    ].filter(Boolean),
+    missingWebhooks: [
+      !questionWh ? 'N8N_QUESTION_NOTIFY_WEBHOOK' : null,
+      !answerWh ? 'N8N_NOTION_ANSWER_WEBHOOK' : null,
+    ].filter(Boolean),
+  };
+}
+
+export function signPayload(secret, body) {
+  return createHmac('sha256', String(secret)).update(body).digest('hex');
+}
+
+export function postWebhook({ url, secret, payload, timeoutMs = 6000 }) {
+  return new Promise((resolveP) => {
+    let parsed;
+    try { parsed = new URL(url); } catch { return resolveP({ ok: false, status: 0, reason: 'invalid url' }); }
+    const body = Buffer.from(JSON.stringify(payload ?? {}));
+    const sig = signPayload(secret, body);
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: `${parsed.pathname}${parsed.search}`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': body.length,
+        'X-Webapp-Signature': sig,
+      },
+    };
+    const reqFn = parsed.protocol === 'https:' ? request : httpRequest;
+    const req = reqFn(opts, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        resolveP({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, raw });
+      });
+    });
+    req.on('error', (err) => resolveP({ ok: false, status: 0, reason: err.message }));
+    req.setTimeout(timeoutMs, () => { req.destroy(new Error('n8n request timeout')); });
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function notifyQuestion({ config, question, poster = postWebhook }) {
+  if (!config.baseConfigured) return { ok: false, skipped: true, reason: 'n8n base not configured' };
+  if (!config.questionWebhookConfigured) return { ok: false, skipped: true, reason: 'N8N_QUESTION_NOTIFY_WEBHOOK missing' };
+  return await poster({ url: config.questionWebhook, secret: config.secret, payload: { type: 'question', question } });
+}

--- a/tools/local-control/integrations/notion-questions.mjs
+++ b/tools/local-control/integrations/notion-questions.mjs
@@ -1,0 +1,157 @@
+import { request } from 'node:https';
+
+const NOTION_VERSION = '2022-06-28';
+
+export const NOTION_PROPERTIES_EXPECTED = Object.freeze([
+  'Name',
+  'Question ID',
+  'Issue Number',
+  'Status',
+  'Block Level',
+  'Question',
+  'Options',
+  'Claude Recommendation',
+  'Human Answer',
+  'Source',
+  'GitHub URL',
+  'Created At',
+  'Answered At',
+]);
+
+export function evaluateNotionConfig(env) {
+  const token = (env.NOTION_TOKEN ?? '').trim();
+  const dbId = (env.NOTION_QUESTIONS_DATABASE_ID ?? '').trim();
+  const configured = !!(token && dbId);
+  return {
+    configured,
+    token: configured ? token : null,
+    databaseId: configured ? dbId : null,
+    missing: [
+      !token ? 'NOTION_TOKEN' : null,
+      !dbId ? 'NOTION_QUESTIONS_DATABASE_ID' : null,
+    ].filter(Boolean),
+  };
+}
+
+function notionFetch({ token, path, method = 'GET', body = null, timeoutMs = 8000 }) {
+  return new Promise((resolveP) => {
+    const data = body ? Buffer.from(JSON.stringify(body)) : null;
+    const req = request({
+      hostname: 'api.notion.com',
+      port: 443,
+      path,
+      method,
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+        ...(data ? { 'Content-Length': data.length } : {}),
+      },
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        let json = null;
+        try { json = JSON.parse(raw); } catch { /* keep raw */ }
+        resolveP({ ok: res.statusCode >= 200 && res.statusCode < 300, status: res.statusCode, body: json, raw });
+      });
+    });
+    req.on('error', (err) => resolveP({ ok: false, status: 0, body: null, raw: '', error: err.message }));
+    req.setTimeout(timeoutMs, () => { req.destroy(new Error('notion request timeout')); });
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+export async function validateNotionDatabase({ token, databaseId, fetcher = notionFetch }) {
+  const res = await fetcher({ token, path: `/v1/databases/${databaseId}` });
+  if (!res.ok) {
+    return { ok: false, status: res.status, reason: res.body?.message ?? res.error ?? `HTTP ${res.status}`, missing: [], extras: [] };
+  }
+  const props = res.body?.properties ?? {};
+  const have = Object.keys(props);
+  const missing = NOTION_PROPERTIES_EXPECTED.filter((p) => !have.includes(p));
+  return {
+    ok: missing.length === 0,
+    status: res.status,
+    reason: missing.length === 0 ? null : `missing properties: ${missing.join(', ')}`,
+    missing,
+    extras: have.filter((p) => !NOTION_PROPERTIES_EXPECTED.includes(p)),
+    have,
+  };
+}
+
+function richText(s) { return [{ type: 'text', text: { content: String(s ?? '').slice(0, 2000) } }]; }
+
+export function buildQuestionPage({ databaseId, question }) {
+  const q = question || {};
+  const title = q.title ?? `Q ${q.id ?? ''}`;
+  return {
+    parent: { database_id: databaseId },
+    properties: {
+      'Name': { title: richText(title) },
+      'Question ID': { rich_text: richText(q.id ?? '') },
+      'Issue Number': { number: Number.isFinite(q.issue) ? q.issue : null },
+      'Status': { select: { name: q.status ?? 'open' } },
+      'Block Level': { select: { name: q.blockLevel ?? 'soft' } },
+      'Question': { rich_text: richText(q.question ?? '') },
+      'Options': { rich_text: richText((q.options ?? []).join(' | ')) },
+      'Claude Recommendation': { rich_text: richText(q.recommendation ?? '') },
+      'Source': { select: { name: q.source ?? 'github' } },
+      'GitHub URL': { url: q.githubUrl ?? null },
+      'Created At': q.createdAt ? { date: { start: q.createdAt } } : { date: null },
+    },
+  };
+}
+
+export async function findQuestionPageByQid({ token, databaseId, qid, fetcher = notionFetch }) {
+  const res = await fetcher({
+    token,
+    path: `/v1/databases/${databaseId}/query`,
+    method: 'POST',
+    body: {
+      filter: { property: 'Question ID', rich_text: { equals: String(qid) } },
+      page_size: 1,
+    },
+  });
+  if (!res.ok) return null;
+  return res.body?.results?.[0] ?? null;
+}
+
+export async function upsertQuestion({ token, databaseId, question, fetcher = notionFetch }) {
+  const existing = await findQuestionPageByQid({ token, databaseId, qid: question.id, fetcher });
+  if (existing) {
+    const patch = buildQuestionPage({ databaseId, question }).properties;
+    delete patch['Created At'];
+    const res = await fetcher({ token, path: `/v1/pages/${existing.id}`, method: 'PATCH', body: { properties: patch } });
+    return { ok: res.ok, mode: 'update', pageId: existing.id, status: res.status, reason: res.body?.message ?? null };
+  }
+  const res = await fetcher({ token, path: '/v1/pages', method: 'POST', body: buildQuestionPage({ databaseId, question }) });
+  return { ok: res.ok, mode: 'create', pageId: res.body?.id ?? null, status: res.status, reason: res.body?.message ?? null };
+}
+
+export async function listAnsweredQuestions({ token, databaseId, fetcher = notionFetch }) {
+  const res = await fetcher({
+    token,
+    path: `/v1/databases/${databaseId}/query`,
+    method: 'POST',
+    body: {
+      filter: { property: 'Status', select: { equals: 'answered' } },
+      page_size: 50,
+    },
+  });
+  if (!res.ok) return { ok: false, items: [], reason: res.body?.message ?? `HTTP ${res.status}` };
+  const items = (res.body?.results ?? []).map((page) => {
+    const props = page.properties ?? {};
+    const text = (p) => (p?.rich_text?.[0]?.plain_text ?? p?.title?.[0]?.plain_text ?? '');
+    return {
+      pageId: page.id,
+      qid: text(props['Question ID']),
+      issue: props['Issue Number']?.number ?? null,
+      answer: text(props['Human Answer']),
+      answeredAt: props['Answered At']?.date?.start ?? null,
+    };
+  }).filter((x) => x.qid && x.answer);
+  return { ok: true, items, reason: null };
+}

--- a/tools/local-control/integrations/whatsapp.mjs
+++ b/tools/local-control/integrations/whatsapp.mjs
@@ -1,0 +1,36 @@
+export function evaluateWhatsappConfig(env) {
+  const provider = (env.WHATSAPP_PROVIDER ?? '').trim();
+  const from = (env.WHATSAPP_FROM ?? '').trim();
+  const to = (env.WHATSAPP_TO ?? '').trim();
+  const sid = (env.TWILIO_ACCOUNT_SID ?? '').trim();
+  const token = (env.TWILIO_AUTH_TOKEN ?? '').trim();
+  const baseConfigured = !!(provider && from && to);
+  const twilioConfigured = !!(sid && token);
+  const directConfigured = provider === 'twilio' ? baseConfigured && twilioConfigured : baseConfigured;
+  return {
+    provider: provider || null,
+    configured: directConfigured,
+    via: provider === 'n8n' ? 'n8n' : (directConfigured ? provider : null),
+    twilioConfigured,
+    missing: [
+      !provider ? 'WHATSAPP_PROVIDER' : null,
+      !from ? 'WHATSAPP_FROM' : null,
+      !to ? 'WHATSAPP_TO' : null,
+      provider === 'twilio' && !sid ? 'TWILIO_ACCOUNT_SID' : null,
+      provider === 'twilio' && !token ? 'TWILIO_AUTH_TOKEN' : null,
+    ].filter(Boolean),
+  };
+}
+
+export function buildQuestionMessage(question) {
+  const q = question || {};
+  const opts = (q.options ?? []).map((o, i) => `${i + 1}. ${o}`).join('\n');
+  return [
+    `🤖 Claude needs you (#${q.issue ?? '?'})`,
+    q.question ?? '',
+    opts ? `\nOptions:\n${opts}` : '',
+    q.recommendation ? `\nClaude recommends: ${q.recommendation}` : '',
+    q.githubUrl ? `\n${q.githubUrl}` : '',
+    `\nReply on GitHub or Notion. Timeout: 25 min.`,
+  ].filter(Boolean).join('\n');
+}

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -16,6 +16,7 @@ import { confirmDanger } from "./lib/confirm.js";
 import { renderOnboarding } from "./lib/onboarding.js";
 import { runWithState } from "./lib/buttonState.js";
 import { renderV5Card } from "./lib/v5.js";
+import { renderAutopilotState, startAutopilot, stopAutopilot, resumeAutopilot, fetchAutopilotStatus } from "./lib/autopilot.js";
 import {
   TokenStore, ConnState, readTokenFromUrl,
   classifyError, badgeLabel, badgeClass, shouldKeepPolling,
@@ -124,6 +125,7 @@ async function refreshAll() {
     applySettingsToBadges(settings);
     renderOnboarding({ conn: "connected", settings, network });
     if (v5) renderV5Card(document.getElementById("v5-card"), v5);
+    renderAutopilotState(document.getElementById("autopilot-card"), v5?.autopilot ?? null, v5);
     setConnState(ConnState.CONNECTED);
   } catch (e) {
     const next = classifyError(e);
@@ -216,6 +218,43 @@ document.querySelector('[data-action="v5-resume"]')?.addEventListener("click", a
     if (r?.canResume) log(`✓ v5: can resume run ${r.runId} for issue #${r.issue}`);
     else log(`⚠ v5: resume blocked — ${r?.reason ?? "unknown"}`);
   } catch (e) { log(`⚠ v5 resume failed: ${redact(String(e?.message || e))}`); }
+});
+
+document.getElementById("autopilot-start")?.addEventListener("click", async (ev) => {
+  const btn = ev.currentTarget;
+  await runWithState(btn, async () => {
+    const issueRaw = document.getElementById("v5-issue")?.value;
+    const issue = issueRaw ? Number(issueRaw) : null;
+    const mode = (lastSettings?.allowExec) ? "exec" : "plan";
+    const r = await startAutopilot(api, { mode, issue: Number.isInteger(issue) && issue > 0 ? issue : null });
+    if (r?.run) {
+      const card = document.getElementById("autopilot-card");
+      const promptEl = card.querySelector("#autopilot-prompt");
+      if (r.prompt && promptEl) { promptEl.textContent = r.prompt; promptEl.classList.remove("hidden"); }
+      log(`✓ autopilot started — issue=${r.run.issue ?? "?"} mode=${r.run.mode}`);
+    } else {
+      log(`⚠ autopilot: ${r?.reason ?? "failed to start"}`);
+    }
+    refreshAll().catch(() => {});
+  }).catch((e) => log(`⚠ autopilot start failed: ${redact(String(e?.message || e))}`));
+});
+
+document.getElementById("autopilot-stop")?.addEventListener("click", async (ev) => {
+  const btn = ev.currentTarget;
+  await runWithState(btn, async () => {
+    const r = await stopAutopilot(api);
+    log(r?.ok ? "✓ autopilot stopped" : `⚠ autopilot: ${r?.reason ?? "stop failed"}`);
+    refreshAll().catch(() => {});
+  }).catch((e) => log(`⚠ autopilot stop failed: ${redact(String(e?.message || e))}`));
+});
+
+document.getElementById("autopilot-resume")?.addEventListener("click", async (ev) => {
+  const btn = ev.currentTarget;
+  await runWithState(btn, async () => {
+    const r = await resumeAutopilot(api);
+    log(r?.ok ? "✓ autopilot resumed" : `⚠ autopilot: ${r?.reason ?? "resume failed"}`);
+    refreshAll().catch(() => {});
+  }).catch((e) => log(`⚠ autopilot resume failed: ${redact(String(e?.message || e))}`));
 });
 
 setConnState(api.token ? ConnState.UNKNOWN : ConnState.AUTH_REQUIRED);

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -52,6 +52,36 @@
 <main>
   <!-- DASHBOARD -->
   <section data-pane="dashboard" class="pane active">
+    <div class="card autopilot-card" id="autopilot-card">
+      <div class="autopilot-header">
+        <h3>Autopilot</h3>
+        <span id="autopilot-status-badge" class="badge">idle</span>
+      </div>
+      <p class="muted small" id="autopilot-summary">Pick the safest open task and hand it to Claude. Stays in dry-run until you flip <code>allowExec</code>.</p>
+      <div class="autopilot-actions">
+        <button id="autopilot-start" class="primary big" data-needs="auth">Start Autopilot</button>
+        <button id="autopilot-stop" data-needs="auth">Stop</button>
+        <button id="autopilot-resume" data-needs="auth">Resume</button>
+      </div>
+      <ul class="autopilot-stats" id="autopilot-stats">
+        <li><span class="label">Mode</span><span class="value" data-key="mode">—</span></li>
+        <li><span class="label">Issue</span><span class="value" data-key="issue">—</span></li>
+        <li><span class="label">PRs</span><span class="value" data-key="prs">0</span></li>
+        <li><span class="label">Errors</span><span class="value" data-key="errors">0</span></li>
+        <li><span class="label">Next</span><span class="value" data-key="next">—</span></li>
+        <li><span class="label">Auto-merge</span><span class="value" data-key="automerge">OFF</span></li>
+      </ul>
+      <pre id="autopilot-prompt" class="log-view hidden" aria-live="polite"></pre>
+      <details class="advanced-controls">
+        <summary>Advanced controls</summary>
+        <div class="actions">
+          <button data-action="doctor" data-needs="auth">Run doctor</button>
+          <button data-action="score" data-needs="auth">Score tasks</button>
+          <button data-action="queue" data-needs="auth">Queue</button>
+          <button data-action="plan-next" data-needs="auth">Plan next task</button>
+        </div>
+      </details>
+    </div>
     <div class="card onboarding" id="onboarding-card">
       <h3>Démarrage rapide</h3>
       <ul class="onboarding-list" id="onboarding-list">

--- a/tools/local-control/public/lib/autopilot.js
+++ b/tools/local-control/public/lib/autopilot.js
@@ -1,0 +1,47 @@
+export function renderAutopilotState(card, state, v5) {
+  if (!card) return;
+  const badge = card.querySelector('#autopilot-status-badge');
+  const stats = card.querySelector('#autopilot-stats');
+  const prompt = card.querySelector('#autopilot-prompt');
+  const ap = state || null;
+  if (badge) {
+    const status = ap?.status ?? 'idle';
+    badge.textContent = status;
+    if (badge.classList) {
+      badge.classList.remove('ok', 'warn', 'danger');
+      const cls = status === 'running' ? 'ok' : status === 'waiting' ? 'warn' : status === 'stopped' ? 'danger' : null;
+      if (cls) badge.classList.add(cls);
+    }
+  }
+  if (stats) {
+    setValue(stats, 'mode', ap?.mode ?? '—');
+    setValue(stats, 'issue', ap?.issue ?? '—');
+    setValue(stats, 'prs', String(ap?.prsCreated ?? 0));
+    setValue(stats, 'errors', String(ap?.errors ?? 0));
+    setValue(stats, 'next', ap?.nextAction ?? '—');
+    const am = v5?.autoMergeMode ?? (v5?.autoMergeAllowed ? 'ENABLED' : 'OFF');
+    setValue(stats, 'automerge', am);
+  }
+  if (prompt && ap?.lastPrompt) {
+    prompt.textContent = ap.lastPrompt;
+    prompt.classList.remove('hidden');
+  }
+}
+
+function setValue(root, key, val) {
+  const el = root.querySelector(`[data-key="${key}"]`);
+  if (el) el.textContent = String(val ?? '—');
+}
+
+export async function startAutopilot(api, { mode = 'plan', issue = null } = {}) {
+  return api.post('/api/autopilot/start', { mode, issue });
+}
+export async function stopAutopilot(api) {
+  return api.post('/api/autopilot/stop', {});
+}
+export async function resumeAutopilot(api, answeredQid = null) {
+  return api.post('/api/autopilot/resume', { answeredQid });
+}
+export async function fetchAutopilotStatus(api) {
+  return api.get('/api/autopilot/status');
+}

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -177,3 +177,20 @@ tr.task-blocked { opacity: 0.65; }
 .v5-list .value.warn { color: var(--warn); }
 .v5-actions summary { cursor: pointer; color: var(--fg-dim); font-size: 12px; margin-bottom: 6px; }
 .v5-actions ul { list-style: disc; padding-left: 18px; margin: 4px 0 0; }
+
+/* Autopilot card */
+.autopilot-card { grid-column: 1 / -1; padding: 18px; margin-bottom: 14px; border: 1px solid var(--accent); }
+.autopilot-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.autopilot-header h3 { margin: 0; font-size: 18px; }
+.autopilot-actions { display: flex; gap: 10px; flex-wrap: wrap; margin: 12px 0; }
+.autopilot-actions .big { padding: 14px 26px; font-size: 16px; font-weight: 700; }
+.autopilot-stats { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 6px; }
+.autopilot-stats li { display: flex; justify-content: space-between; padding: 6px 10px; background: var(--bg-elev-2); border-radius: 6px; font-size: 12px; }
+.autopilot-stats .label { color: var(--fg-dim); text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+.autopilot-stats .value { font-weight: 600; }
+.advanced-controls { margin-top: 14px; }
+.advanced-controls summary { cursor: pointer; color: var(--fg-dim); font-size: 12px; }
+.advanced-controls .actions { margin-top: 8px; flex-wrap: wrap; }
+@media (max-width: 600px) {
+  .autopilot-actions .big { width: 100%; padding: 18px; font-size: 18px; }
+}

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -15,9 +15,13 @@ import {
   runTaskGuard, evaluateAutoMerge, applyAutoMerge,
 } from './automerge.mjs';
 import { loadV5Env, evaluateV5Env } from './v5-env.mjs';
-import { v5StatusFromEnv, prepareClaudeRun } from './claude-adapter.mjs';
+import { v5StatusFromEnv, prepareClaudeRun, buildAdapter } from './claude-adapter.mjs';
 import { V5StateStore } from './state.mjs';
 import { evaluateResume } from './resume.mjs';
+import { evaluateNotionConfig, validateNotionDatabase } from './integrations/notion-questions.mjs';
+import { evaluateN8nConfig } from './integrations/n8n-webhooks.mjs';
+import { evaluateWhatsappConfig } from './integrations/whatsapp.mjs';
+import { AutopilotEngine, exportRunSummary } from './autopilot.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT_DEFAULT = resolve(__dirname, '..', '..');
@@ -67,6 +71,18 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
   const startedAt = Date.now();
   const network = { host: '127.0.0.1', port: 8787, lan: false };
   const v5Store = new V5StateStore(repoRoot);
+  const autopilotStore = new V5StateStore(repoRoot);
+  let autopilot = null;
+  function getAutopilot() {
+    if (autopilot) return autopilot;
+    const { values: env } = loadV5Env(repoRoot);
+    autopilot = new AutopilotEngine({
+      repoRoot, settings, store: autopilotStore, logs, env,
+      claudeAdapter: buildAdapter({ env, repoRoot }),
+      dryRun: !settings.get().allowExec,
+    });
+    return autopilot;
+  }
 
   function authOk(req) { return isAuthenticated(req, settings.get().authToken); }
   function send(res, code, body, extraHeaders = {}) {
@@ -356,19 +372,24 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       const { values: env } = loadV5Env(repoRoot);
       const envEval = evaluateV5Env(env);
       const claude = v5StatusFromEnv({ env, repoRoot });
+      const notionCfg = evaluateNotionConfig(env);
+      const n8nCfg = evaluateN8nConfig(env);
+      const whatsappCfg = evaluateWhatsappConfig(env);
       const phaseStatus = {
         phase1: 'ready',
         phase2: claude.claudeAvailable ? 'ready' : 'pending',
-        phase3: envEval.notionConfigured && envEval.n8nConfigured && envEval.whatsappConfigured ? 'ready' : 'pending',
+        phase3: notionCfg.configured && n8nCfg.baseConfigured ? 'ready' : 'pending',
         phase4: 'pending',
       };
       const nextHumanActions = [];
       if (!claude.claudeAvailable) nextHumanActions.push(`Install/expose Claude Code CLI: ${claude.claudeReason ?? 'set CLAUDE_CODE_COMMAND'}`);
-      if (!envEval.notionConfigured) nextHumanActions.push(`Fill Notion env: ${envEval.missingByGroup.notion.join(', ')}`);
-      if (!envEval.n8nConfigured) nextHumanActions.push(`Fill n8n env: ${envEval.missingByGroup.n8n.join(', ')}`);
-      if (!envEval.whatsappConfigured) nextHumanActions.push(`Fill WhatsApp env: ${envEval.missingByGroup.whatsapp.join(', ')}`);
+      if (!notionCfg.configured) nextHumanActions.push(`Fill Notion env: ${notionCfg.missing.join(', ')}`);
+      if (!n8nCfg.baseConfigured) nextHumanActions.push(`Fill n8n env: ${n8nCfg.missing.join(', ')}`);
+      if (n8nCfg.baseConfigured && n8nCfg.missingWebhooks.length) nextHumanActions.push(`Create/import n8n workflows then fill: ${n8nCfg.missingWebhooks.join(', ')}`);
+      if (!whatsappCfg.configured) nextHumanActions.push(`Optional: configure WhatsApp (${whatsappCfg.missing.join(', ') || 'WHATSAPP_PROVIDER'})`);
       if (!s.allowExec) nextHumanActions.push('Enable allowExec in Settings to run real exec');
       if (!s.allowAutoMerge) nextHumanActions.push('Auto-merge stays OFF until explicitly enabled');
+      const ap = autopilot?.current?.() ?? null;
       return send(res, 200, {
         claudeCommand: claude.claudeCommand,
         claudeAvailable: claude.claudeAvailable,
@@ -377,14 +398,55 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
         execAllowed: !!s.allowExec,
         loopAllowed: !!s.allowLoop,
         autoMergeAllowed: !!s.allowAutoMerge,
-        notionConfigured: envEval.notionConfigured,
-        n8nConfigured: envEval.n8nConfigured,
-        whatsappConfigured: envEval.whatsappConfigured,
+        autoMergeMode: s.allowAutoMerge ? 'ENABLED' : 'OFF',
+        notionConfigured: notionCfg.configured,
+        n8nConfigured: n8nCfg.baseConfigured,
+        n8nWebhooksConfigured: n8nCfg.questionWebhookConfigured && n8nCfg.answerWebhookConfigured,
+        n8nMissingWebhooks: n8nCfg.missingWebhooks,
+        whatsappConfigured: whatsappCfg.configured,
+        whatsappVia: whatsappCfg.via,
         missingEnv: envEval.missingEnv,
         missingByGroup: envEval.missingByGroup,
         phaseStatus,
         nextHumanActions,
+        autopilot: ap,
       });
+    }
+
+    if (method === 'GET' && path === '/api/v5/notion/validate') {
+      const { values: env } = loadV5Env(repoRoot);
+      const cfg = evaluateNotionConfig(env);
+      if (!cfg.configured) return send(res, 200, { ok: false, configured: false, reason: `missing: ${cfg.missing.join(', ')}` });
+      try {
+        const out = await validateNotionDatabase({ token: cfg.token, databaseId: cfg.databaseId });
+        return send(res, 200, { configured: true, ...out });
+      } catch (e) { return send(res, 200, { configured: true, ok: false, reason: e.message }); }
+    }
+
+    if (method === 'POST' && path === '/api/autopilot/start') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const mode = ['plan', 'exec', 'loop'].includes(body?.mode) ? body.mode : 'plan';
+      const issue = body?.issue == null ? null : Number(body.issue);
+      if (issue != null && (!Number.isInteger(issue) || issue <= 0)) return sendErr(res, 422, 'invalid issue');
+      const ap = getAutopilot();
+      ap.dryRun = !settings.get().allowExec || mode === 'plan';
+      const result = await ap.start({ mode, issue });
+      return send(res, result.ok ? 200 : 409, result);
+    }
+    if (method === 'POST' && path === '/api/autopilot/stop') {
+      const ap = getAutopilot();
+      const result = ap.stop();
+      return send(res, 200, result);
+    }
+    if (method === 'POST' && path === '/api/autopilot/resume') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const ap = getAutopilot();
+      const result = ap.resume({ answeredQid: body?.answeredQid ?? null });
+      return send(res, result.ok ? 200 : 409, result);
+    }
+    if (method === 'GET' && path === '/api/autopilot/status') {
+      const ap = getAutopilot();
+      return send(res, 200, { autopilot: ap.current() });
     }
 
     if (method === 'POST' && path === '/api/v5/prepare-run') {

--- a/tools/local-control/tests/autopilot-ui.test.mjs
+++ b/tools/local-control/tests/autopilot-ui.test.mjs
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// minimal DOM stub so renderAutopilotState runs in a node environment
+function makeCard() {
+  const map = new Map();
+  function el(id, opts = {}) {
+    const node = {
+      id,
+      textContent: '',
+      classList: { _set: new Set(), add(c) { this._set.add(c); }, remove(...cs) { for (const c of cs) this._set.delete(c); }, contains(c) { return this._set.has(c); }, toggle(c, v) { v ? this.add(c) : this.remove(c); } },
+      dataset: opts.dataset ?? {},
+      _children: [],
+      querySelector(sel) { return findInTree(this, sel); },
+      querySelectorAll(sel) { const out = []; collectInTree(this, sel, out); return out; },
+      appendChild(c) { this._children.push(c); return c; },
+    };
+    map.set(id, node);
+    return node;
+  }
+  function findInTree(root, sel) {
+    if (matches(root, sel)) return root;
+    for (const c of root._children) { const r = findInTree(c, sel); if (r) return r; }
+    return null;
+  }
+  function collectInTree(root, sel, out) {
+    if (matches(root, sel)) out.push(root);
+    for (const c of root._children) collectInTree(c, sel, out);
+  }
+  function matches(node, sel) {
+    if (sel.startsWith('#')) return node.id === sel.slice(1);
+    if (sel.startsWith('[data-key="')) {
+      const v = sel.slice(11, -2);
+      return node.dataset?.key === v;
+    }
+    return false;
+  }
+  const card = el('autopilot-card');
+  card.appendChild(el('autopilot-status-badge'));
+  const stats = el('autopilot-stats');
+  for (const k of ['mode', 'issue', 'prs', 'errors', 'next', 'automerge']) {
+    stats.appendChild(el(`stat-${k}`, { dataset: { key: k } }));
+  }
+  card.appendChild(stats);
+  card.appendChild(el('autopilot-prompt'));
+  return card;
+}
+
+test('renderAutopilotState handles null state without crashing', async () => {
+  const { renderAutopilotState } = await import('../public/lib/autopilot.js');
+  const card = makeCard();
+  renderAutopilotState(card, null, null);
+  const badge = card.querySelector('#autopilot-status-badge');
+  assert.equal(badge.textContent, 'idle');
+});
+
+test('renderAutopilotState reflects running state and v5 automerge', async () => {
+  const { renderAutopilotState } = await import('../public/lib/autopilot.js');
+  const card = makeCard();
+  renderAutopilotState(card, { status: 'running', mode: 'plan', issue: 42, prsCreated: 1, errors: 0, nextAction: 'continue', lastPrompt: 'do X' }, { autoMergeMode: 'OFF' });
+  assert.equal(card.querySelector('#autopilot-status-badge').textContent, 'running');
+  assert.equal(card.querySelector('[data-key="issue"]').textContent, '42');
+  assert.equal(card.querySelector('[data-key="prs"]').textContent, '1');
+  assert.equal(card.querySelector('[data-key="automerge"]').textContent, 'OFF');
+  assert.equal(card.querySelector('#autopilot-prompt').textContent, 'do X');
+});
+
+test('renderAutopilotState waiting status flagged warn', async () => {
+  const { renderAutopilotState } = await import('../public/lib/autopilot.js');
+  const card = makeCard();
+  renderAutopilotState(card, { status: 'waiting', mode: 'exec', issue: 10, prsCreated: 0, errors: 0, nextAction: 'answer q-1' }, null);
+  const badge = card.querySelector('#autopilot-status-badge');
+  assert.ok(badge.classList.contains('warn'));
+});

--- a/tools/local-control/v5-server.test.mjs
+++ b/tools/local-control/v5-server.test.mjs
@@ -120,3 +120,50 @@ test('POST /api/resume returns canResume=false when no state', async () => {
     assert.equal(r.data.canResume, false);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+test('GET /api/autopilot/status without auth returns 401', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const r = await call(app, 'GET', '/api/autopilot/status');
+    assert.equal(r.status, 401);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/autopilot/status returns idle autopilot=null initially', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/autopilot/status', { token: tok });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.autopilot, null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('POST /api/autopilot/stop returns ok=false when no run', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'POST', '/api/autopilot/stop', { token: tok, body: JSON.stringify({}) });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.ok, false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/v5/status surfaces autoMergeMode and notion/n8n flags', async () => {
+  const root = tmpRepo();
+  writeFileSync(join(root, '.local-control', 'v5.env'),
+    'CLAUDE_CODE_COMMAND=yu\nNOTION_TOKEN=x\nNOTION_QUESTIONS_DATABASE_ID=db\nN8N_BASE_URL=https://n8n\nN8N_WEBHOOK_SECRET=s\n');
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/v5/status', { token: tok });
+    assert.equal(r.status, 200);
+    assert.equal(r.data.notionConfigured, true);
+    assert.equal(r.data.n8nConfigured, true);
+    assert.equal(r.data.autoMergeMode, 'OFF');
+    assert.deepEqual(r.data.n8nMissingWebhooks.sort(), ['N8N_NOTION_ANSWER_WEBHOOK', 'N8N_QUESTION_NOTIFY_WEBHOOK'].sort());
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary

- New **Autopilot engine** (`tools/local-control/autopilot.mjs`) with safe-task selection, preflight, stop conditions (time / errors / PR budget / question / dirty repo / guard BLOCK), and a dry-run-by-default lifecycle.
- New endpoints: `POST /api/autopilot/start|stop|resume` + `GET /api/autopilot/status`. `/api/v5/status` enriched with `autoMergeMode`, `n8nMissingWebhooks`, and live autopilot summary.
- Real `yu`-via-zsh launch path in `claude-adapter.mjs`, gated behind `allowExec=true`. Falls back to prompt-only otherwise.
- Pure config modules for Notion / n8n / WhatsApp + Notion DB schema validator. No live calls when env is empty.
- Simpler UI: a single Autopilot card on the Dashboard (Start / Stop / Resume + stats + prompt view). Old buttons moved to a collapsed **Advanced controls** panel.

## Safety guarantees

- Auto-merge stays **OFF** by default. Even when ON, every merge is gated by CI green + linked issue + `ai:autonomous` + `risk:safe` + branch protection + `task:guard ALLOW` + small diff + no sensitive paths.
- Autopilot refuses to start on a dirty repo or a non-main branch.
- `.claude/` left untouched. `.local-control/` stays gitignored.
- No secret values printed to logs (`redactSecrets` covers GH/OpenAI/AWS/Slack/Twilio + custom token).

## Tests

- 112 backend unit/integration tests (was 78).
- 68 UI tests.
- 76 task-tooling tests.
- `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm build` all green.

## Test plan

- [ ] `pnpm local:control` and visit `http://127.0.0.1:8787`.
- [ ] Paste auth token → Dashboard renders Autopilot card with stats.
- [ ] Click **Start Autopilot** on a dirty branch → autopilot refuses with "repo dirty" reason (verified in smoke).
- [ ] Toggle `allowExec=true` → prompt is generated and `yu` is launched in a subshell when on a clean main.
- [ ] Toggle `allowAutoMerge=true` → `/api/automerge/check` reports eligibility for a real PR; `apply` only runs after the eligible report.

## Follow-ups (require Yume secrets)

- Fill `NOTION_TOKEN` + `NOTION_QUESTIONS_DATABASE_ID` in `.local-control/v5.env` so `/api/v5/notion/validate` can run.
- Fill `N8N_BASE_URL` + `N8N_WEBHOOK_SECRET` and import the workflow JSONs in `scripts/n8n/` to populate `N8N_QUESTION_NOTIFY_WEBHOOK` and `N8N_NOTION_ANSWER_WEBHOOK`.
- Optional: configure WhatsApp/Twilio variables to enable mobile notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)