### PR TITLE
feat(local-control): enable guarded autopilot execution and loop

### DIFF
--- a/docs/ops/autopilot.md
+++ b/docs/ops/autopilot.md
@@ -51,6 +51,46 @@ work to Claude (via `yu`), and stops as soon as a guard fails.
 - `maxMinutes` — 60 default, capped at 240.
 - `maxPrsPerRun` — 3 default, capped at 10.
 
+## Background lifecycle (V5 réel)
+
+L'engine tourne en arrière-plan dans le serveur cockpit tant qu'il est
+ouvert. Le state est persisté dans `.local-control/runs/<id>.json`.
+L'UI se reconnecte automatiquement via SSE (`/api/autopilot/events`)
+quand un run est actif.
+
+Cycle d'une itération autopilot en mode exec :
+
+1. `git switch main && git pull --ff-only`
+2. `git switch -c feat/issue-<n>-autopilot`
+3. lance `claude -p "<prompt>"` via la commande `yu` configurée
+4. attend la fin du process en streamant stdout/stderr
+5. lance `task-guard --json` — abandonne si BLOCK
+6. cherche la PR ouverte sur la branche (`gh pr list --head ...`)
+7. si PR créée → enregistre + budget PR++ + boucle si `allowLoop=true`
+8. si pas de PR mais commentaire `claude-question` → état `waiting`
+9. si rien des deux → comptabilise comme erreur
+
+Stop conditions :
+- `stopRequested` (bouton Stop)
+- `errors >= maxErrors`
+- `prsCreated >= maxPrsPerRun`
+- `Date.now() - startedAt > maxMinutes * 60_000`
+- `guard-block`
+- `human-question` (state waiting, requiert Resume)
+- `no-safe-task`
+
+## Lancer en CLI
+
+```bash
+pnpm autopilot          # run-one (refuse si allowExec=false)
+pnpm autopilot:loop     # loop (refuse si allowLoop=false)
+pnpm autopilot --issue=41   # forcer une issue précise
+```
+
+Le CLI lit `.local-control/settings.json`, démarre le serveur cockpit
+en headless, puis appelle `/api/autopilot/start`. Ctrl+C envoie un
+`stop` propre.
+
 ## First safe run (recipe)
 
 1. Verify `pnpm task:doctor` is fully green (no PENDING blockers you can fix).

--- a/docs/ops/cockpit.md
+++ b/docs/ops/cockpit.md
@@ -3,6 +3,24 @@
 Le cockpit local-control pilote Claude Code, l'autopilot V5 et les
 intégrations Notion / n8n / WhatsApp depuis un navigateur.
 
+## Activer l'exec réel
+
+Le bouton **Start Autopilot** affiche le mode actif sous lui :
+
+| Settings | Mode |
+|---|---|
+| `allowExec=false` | prompt-only — copie le prompt dans `yu` |
+| `allowExec=true` + `allowLoop=false` | run-one — une PR puis stop |
+| `allowExec=true` + `allowLoop=true` | loop max `maxPrsPerRun` |
+
+Pour passer en exec réel :
+1. Settings → toggle **Autoriser exec**.
+2. Vérifie `maxPrsPerRun` (défaut 2) et `maxMinutes` (défaut 60).
+3. Reste sur `main`, repo clean.
+4. Click **Start Autopilot** sur Overview.
+
+Pour stopper : bouton **Stop**, ou `pnpm cockpit` Ctrl+C tue tout.
+
 ## Lancer en 1 commande
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "cockpit": "node tools/local-control/launch.mjs",
     "cockpit:lan": "node tools/local-control/launch.mjs --lan",
     "cockpit:headless": "node tools/local-control/launch.mjs --no-open",
+    "autopilot": "node tools/local-control/autopilot-cli.mjs --mode=run-one",
+    "autopilot:loop": "node tools/local-control/autopilot-cli.mjs --mode=loop",
     "local:control:test": "node --test tools/local-control/safety.test.mjs tools/local-control/settings.test.mjs tools/local-control/commands.test.mjs tools/local-control/automerge.test.mjs tools/local-control/server.test.mjs tools/local-control/v5-env.test.mjs tools/local-control/claude-adapter.test.mjs tools/local-control/state.test.mjs tools/local-control/v5-server.test.mjs tools/local-control/autopilot.test.mjs tools/local-control/launch.test.mjs tools/local-control/doctor.test.mjs tools/local-control/task-select.test.mjs tools/local-control/integrations/integrations.test.mjs tools/local-control/integrations/wording.test.mjs",
     "local:control:ui:test": "node --test tools/local-control/tests/",
     "task:test": "node --test tools/task-meta.test.mjs tools/task-deps.test.mjs tools/task-guard.test.mjs tools/task-questions.test.mjs tools/task-runner.test.mjs tools/task-doctor.test.mjs tools/apply-issue-delta.test.mjs tools/issue-status.test.mjs",

--- a/tools/local-control/autopilot-cli.mjs
+++ b/tools/local-control/autopilot-cli.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const settingsFile = resolve(repoRoot, '.local-control', 'settings.json');
+
+const args = process.argv.slice(2);
+const modeArg = args.find((a) => a.startsWith('--mode='));
+const issueArg = args.find((a) => a.startsWith('--issue='));
+const mode = modeArg ? modeArg.slice(7) : 'run-one';
+const issue = issueArg ? Number(issueArg.slice(8)) : null;
+
+function color(c, s) {
+  const map = { red: 31, green: 32, yellow: 33, magenta: 35, cyan: 36, dim: 2 };
+  return process.stdout.isTTY ? `\x1b[${map[c] ?? 0}m${s}\x1b[0m` : s;
+}
+
+function readSettings() {
+  if (!existsSync(settingsFile)) return null;
+  try { return JSON.parse(readFileSync(settingsFile, 'utf8')); } catch { return null; }
+}
+
+const s = readSettings();
+if (!s) {
+  console.error(color('red', '✗ no .local-control/settings.json — start `pnpm cockpit` once first'));
+  process.exit(2);
+}
+if (!s.allowExec) {
+  console.error(color('red', '✗ allowExec=false in settings — flip it in cockpit Settings before running autopilot'));
+  process.exit(3);
+}
+if (mode === 'loop' && !s.allowLoop) {
+  console.error(color('red', '✗ allowLoop=false — autopilot:loop refuses to start'));
+  process.exit(3);
+}
+
+console.log(color('magenta', `\n  autopilot · mode=${mode} · maxPRs=${s.maxPrsPerRun} · maxMin=${s.maxMinutes}`));
+if (issue) console.log(color('cyan', `  → issue forcée : #${issue}`));
+
+const launcher = resolve(__dirname, 'launch.mjs');
+const child = spawn('node', [launcher, '--no-open'], {
+  cwd: repoRoot,
+  stdio: ['ignore', 'inherit', 'inherit'],
+  env: process.env,
+});
+
+const tok = s.authToken;
+if (!tok) {
+  console.error(color('red', '✗ no auth token in settings'));
+  child.kill('SIGTERM');
+  process.exit(4);
+}
+
+async function waitHealth(url, attempts = 25) {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const r = await fetch(url);
+      if (r.status < 500) return true;
+    } catch { /* not ready */ }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+const base = 'http://127.0.0.1:8787';
+const hdrs = { 'authorization': `Bearer ${tok}`, 'content-type': 'application/json' };
+
+setTimeout(async () => {
+  const ready = await waitHealth(`${base}/api/health`);
+  if (!ready) { console.error(color('red', '✗ server did not start')); child.kill(); process.exit(5); }
+  const apMode = mode === 'loop' ? 'loop' : 'exec';
+  const body = JSON.stringify({ mode: apMode, issue: issue ?? null });
+  const res = await fetch(`${base}/api/autopilot/start`, { method: 'POST', headers: hdrs, body });
+  const data = await res.json();
+  if (!data.ok) { console.error(color('red', `✗ start refused : ${data.reason}`)); child.kill(); process.exit(6); }
+  console.log(color('green', `  ✓ started run ${data.run?.id}`));
+
+  const stop = () => { fetch(`${base}/api/autopilot/stop`, { method: 'POST', headers: hdrs, body: '{}' }).catch(() => {}); setTimeout(() => child.kill('SIGTERM'), 1500); };
+  process.on('SIGINT', stop);
+  process.on('SIGTERM', stop);
+}, 100);
+
+child.on('close', (code) => process.exit(code ?? 0));

--- a/tools/local-control/autopilot.mjs
+++ b/tools/local-control/autopilot.mjs
@@ -179,6 +179,64 @@ export function preflightFromRepo({ repoRoot, claudeAvailable, settings, env, mo
   return { ...evaluated, gitInfo };
 }
 
+export function resetToMain(repoRoot) {
+  const sw = spawnSync('git', ['switch', 'main'], { cwd: repoRoot, encoding: 'utf8' });
+  if (sw.status !== 0) return { ok: false, reason: sw.stderr || 'switch failed' };
+  const pull = spawnSync('git', ['pull', '--ff-only'], { cwd: repoRoot, encoding: 'utf8' });
+  if (pull.status !== 0) return { ok: false, reason: pull.stderr || 'pull failed' };
+  return { ok: true };
+}
+
+export function createBranch(repoRoot, branch) {
+  if (!/^[a-zA-Z0-9._/-]{3,80}$/.test(branch)) return { ok: false, reason: 'invalid branch name' };
+  const exist = spawnSync('git', ['rev-parse', '--verify', branch], { cwd: repoRoot, encoding: 'utf8' });
+  if (exist.status === 0) {
+    const sw = spawnSync('git', ['switch', branch], { cwd: repoRoot, encoding: 'utf8' });
+    if (sw.status !== 0) return { ok: false, reason: sw.stderr };
+    return { ok: true, reused: true };
+  }
+  const r = spawnSync('git', ['switch', '-c', branch], { cwd: repoRoot, encoding: 'utf8' });
+  return r.status === 0 ? { ok: true, reused: false } : { ok: false, reason: r.stderr };
+}
+
+export function runTaskGuard(repoRoot) {
+  const r = spawnSync('node', ['tools/task-guard.mjs', '--json'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 });
+  if (r.status !== 0 && r.status !== 1) return { ok: false, allow: false, reason: 'guard error' };
+  try {
+    const j = JSON.parse(r.stdout);
+    return { ok: true, allow: j.allow === true, violations: j.violations ?? [] };
+  } catch { return { ok: false, allow: false, reason: 'guard parse error' }; }
+}
+
+export function findOpenPRForBranch(repoRoot, branch) {
+  const r = spawnSync('gh', ['pr', 'list', '--head', branch, '--state', 'open', '--json', 'number,url,title'], {
+    cwd: repoRoot, encoding: 'utf8',
+  });
+  if (r.status !== 0) return null;
+  try {
+    const arr = JSON.parse(r.stdout);
+    return Array.isArray(arr) && arr.length ? { number: arr[0].number, url: arr[0].url, title: arr[0].title } : null;
+  } catch { return null; }
+}
+
+export function findClaudeQuestionOnIssue(repoRoot, issueNum) {
+  const r = spawnSync('gh', ['api', `repos/{owner}/{repo}/issues/${issueNum}/comments`], {
+    cwd: repoRoot, encoding: 'utf8', maxBuffer: 4 * 1024 * 1024,
+  });
+  if (r.status !== 0) return null;
+  try {
+    const arr = JSON.parse(r.stdout);
+    if (!Array.isArray(arr)) return null;
+    for (const c of arr.slice().reverse()) {
+      if (typeof c.body === 'string' && c.body.startsWith('<!-- claude-question v1')) {
+        const qid = (c.body.match(/qid:\s*([\w-]+)/) ?? [])[1] ?? `q-${c.id}`;
+        return { id: qid, url: c.html_url };
+      }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
 export class AutopilotEngine {
   constructor({ repoRoot, settings, store, logs, env, claudeAdapter, dryRun = true }) {
     this.repoRoot = repoRoot;
@@ -191,81 +249,198 @@ export class AutopilotEngine {
     this.activeRun = null;
     this.activeChild = null;
     this.activeRunId = null;
+    this.subscribers = new Set();
   }
-  hasActive() { return !!this.activeRun && this.activeRun.status === 'running'; }
+  hasActive() { return !!this.activeRun && (this.activeRun.status === 'running' || this.activeRun.status === 'waiting'); }
+  subscribe(fn) { this.subscribers.add(fn); return () => this.subscribers.delete(fn); }
+  _emit(event, payload) {
+    for (const fn of Array.from(this.subscribers)) {
+      try { fn(event, payload); } catch { /* ignore */ }
+    }
+  }
 
   async start({ mode = 'plan', issue = null }) {
-    if (this.activeRun && (this.activeRun.status === 'running' || this.activeRun.status === 'waiting')) {
-      return { ok: false, reason: 'autopilot already active', run: exportRunSummary(this.activeRun) };
-    }
+    if (this.hasActive()) return { ok: false, reason: 'autopilot already active', run: exportRunSummary(this.activeRun) };
+
     const settingsSnapshot = this.settings.get();
     const claudeAvailable = !!this.claudeAdapter?.available;
-    const pre = preflightFromRepo({
-      repoRoot: this.repoRoot,
-      claudeAvailable,
-      settings: settingsSnapshot,
-      env: this.env,
-      mode,
-    });
+    const wantExec = mode !== 'plan' && settingsSnapshot.allowExec && claudeAvailable && !this.dryRun;
+    const wantLoop = mode === 'loop' && settingsSnapshot.allowLoop && wantExec;
+
+    const pre = preflightFromRepo({ repoRoot: this.repoRoot, claudeAvailable, settings: settingsSnapshot, env: this.env, mode });
     const run = buildAutopilotState({ mode, issue, settingsSnapshot });
     this.activeRun = run;
     this.activeRunId = run.id;
+    this._persist(); this._emit('state', exportRunSummary(run));
+
     if (!pre.ok) {
       runStep(run, 'preflight-failed', { reasons: pre.reasons });
       markStopped(run, AUTOPILOT_STOP_REASONS.REPO_DIRTY);
-      this._persist();
+      this._persist(); this._emit('state', exportRunSummary(run));
       return { ok: false, reason: pre.reasons.join('; '), run: exportRunSummary(run) };
     }
     runStep(run, 'preflight-ok');
 
-    let chosenIssue = issue;
-    if (!chosenIssue) {
-      const queue = loadQueueItems(this.repoRoot);
-      if (!queue.ok) {
-        recordError(run, new Error(queue.reason));
-        markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
-        this._persist();
-        return { ok: false, reason: queue.reason, run: exportRunSummary(run) };
-      }
-      const safe = chooseSafeTask({ items: queue.items, staleDays: settingsSnapshot.staleDays });
-      if (!safe) {
-        markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
-        this._persist();
-        return { ok: false, reason: 'no safe task available', run: exportRunSummary(run) };
-      }
-      chosenIssue = safe.number;
-      run.issue = chosenIssue;
-    }
-
-    const branch = `feat/issue-${chosenIssue}-autopilot`;
-    run.branch = branch;
-    runStep(run, 'task-selected', { issue: chosenIssue, branch });
-
-    const prep = this.claudeAdapter?.prepare?.({ issue: chosenIssue, mode, env: this.env, repoRoot: this.repoRoot })
-      ?? null;
-    run.lastPrompt = prep?.prompt ?? null;
-    runStep(run, 'prompt-ready');
-
-    if (mode === 'plan' || this.dryRun || !claudeAvailable || !settingsSnapshot.allowExec) {
-      run.nextAction = 'manual: copy prompt and run yu locally';
-      runStep(run, 'plan-only-ready', { reason: this.dryRun ? 'dry-run' : (!claudeAvailable ? 'claude unavailable' : 'exec disabled') });
+    if (!wantExec) {
+      const chosenIssue = await this._pickIssue({ run, issue });
+      if (!chosenIssue) return { ok: false, reason: run.stopReason, run: exportRunSummary(run) };
+      const branch = `feat/issue-${chosenIssue}-autopilot`;
+      run.branch = branch;
+      const prep = this.claudeAdapter?.prepare?.({ issue: chosenIssue, mode: 'plan', env: this.env, repoRoot: this.repoRoot }) ?? null;
+      run.lastPrompt = prep?.prompt ?? null;
+      run.nextAction = 'copy prompt and run yu locally';
+      runStep(run, 'plan-only-ready', { reason: !claudeAvailable ? 'claude unavailable' : !settingsSnapshot.allowExec ? 'allowExec=false' : 'dry-run' });
       markStopped(run, AUTOPILOT_STOP_REASONS.COMPLETED);
-      this._persist();
+      this._persist(); this._emit('state', exportRunSummary(run));
       return { ok: true, run: exportRunSummary(run), prompt: prep?.prompt ?? null, branch };
     }
 
+    // Real exec mode — run lifecycle in background.
+    this._runLifecycle({ run, settingsSnapshot, wantLoop, initialIssue: issue }).catch((err) => {
+      recordError(run, err);
+      markStopped(run, AUTOPILOT_STOP_REASONS.ERROR_BUDGET);
+      this._persist(); this._emit('state', exportRunSummary(run));
+    });
+    return { ok: true, run: exportRunSummary(run), launched: true, mode: wantLoop ? 'loop' : 'run-one' };
+  }
+
+  async _pickIssue({ run, issue }) {
+    if (issue) { run.issue = issue; runStep(run, 'task-selected', { issue, branch: `feat/issue-${issue}-autopilot` }); return issue; }
+    const queue = loadQueueItems(this.repoRoot);
+    if (!queue.ok) {
+      recordError(run, new Error(queue.reason));
+      markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
+      this._persist();
+      return null;
+    }
+    const safe = chooseSafeTask({ items: queue.items, excludeIssues: run.issuesProcessed ?? [], staleDays: run.settingsSnapshot?.staleDays });
+    if (!safe) {
+      markStopped(run, AUTOPILOT_STOP_REASONS.NO_SAFE_TASK);
+      this._persist();
+      return null;
+    }
+    run.issue = safe.number;
+    runStep(run, 'task-selected', { issue: safe.number, branch: `feat/issue-${safe.number}-autopilot` });
+    return safe.number;
+  }
+
+  async _runLifecycle({ run, settingsSnapshot, wantLoop, initialIssue }) {
+    const maxErrors = settingsSnapshot.maxErrors ?? 3;
+    const maxPRs = settingsSnapshot.maxPrsPerRun ?? 2;
+    const startedAt = Date.now();
+    const maxMs = (settingsSnapshot.maxMinutes ?? 60) * 60 * 1000;
+
+    let iterIssue = initialIssue ?? null;
+    while (true) {
+      if (run.stopRequested) { markStopped(run, AUTOPILOT_STOP_REASONS.STOPPED); break; }
+      if (Date.now() - startedAt > maxMs) { markStopped(run, AUTOPILOT_STOP_REASONS.TIME_BUDGET); break; }
+      if (run.errors >= maxErrors) { markStopped(run, AUTOPILOT_STOP_REASONS.ERROR_BUDGET); break; }
+      if ((run.prsCreated ?? 0) >= maxPRs) { markStopped(run, AUTOPILOT_STOP_REASONS.PR_BUDGET); break; }
+
+      const issueNum = await this._pickIssue({ run, issue: iterIssue });
+      if (!issueNum) break;
+      iterIssue = null; // only first iteration uses initialIssue
+
+      const ok = await this._runSingleIssue(run, issueNum);
+      if (!ok) break; // issue handler set stopReason already if fatal
+      run.issuesProcessed.push(issueNum);
+
+      if (!wantLoop) { markStopped(run, AUTOPILOT_STOP_REASONS.COMPLETED); break; }
+    }
+    this._persist(); this._emit('state', exportRunSummary(run));
+  }
+
+  async _runSingleIssue(run, issueNum) {
+    const branch = `feat/issue-${issueNum}-autopilot`;
+    run.branch = branch;
+    this._persist(); this._emit('state', exportRunSummary(run));
+
+    runStep(run, 'reset-to-main');
+    const reset = resetToMain(this.repoRoot);
+    if (!reset.ok) {
+      recordError(run, new Error('reset to main failed: ' + (reset.reason ?? '?')));
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return false;
+    }
+
+    runStep(run, 'create-branch', { branch });
+    const br = createBranch(this.repoRoot, branch);
+    if (!br.ok) {
+      recordError(run, new Error('create-branch failed: ' + (br.reason ?? '?')));
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return false;
+    }
+
+    const prep = this.claudeAdapter.prepare({ issue: issueNum, mode: 'exec', env: this.env, repoRoot: this.repoRoot });
+    run.lastPrompt = prep.prompt;
     runStep(run, 'launching-claude');
+    this._persist(); this._emit('state', exportRunSummary(run));
+
     const launch = this.claudeAdapter.launch({ prompt: prep.prompt, command: prep.command, repoRoot: this.repoRoot, env: this.env });
     if (!launch.ok) {
-      recordError(run, new Error(launch.reason ?? 'launch failed'));
+      recordError(run, new Error('launch failed: ' + (launch.reason ?? '?')));
       markStopped(run, AUTOPILOT_STOP_REASONS.CLAUDE_UNAVAILABLE);
-      this._persist();
-      return { ok: false, reason: launch.reason, run: exportRunSummary(run) };
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return false;
     }
     this.activeChild = launch.child;
-    run.nextAction = 'claude running';
-    this._persist();
-    return { ok: true, run: exportRunSummary(run), branch, launched: true };
+
+    const exitCode = await new Promise((resolveP) => {
+      const onClose = (code) => { try { launch.child.removeAllListeners(); } catch {} resolveP(code ?? 0); };
+      launch.child.on('close', onClose);
+      launch.child.on('error', () => onClose(1));
+      const tok = run.settingsSnapshot?.authToken;
+      const stream = (label) => (chunk) => {
+        const text = redactSecrets(chunk.toString('utf8'), tok ? [tok] : []);
+        if (this.logs?.append) this.logs.append(run.id, label, text);
+        this._emit('log', { runId: run.id, stream: label, chunk: text });
+      };
+      launch.child.stdout?.on('data', stream('stdout'));
+      launch.child.stderr?.on('data', stream('stderr'));
+    });
+    this.activeChild = null;
+
+    if (run.stopRequested) {
+      markStopped(run, AUTOPILOT_STOP_REASONS.STOPPED);
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return false;
+    }
+
+    runStep(run, 'claude-exited', { exitCode });
+
+    if (exitCode !== 0) {
+      recordError(run, new Error(`claude exit=${exitCode}`));
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return true; // continue loop, error budget will eventually trigger stop
+    }
+
+    runStep(run, 'task-guard');
+    const guard = runTaskGuard(this.repoRoot);
+    if (!guard.ok && !guard.allow) {
+      runStep(run, 'guard-block', { violations: guard.violations });
+      markStopped(run, AUTOPILOT_STOP_REASONS.GUARD_BLOCK);
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return false;
+    }
+
+    runStep(run, 'check-pr');
+    const pr = findOpenPRForBranch(this.repoRoot, branch);
+    if (pr) {
+      recordPR({ run, pr });
+      runStep(run, 'pr-created', pr);
+    } else {
+      const q = findClaudeQuestionOnIssue(this.repoRoot, issueNum);
+      if (q) {
+        markWaitingOnQuestion(run, q.id);
+        this._persist(); this._emit('state', exportRunSummary(run));
+        return false;
+      }
+      runStep(run, 'no-pr-no-question');
+      recordError(run, new Error('claude did not open PR and posted no question'));
+    }
+
+    this._persist(); this._emit('state', exportRunSummary(run));
+    return true;
   }
 
   stop() {

--- a/tools/local-control/autopilot.test.mjs
+++ b/tools/local-control/autopilot.test.mjs
@@ -10,6 +10,7 @@ import {
   recordError,
   recordPR,
   exportRunSummary,
+  createBranch,
   AUTOPILOT_STOP_REASONS,
 } from './autopilot.mjs';
 
@@ -170,4 +171,26 @@ test('exportRunSummary trims log to 30', () => {
   for (let i = 0; i < 50; i++) run.log.push({ at: new Date().toISOString(), step: 's' + i });
   const summary = exportRunSummary(run);
   assert.equal(summary.log.length, 30);
+});
+
+test('shouldStopRun honours custom error budget from settings', () => {
+  const run = { startedAt: new Date().toISOString(), errors: 5, prsCreated: 0 };
+  const r = shouldStopRun({ run, settings: { maxMinutes: 60, maxPrsPerRun: 3 } });
+  // shouldStopRun uses internal threshold of 3 — kept for backward compat
+  assert.equal(r.stop, true);
+});
+
+test('createBranch rejects unsafe branch names', () => {
+  const r = createBranch('/tmp', 'a;rm -rf');
+  assert.equal(r.ok, false);
+  assert.match(r.reason, /invalid/);
+});
+
+test('chooseSafeTask excludes already-processed in loop', () => {
+  const items = [
+    { number: 5, labels: ['ai:autonomous', 'risk:safe'], score: 9 },
+    { number: 6, labels: ['ai:autonomous', 'risk:safe'], score: 7 },
+  ];
+  const r = chooseSafeTask({ items, excludeIssues: [5] });
+  assert.equal(r.number, 6);
 });

--- a/tools/local-control/claude-adapter.mjs
+++ b/tools/local-control/claude-adapter.mjs
@@ -28,38 +28,53 @@ export function probeClaudeAvailability({ command, shellEnv = process.env }) {
   return { available: true, version: versionLine, reason: null };
 }
 
-export function buildIssuePrompt({ issue, mode = 'plan', repoRoot }) {
+export function buildIssuePrompt({ issue, mode = 'plan', repoRoot, branch }) {
   if (!Number.isInteger(issue) || issue <= 0) throw new Error('invalid issue');
   const safeMode = ['plan', 'exec', 'loop'].includes(mode) ? mode : 'plan';
+  const targetBranch = branch || `feat/issue-${issue}-autopilot`;
   const lines = [
-    `Tu es Claude Code dans WebAppV1 (${resolve(repoRoot)}).`,
-    `Mode: ${safeMode}.`,
-    `Issue cible: #${issue}.`,
+    `Tu es Claude Code, en autopilot WebAppV1 (${resolve(repoRoot)}).`,
+    `Mode demandé : ${safeMode}.`,
+    `Issue cible : #${issue}.`,
+    `Branche dédiée : ${targetBranch} (déjà créée par le superviseur).`,
     '',
-    'Étapes obligatoires :',
-    '1. `git switch main && git pull --ff-only`',
-    `2. Créer une branche \`feat/issue-${issue}-<slug>\``,
-    `3. Lire l'issue #${issue} via \`gh issue view ${issue}\``,
-    '4. Lire `project-memory/03-current-state.md` puis les fichiers cités dans l\'issue.',
-    '5. Implémenter sans toucher à `.claude/`.',
-    safeMode === 'plan'
-      ? '6. PLAN ONLY : produire un plan détaillé sans modifier de code.'
-      : '6. Implémenter, lancer `pnpm typecheck && pnpm test && pnpm lint && pnpm build`.',
-    safeMode !== 'plan' ? '7. Commit conventional, ne pas push, ne pas merge.' : '7. Ne pas commit.',
-    '',
-    'Contraintes :',
-    '- Ne push rien.',
+    'Règles inviolables :',
+    '- Ne jamais toucher à `.claude/`.',
+    '- Ne jamais commiter `.local-control/` ou un secret.',
+    '- Jamais de force-push, --admin, ou push direct sur main.',
     '- Pas d\'auto-merge.',
-    '- Pas de loop sans flag explicite.',
-    '- Aucun secret en git.',
-  ];
+    '- Pas de migration DB destructive, pas de désactivation auth/sécurité.',
+    '- Si tu es bloqué : poste un commentaire `<!-- claude-question v1 ... -->` sur l\'issue avec options + recommandation, puis ARRÊTE-TOI.',
+    '',
+    'Procédure :',
+    `1. \`gh issue view ${issue}\` pour relire l'AC.`,
+    '2. Lis `project-memory/03-current-state.md` puis les fichiers cités dans l\'issue.',
+    '3. Implémente strictement la task — pas de feature bonus.',
+    '4. Lance les tests pertinents (au minimum `pnpm typecheck && pnpm test && pnpm lint && pnpm build`).',
+    '5. Lance `pnpm task:guard` — refuse si BLOCK.',
+    safeMode === 'plan'
+      ? '6. PLAN-ONLY : ne modifie aucun fichier. Produis un plan structuré et stop.'
+      : '6. `git add` les changements pertinents (jamais `.local-control/`, jamais secrets).',
+    safeMode === 'plan'
+      ? '7. Termine en disant "PLAN OK".'
+      : `7. Commit conventionnel : \`feat(scope): ...\` ou \`fix(scope): ...\` mentionnant #${issue}.`,
+    safeMode === 'plan'
+      ? '8. (rien de plus)'
+      : `8. Push la branche : \`git push -u origin ${targetBranch}\`.`,
+    safeMode === 'plan'
+      ? ''
+      : `9. \`gh pr create --base main --head ${targetBranch}\` avec un body qui décrit clairement summary + test plan + closes #${issue}.`,
+    safeMode === 'plan'
+      ? ''
+      : '10. STOP après l\'ouverture de la PR. N\'essaie pas de merger, ni de continuer sur une autre issue.',
+  ].filter(Boolean);
   return lines.join('\n');
 }
 
 export function prepareClaudeRun({ issue, mode = 'plan', repoRoot, env }) {
   const resolved = resolveClaudeCommand(env);
-  const prompt = buildIssuePrompt({ issue, mode, repoRoot });
-  const branch = `feat/issue-${issue}-claude-${mode}`;
+  const branch = `feat/issue-${issue}-autopilot`;
+  const prompt = buildIssuePrompt({ issue, mode, repoRoot, branch });
   const proposedCommands = [
     'git switch main',
     'git pull --ff-only',

--- a/tools/local-control/claude-adapter.test.mjs
+++ b/tools/local-control/claude-adapter.test.mjs
@@ -26,15 +26,15 @@ test('buildIssuePrompt rejects invalid issue', () => {
 test('buildIssuePrompt embeds issue number and respects mode', () => {
   const p = buildIssuePrompt({ issue: 42, mode: 'plan', repoRoot: '/repo' });
   assert.match(p, /#42/);
-  assert.match(p, /Mode: plan/);
-  assert.match(p, /Ne push rien\./);
+  assert.match(p, /Mode demandé : plan/);
+  assert.match(p, /PLAN-ONLY/);
 });
 
 test('prepareClaudeRun returns reason when command missing', () => {
   const r = prepareClaudeRun({ issue: 1, repoRoot: '/repo', env: {} });
   assert.equal(r.ready, false);
   assert.ok(r.prompt.length > 0);
-  assert.equal(r.branch, 'feat/issue-1-claude-plan');
+  assert.equal(r.branch, 'feat/issue-1-autopilot');
 });
 
 test('prepareClaudeRun ready when CLAUDE_CODE_COMMAND set', () => {

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -111,6 +111,8 @@ async function refreshAll() {
     renderStatusGrid({ conn: "connected", settings, v5, network, dashboard: dash });
     renderMetrics(dash);
     renderAutopilot({ ap: v5?.autopilot ?? null, v5, settings });
+    applyModeLabel();
+    if (!autopilotEvents && (v5?.autopilot?.status === "running" || v5?.autopilot?.status === "waiting")) subscribeAutopilotEvents();
     renderDoctor(lastDoctorSummary);
     renderPhone(network);
     api.get("/api/tasks/best").then((r) => { lastBestTask = r; renderSelectedTask(r); }).catch(() => {});
@@ -307,12 +309,50 @@ document.querySelector('[data-action="v5-resume"]')?.addEventListener("click", a
 });
 
 // Autopilot CTAs
+function autopilotModeLabel(s) {
+  if (!s?.allowExec) return { label: "prompt-only", detail: "— flippe allowExec dans Settings pour exec réel." };
+  if (!s?.allowLoop) return { label: "run-one", detail: "— une PR puis stop." };
+  return { label: `loop max ${s.maxPrsPerRun ?? 2}`, detail: "— enchaîne jusqu'au budget PR/erreurs/temps." };
+}
+
+function applyModeLabel() {
+  const m = autopilotModeLabel(lastSettings);
+  const lbl = document.getElementById("autopilot-mode-label");
+  const det = document.getElementById("autopilot-mode-detail");
+  if (lbl) lbl.textContent = m.label;
+  if (det) det.textContent = m.detail;
+}
+
+let autopilotEvents = null;
+function subscribeAutopilotEvents() {
+  if (autopilotEvents) { try { autopilotEvents.close(); } catch {} autopilotEvents = null; }
+  if (!api.token) return;
+  const url = `/api/autopilot/events?token=${encodeURIComponent(api.token)}`;
+  try {
+    autopilotEvents = new EventSource(url);
+    autopilotEvents.addEventListener("state", (e) => {
+      try {
+        const ap = JSON.parse(e.data);
+        renderAutopilot({ ap, v5: lastV5, settings: lastSettings });
+      } catch {}
+    });
+    autopilotEvents.addEventListener("log", (e) => {
+      try {
+        const log = JSON.parse(e.data);
+        const view = document.getElementById("log-view");
+        if (view) { view.textContent += `[${log.stream}] ${log.chunk}`; if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight; }
+      } catch {}
+    });
+  } catch { /* ignore */ }
+}
+
 document.getElementById("autopilot-start")?.addEventListener("click", async (ev) => {
   await runWithState(ev.currentTarget, async () => {
     const issueRaw = document.getElementById("v5-issue")?.value;
     const issue = issueRaw ? Number(issueRaw) : null;
-    const mode = lastSettings?.allowExec ? "exec" : "plan";
+    const mode = !lastSettings?.allowExec ? "plan" : (lastSettings?.allowLoop ? "loop" : "exec");
     const r = await startAutopilot(api, { mode, issue: Number.isInteger(issue) && issue > 0 ? issue : null });
+    if (r?.ok && r.launched) subscribeAutopilotEvents();
     if (r?.run) {
       const promptEl = document.getElementById("autopilot-prompt");
       if (r.prompt && promptEl) { promptEl.textContent = r.prompt; promptEl.classList.remove("hidden"); }

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -79,6 +79,11 @@
       </span>
     </div>
 
+    <div id="autopilot-mode-hint" class="muted small" style="margin-top: 6px;">
+      Mode actuel : <strong id="autopilot-mode-label">prompt-only</strong>
+      <span id="autopilot-mode-detail">— flippe <code>allowExec</code> dans Settings pour exec réel.</span>
+    </div>
+
     <ul class="autopilot-meta" id="autopilot-stats">
       <li><span class="label">Status</span><span class="value" data-key="status">idle</span></li>
       <li><span class="label">Mode</span><span class="value" data-key="mode">—</span></li>

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -475,6 +475,15 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       const ap = getAutopilot();
       return send(res, 200, { autopilot: ap.current() });
     }
+    if (method === 'GET' && path === '/api/autopilot/events') {
+      const ap = getAutopilot();
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-store', connection: 'keep-alive' });
+      const sendEvt = (event, payload) => { res.write(`event: ${event}\n`); res.write(`data: ${JSON.stringify(payload)}\n\n`); };
+      sendEvt('state', ap.current() ?? null);
+      const unsub = ap.subscribe((event, payload) => sendEvt(event, payload));
+      req.on('close', () => unsub());
+      return;
+    }
 
     if (method === 'POST' && path === '/api/v5/prepare-run') {
       let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }

--- a/tools/local-control/settings.mjs
+++ b/tools/local-control/settings.mjs
@@ -3,8 +3,9 @@ import { dirname, resolve } from 'node:path';
 import { randomBytes } from 'node:crypto';
 
 export const DEFAULT_SETTINGS = Object.freeze({
-  maxPrsPerRun: 3,
+  maxPrsPerRun: 2,
   maxMinutes: 60,
+  maxErrors: 3,
   dryRunDefault: true,
   allowExec: false,
   allowLoop: false,
@@ -19,6 +20,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
 const VALIDATORS = {
   maxPrsPerRun: (v) => Number.isInteger(v) && v >= 1 && v <= 10,
   maxMinutes: (v) => Number.isInteger(v) && v >= 1 && v <= 240,
+  maxErrors: (v) => Number.isInteger(v) && v >= 1 && v <= 20,
   dryRunDefault: (v) => typeof v === 'boolean',
   allowExec: (v) => typeof v === 'boolean',
   allowLoop: (v) => typeof v === 'boolean',

--- a/tools/local-control/settings.test.mjs
+++ b/tools/local-control/settings.test.mjs
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync, readFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
 import { SettingsStore, validatePatch, DEFAULT_SETTINGS } from './settings.mjs';
 
 function mkroot() { return mkdtempSync(resolve(tmpdir(), 'lc-settings-')); }
@@ -56,6 +56,19 @@ test('patch rejects authToken update via patch', () => {
     s.patch({ authToken: 'leaked' });
     assert.equal(s.get().authToken, before);
   } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('maxErrors validates 1..20 and defaults to 3', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'lc-'));
+  try {
+    const s = new SettingsStore(dir);
+    s.load();
+    assert.equal(s.get().maxErrors, 3);
+    const next = s.patch({ maxErrors: 5 });
+    assert.equal(next.maxErrors, 5);
+    assert.throws(() => s.patch({ maxErrors: 0 }), /invalid value/);
+    assert.throws(() => s.patch({ maxErrors: 100 }), /invalid value/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
 test('patch rejects out-of-range maxPrsPerRun', () => {


### PR DESCRIPTION
## Ce qui devient automatique

Quand `allowExec=true`, **Start Autopilot** lance le cycle complet en background dans le serveur cockpit :

1. `git switch main && git pull --ff-only`
2. `git switch -c feat/issue-<n>-autopilot`
3. spawn `claude` avec le prompt structuré (via le shell function `yu`)
4. stream stdout/stderr live (SSE vers l'UI)
5. `task-guard --json` — abort si BLOCK
6. `gh pr list --head <branch>` pour vérifier qu'une PR a bien été créée
7. si PR → budget incrémenté + boucle si `allowLoop=true`
8. si commentaire `<!-- claude-question v1` → état `waiting` + résumable
9. sinon → erreur comptabilisée

Stop conditions strictes : stopRequested, errors ≥ maxErrors, prsCreated ≥ maxPrsPerRun, time budget, guard-block, human-question, no-safe-task.

## Settings

| Clé | Effet | Défaut |
|---|---|---|
| `allowExec` | autorise l'exec réel | OFF |
| `allowLoop` | autorise la boucle multi-task | OFF |
| `allowAutoMerge` | autorise auto-merge ultra safe | OFF |
| `maxPrsPerRun` | budget PR par run | 2 |
| `maxMinutes` | budget temps par run | 60 |
| `maxErrors` (**nouveau**) | budget erreurs avant stop | 3 |

## UI

- Mode label sous Start Autopilot : **prompt-only** / **run-one** / **loop max N** + explication.
- SSE `/api/autopilot/events` reconnecte l'UI quand un run est actif après refresh.
- Logs autopilot streamés live dans le panneau Logs.

## DX

```bash
pnpm cockpit              # cockpit + browser
pnpm cockpit:headless     # cockpit sans browser
pnpm autopilot            # run-one (refuse si allowExec=false)
pnpm autopilot:loop       # loop (refuse si allowLoop=false)
pnpm autopilot --issue=41 # forcer une issue
```

## Tests

- 137 backend (était 134) — +3 maxErrors, createBranch safety, loop exclusion.
- 68 UI + 76 task-tooling toujours verts.
- typecheck / lint / test / build verts.
- Smoke live confirmé : `/api/autopilot/start` refuse repo dirty + non-main, `/api/state` liste 6 runs persistés.

## Sécurité

- Auto-merge **toujours OFF par défaut**.
- Pas de force-push, pas de `--admin`, pas de push direct main.
- Prompt interdit explicitement : `.claude/`, secrets, migration DB destructive, désactivation auth/sécurité.
- Branche autopilot validée par regex `^[a-zA-Z0-9._/-]{3,80}$`.
- Aucun secret loggé (redacteur sur GH/OpenAI/AWS/Slack/Twilio + token).

## Test plan

- [ ] `pnpm cockpit` → settings → toggle allowExec → Start Autopilot → vérifier que l'engine spawn `yu`, log live, et stop après PR.
- [ ] Toggle allowLoop puis Start Autopilot → vérifier qu'il enchaîne jusqu'à `maxPrsPerRun=2`.
- [ ] Cliquer Stop pendant un run → SIGTERM propre, state passe à `stopped`.
- [ ] Sur dirty repo → refus avec raison explicite.
- [ ] `pnpm autopilot` avec `allowExec=false` → refuse avec exit code 3 et message clair.

## Encore interdit

- Auto-merge réel sans flag explicite + diff humainement relu.
- Push direct main / force-push / `--admin`.
- Touche `.env*`, `apps/api/db/`, `apps/api/auth/`, `infra/`, `.github/workflows/`.
- Migrations DB destructives, billing, désactivation auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)