### PR TITLE
fix(local-control): ignore local runtime dirs in autopilot dirty check

### DIFF
--- a/tools/local-control/autopilot.mjs
+++ b/tools/local-control/autopilot.mjs
@@ -48,9 +48,32 @@ export function chooseSafeTask({ items = [], excludeIssues = [], staleDays = 7 }
   return filtered[0] ?? null;
 }
 
+const AUTOPILOT_IGNORED_DIRTY_PREFIXES = Object.freeze(['.claude/', '.local-control/']);
+
+export function filterDirtyStatusLines(lines) {
+  const arr = Array.isArray(lines) ? lines : String(lines ?? '').split('\n');
+  const blocking = [];
+  for (const raw of arr) {
+    if (raw == null) continue;
+    const line = String(raw).replace(/\r$/, '');
+    if (line.trim() === '') continue;
+    const path = line.length >= 3 ? line.slice(3) : line;
+    const cleanPath = path.replace(/^"(.*)"$/, '$1');
+    const ignored = AUTOPILOT_IGNORED_DIRTY_PREFIXES.some(
+      (p) => cleanPath === p || cleanPath === p.replace(/\/$/, '') || cleanPath.startsWith(p),
+    );
+    if (ignored) continue;
+    blocking.push(line);
+  }
+  return blocking;
+}
+
 export function evaluatePreflight({ gitInfo, claudeAvailable, settings, env, mode }) {
   const reasons = [];
-  if (gitInfo?.dirty) reasons.push('repo dirty');
+  if (gitInfo?.dirty) {
+    const files = Array.isArray(gitInfo.dirtyFiles) ? gitInfo.dirtyFiles : [];
+    reasons.push(files.length ? `repo dirty: ${files.join(', ')}` : 'repo dirty');
+  }
   if (gitInfo?.branch && gitInfo.branch !== 'main') reasons.push(`not on main (currently ${gitInfo.branch})`);
   if (!claudeAvailable && (mode === 'exec' || mode === 'loop')) reasons.push('Claude CLI not available');
   if (mode !== 'plan' && !settings?.allowExec) reasons.push('allowExec disabled');
@@ -155,9 +178,12 @@ export function exportRunSummary(run) {
   };
 }
 
-function gitClean(repoRoot) {
+function gitDirtyFiles(repoRoot) {
   const r = spawnSync('git', ['status', '--porcelain'], { cwd: repoRoot, encoding: 'utf8' });
-  return r.status === 0 && r.stdout.trim().length === 0;
+  if (r.status !== 0) return { ok: false, files: [] };
+  const lines = r.stdout.split('\n');
+  const blocking = filterDirtyStatusLines(lines);
+  return { ok: true, files: blocking.map((l) => (l.length >= 3 ? l.slice(3) : l).replace(/^"(.*)"$/, '$1')) };
 }
 function gitBranch(repoRoot) {
   const r = spawnSync('git', ['branch', '--show-current'], { cwd: repoRoot, encoding: 'utf8' });
@@ -174,7 +200,8 @@ export function loadQueueItems(repoRoot) {
 }
 
 export function preflightFromRepo({ repoRoot, claudeAvailable, settings, env, mode }) {
-  const gitInfo = { branch: gitBranch(repoRoot), dirty: !gitClean(repoRoot) };
+  const dirtyInfo = gitDirtyFiles(repoRoot);
+  const gitInfo = { branch: gitBranch(repoRoot), dirty: dirtyInfo.files.length > 0, dirtyFiles: dirtyInfo.files };
   const evaluated = evaluatePreflight({ gitInfo, claudeAvailable, settings, env, mode });
   return { ...evaluated, gitInfo };
 }
@@ -274,10 +301,13 @@ export class AutopilotEngine {
     this._persist(); this._emit('state', exportRunSummary(run));
 
     if (!pre.ok) {
-      runStep(run, 'preflight-failed', { reasons: pre.reasons });
-      markStopped(run, AUTOPILOT_STOP_REASONS.REPO_DIRTY);
+      runStep(run, 'preflight-failed', { reasons: pre.reasons, dirtyFiles: pre.gitInfo?.dirtyFiles ?? [] });
+      const stopReason = pre.gitInfo?.dirty
+        ? AUTOPILOT_STOP_REASONS.REPO_DIRTY
+        : AUTOPILOT_STOP_REASONS.GUARD_BLOCK;
+      markStopped(run, stopReason);
       this._persist(); this._emit('state', exportRunSummary(run));
-      return { ok: false, reason: pre.reasons.join('; '), run: exportRunSummary(run) };
+      return { ok: false, reason: pre.reasons.join('; '), run: exportRunSummary(run), dirtyFiles: pre.gitInfo?.dirtyFiles ?? [] };
     }
     runStep(run, 'preflight-ok');
 

--- a/tools/local-control/autopilot.test.mjs
+++ b/tools/local-control/autopilot.test.mjs
@@ -11,6 +11,7 @@ import {
   recordPR,
   exportRunSummary,
   createBranch,
+  filterDirtyStatusLines,
   AUTOPILOT_STOP_REASONS,
 } from './autopilot.mjs';
 
@@ -193,4 +194,46 @@ test('chooseSafeTask excludes already-processed in loop', () => {
   ];
   const r = chooseSafeTask({ items, excludeIssues: [5] });
   assert.equal(r.number, 6);
+});
+
+test('filterDirtyStatusLines: only .claude/ untracked is clean', () => {
+  const out = filterDirtyStatusLines(['?? .claude/']);
+  assert.equal(out.length, 0);
+});
+
+test('filterDirtyStatusLines: only .local-control/ untracked is clean', () => {
+  const out = filterDirtyStatusLines(['?? .local-control/', '?? .local-control/state.json']);
+  assert.equal(out.length, 0);
+});
+
+test('filterDirtyStatusLines: .claude/ plus tracked modified file is dirty', () => {
+  const out = filterDirtyStatusLines(['?? .claude/', ' M apps/api/src/index.ts']);
+  assert.deepEqual(out, [' M apps/api/src/index.ts']);
+});
+
+test('filterDirtyStatusLines: untracked outside ignored dirs is dirty', () => {
+  const out = filterDirtyStatusLines(['?? scratch.txt']);
+  assert.deepEqual(out, ['?? scratch.txt']);
+});
+
+test('filterDirtyStatusLines: tracked modified file is dirty', () => {
+  const out = filterDirtyStatusLines([' M package.json']);
+  assert.deepEqual(out, [' M package.json']);
+});
+
+test('filterDirtyStatusLines: handles raw multiline string', () => {
+  const out = filterDirtyStatusLines('?? .claude/\n M src/foo.ts\n');
+  assert.deepEqual(out, [' M src/foo.ts']);
+});
+
+test('evaluatePreflight reports dirty file list', () => {
+  const r = evaluatePreflight({
+    gitInfo: { dirty: true, dirtyFiles: ['package.json', 'src/foo.ts'], branch: 'main' },
+    claudeAvailable: true,
+    settings: { allowExec: true, allowLoop: true },
+    env: { CLAUDE_CODE_COMMAND: 'yu', GITHUB_OWNER: 'x', GITHUB_REPO: 'y' },
+    mode: 'exec',
+  });
+  assert.equal(r.ok, false);
+  assert.ok(r.reasons.some((x) => x.includes('package.json')));
 });


### PR DESCRIPTION
## Summary
- Add `filterDirtyStatusLines()` helper that ignores `.claude/` and `.local-control/` entries from `git status --porcelain`.
- Autopilot preflight no longer trips `repo-dirty` when only those local-runtime dirs are untracked.
- Tracked modifications and untracked files outside those dirs still block as before.
- Preflight failure now reports the actual blocking file list and uses an accurate `stopReason` (REPO_DIRTY only when something is genuinely dirty).

## Cause
`gitClean()` returned `false` whenever `git status --porcelain` had any non-empty output. `.claude/` is intentionally local and untracked, so it tripped the dirty check and blocked autopilot startup with `stopReason: repo-dirty`.

## Test plan
- [x] `filterDirtyStatusLines` unit tests: only `.claude/` clean, only `.local-control/` clean, `.claude/` + tracked modified = dirty, untracked outside = dirty, tracked modified = dirty, raw multiline string parse.
- [x] `evaluatePreflight` reports dirty file list.
- [x] `pnpm local:control:test` (145/145)
- [x] `pnpm local:control:ui:test` (68/68)
- [x] `pnpm task:test` (76/76)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (516/516 api)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)