### PR TITLE
feat(cockpit): redesign mission control experience

### DIFF
--- a/docs/ops/cockpit.md
+++ b/docs/ops/cockpit.md
@@ -21,6 +21,45 @@ Pour passer en exec réel :
 
 Pour stopper : bouton **Stop**, ou `pnpm cockpit` Ctrl+C tue tout.
 
+## Modes de mission
+
+Le hero **Mission Control** propose un sélecteur de modes :
+
+| Mode | Action | Settings requis |
+|---|---|---|
+| **Manual prompt** | Génère un prompt à coller dans `yu`. Aucun spawn. | aucun |
+| **Auto · 1 task** | Une PR puis stop. | `allowExec` |
+| **Auto · 5 tasks** | Loop jusqu'à 5 PR. **Défaut.** | `allowExec` + `allowLoop` |
+| **Loop · 10 tasks** | Loop intensif. | `allowExec` + `allowLoop` |
+| **Loop · 20 tasks** | Loop max. | `allowExec` + `allowLoop` |
+| **Custom loop** | Tu choisis le budget. | `allowExec` + `allowLoop` |
+| **Full autopilot** | Vérifie checklist complète avant de lancer. | tout dont auto-merge |
+
+Cliquer sur un mode met à jour le hero + le sous-titre + le bouton CTA. Le mode est mémorisé dans `localStorage`.
+
+Pour **Full autopilot**, une checklist apparaît avec chaque item (Claude / branch protection / exec / loop / power / guard / Notion / n8n / WhatsApp) et un statut explicite (ready / missing / optional / blocked). Cliquer **Configure** ouvre directement la bonne section de Settings.
+
+## Lire la timeline
+
+Quand l'autopilot tourne, le hero affiche une **mission progress bar** + une **timeline** 7 étapes :
+
+1. Select · 12%
+2. Branch · 22%
+3. Coding · 50%
+4. Tests · 70%
+5. Guard · 85%
+6. PR · 95%
+7. Done · 100%
+
+Chaque étape passe de `gris → violet (active, glow) → vert (done)` au fur et à mesure. Le panneau sous-titre traduit en humain : "Claude is coding…", "Tests are running…", "PR opened.".
+
+Les logs techniques sont disponibles dans le **drawer collapsé** sous l'activité ; clique pour ouvrir, filtrer, copier ou vider.
+
+## Stopper / Reprendre
+
+- **Stop** dans le hero ou via `pnpm autopilot:loop` Ctrl+C → SIGTERM propre.
+- **Resume** dans le hero quand le state est `waiting` (question humaine répondue sur GitHub).
+
 ## Lancer en 1 commande
 
 ```bash

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -1,24 +1,25 @@
-// WebAppV1 Cockpit V5
-// Talks to backend at same origin. Backend = tools/local-control/server.mjs.
+// WebAppV1 Mission Control · app.js
 
-import { ApiClient, AuthError, NetworkError } from "./lib/api.js";
+import { ApiClient, AuthError } from "./lib/api.js";
 import { redact } from "./lib/redact.js";
 import { mountTabs } from "./lib/tabs.js";
-import { renderTasks } from "./lib/tasks.js";
-import { mountRunner } from "./lib/runner.js";
-import { mountPrompt } from "./lib/prompt.js";
-import { mountLogs } from "./lib/logs.js";
 import { renderQuestions } from "./lib/questions.js";
 import { confirmDanger } from "./lib/confirm.js";
 import { runWithState } from "./lib/buttonState.js";
 import {
   TokenStore, ConnState, readTokenFromUrl,
-  classifyError, badgeLabel, badgeClass, shouldKeepPolling,
+  classifyError, shouldKeepPolling,
 } from "./lib/auth-ui.js";
 import {
-  renderTopbar, renderStatusGrid, renderMetrics, renderAutopilot,
-  renderPhone, showToast, bindToggles, renderDoctor, renderSelectedTask,
+  renderTopbar, renderStatusGrid, renderStatusBranch, renderDoctor, renderPhone,
+  showToast, bindToggles, renderIntegrationSettings, mountSettingsNav, openSettingsSection,
 } from "./lib/cockpit.js";
+import {
+  MISSION_MODES, DEFAULT_MODE_ID, findMode,
+  renderModeRail, buildMissionState, renderMissionHero, renderMissionProgress,
+  renderFullChecklist, renderNextTask, renderTaskBoard,
+  renderLogSummary, appendLogLine, clearLogs,
+} from "./lib/mission.js";
 import { startAutopilot, stopAutopilot, resumeAutopilot } from "./lib/autopilot.js";
 
 const REFRESH_MS = 15000;
@@ -45,89 +46,111 @@ let lastV5 = null;
 let lastBestTask = null;
 let lastBestPrompt = null;
 let lastDoctorSummary = null;
+let lastReadiness = null;
+let activeModeId = (typeof localStorage !== "undefined" && localStorage.getItem("missionMode")) || DEFAULT_MODE_ID;
+let logSummary = { last: null, success: null, error: null };
 
-// Tabs + secondary mounts
 mountTabs();
-mountLogs(api);
-mountRunner(api, { confirmDanger });
-mountPrompt(api);
+mountSettingsNav();
 bindSettingsForm();
+mountModeRail();
+mountLogDrawer();
 
 function setConnState(next, errMsg) {
   connState = next;
-  renderTopbar({ conn: connStateToString(next), settings: lastSettings, lan: lastNetwork?.lan });
+  renderTopbar({ conn: connStateToString(next), settings: lastSettings });
   const authPanel = document.getElementById("auth-panel");
   authPanel.classList.toggle("hidden", next !== ConnState.AUTH_REQUIRED);
-  setActionsDisabled(next !== ConnState.CONNECTED);
-
+  document.querySelectorAll('button[data-needs="auth"]').forEach((b) => {
+    b.disabled = next !== ConnState.CONNECTED;
+  });
   if (next === ConnState.AUTH_REQUIRED) {
-    const title = document.getElementById("auth-title");
-    title.textContent = api.token ? "Token invalide" : "Auth requise";
+    document.getElementById("auth-title").textContent = api.token ? "Token invalide" : "Auth requise";
     const errEl = document.getElementById("auth-error");
     if (errMsg) { errEl.textContent = errMsg; errEl.style.display = "block"; }
     else errEl.style.display = "none";
   }
-
-  if (shouldKeepPolling(next)) startPolling();
-  else stopPolling();
+  if (shouldKeepPolling(next)) startPolling(); else stopPolling();
 }
-
 function connStateToString(s) {
   if (s === ConnState.CONNECTED) return "connected";
   if (s === ConnState.AUTH_REQUIRED) return "auth-required";
   if (s === ConnState.OFFLINE) return "offline";
   return "unknown";
 }
-
-function setActionsDisabled(disabled) {
-  document.querySelectorAll('button[data-needs="auth"]').forEach((b) => {
-    b.disabled = !!disabled;
-    if (disabled) b.setAttribute("data-disabled-reason", "Auth requise.");
-    else b.removeAttribute("data-disabled-reason");
-  });
-}
-
 function startPolling() { if (!pollTimer) pollTimer = setInterval(() => { refreshAll().catch(() => {}); }, REFRESH_MS); }
 function stopPolling() { if (pollTimer) { clearInterval(pollTimer); pollTimer = null; } }
 
 async function refreshAll() {
-  if (!api.token) {
-    setConnState(ConnState.AUTH_REQUIRED);
-    return;
-  }
+  if (!api.token) { setConnState(ConnState.AUTH_REQUIRED); return; }
   try {
-    const [dash, tasks, questions, settings, network, v5] = await Promise.all([
-      api.get("/api/dashboard"),
-      api.get("/api/tasks").catch(() => ({ items: [] })),
+    const [dash, questions, settings, network, v5, readiness] = await Promise.all([
+      api.get("/api/dashboard").catch(() => null),
       api.get("/api/questions").catch(() => ({ items: [] })),
       api.get("/api/settings"),
       api.get("/api/network").catch(() => null),
       api.get("/api/v5/status").catch(() => null),
+      api.get("/api/v5/full-readiness").catch(() => null),
     ]);
     lastSettings = settings;
     lastNetwork = network;
     lastV5 = v5;
+    lastReadiness = readiness;
     setConnState(ConnState.CONNECTED);
-    renderStatusGrid({ conn: "connected", settings, v5, network, dashboard: dash });
-    renderMetrics(dash);
-    renderAutopilot({ ap: v5?.autopilot ?? null, v5, settings });
-    applyModeLabel();
-    if (!autopilotEvents && (v5?.autopilot?.status === "running" || v5?.autopilot?.status === "waiting")) subscribeAutopilotEvents();
+    renderStatusGrid({ conn: "connected", settings, v5, network });
+    if (dash) renderStatusBranch(dash);
     renderDoctor(lastDoctorSummary);
     renderPhone(network);
-    api.get("/api/tasks/best").then((r) => { lastBestTask = r; renderSelectedTask(r); }).catch(() => {});
-    renderTasks(tasks.items || tasks || [], { api, confirmDanger, settings, conn: "connected" });
     renderQuestions(questions.items || questions || [], { api });
+    document.getElementById("questions-empty").style.display = (questions.items ?? questions ?? []).length ? "none" : "block";
     syncSettingsForm(settings);
-    const empty = document.getElementById("questions-empty");
-    if (empty) empty.style.display = (questions.items ?? questions ?? []).length ? "none" : "block";
+    renderIntegrationSettings(v5);
+    rerenderMission();
+    api.get("/api/tasks/best").then((r) => {
+      lastBestTask = r;
+      renderNextTask(r);
+      renderTaskBoard(r);
+    }).catch(() => {});
+    if (!autopilotEvents && (v5?.autopilot?.status === "running" || v5?.autopilot?.status === "waiting")) subscribeAutopilotEvents();
   } catch (e) {
-    const next = classifyError(e);
-    setConnState(next, redact(String(e?.message || e)));
+    setConnState(classifyError(e), redact(String(e?.message || e)));
   }
 }
 
-// Settings form binding
+function rerenderMission() {
+  const m = findMode(activeModeId);
+  const customMax = Number(document.getElementById("mode-custom-value")?.value || 5);
+  const state = buildMissionState({
+    mode: activeModeId,
+    settings: lastSettings,
+    v5: lastV5,
+    ap: lastV5?.autopilot ?? null,
+    fullReadiness: lastReadiness,
+    customMax,
+  });
+  renderMissionHero(state);
+  renderMissionProgress(lastV5?.autopilot ?? null);
+  if (m.full) renderFullChecklist(lastReadiness, openChecklistAction);
+  else document.getElementById("full-checklist-card")?.classList.add("hidden");
+}
+
+function openChecklistAction(action) {
+  if (action === "open-settings-safety") return openSettingsSection("safety");
+  if (action === "open-settings-integrations") return openSettingsSection("integrations");
+  if (action === "run-doctor") return runDoctor();
+  showToast(`Action: ${action}`, "info");
+}
+
+function mountModeRail() {
+  renderModeRail(activeModeId, (id) => {
+    activeModeId = id;
+    try { localStorage.setItem("missionMode", id); } catch {}
+    renderModeRail(activeModeId, (next) => mountModeRail()); // re-render selection
+    rerenderMission();
+  });
+  document.getElementById("mode-custom-value")?.addEventListener("input", () => rerenderMission());
+}
+
 function bindSettingsForm() {
   const form = document.getElementById("settings-form");
   if (!form) return;
@@ -136,7 +159,7 @@ function bindSettingsForm() {
     ev.preventDefault();
     const data = new FormData(form);
     const body = {};
-    for (const k of ["maxPrsPerRun", "maxMinutes", "staleDays"]) {
+    for (const k of ["maxPrsPerRun", "maxMinutes", "maxErrors", "staleDays"]) {
       const v = data.get(k);
       if (v != null && v !== "") body[k] = Number(v);
     }
@@ -173,7 +196,7 @@ function syncSettingsForm(settings) {
   bindToggles(form);
 }
 
-// Auth form
+// Auth
 document.getElementById("auth-form")?.addEventListener("submit", (ev) => {
   ev.preventDefault();
   const input = document.getElementById("auth-token-input");
@@ -184,179 +207,66 @@ document.getElementById("auth-form")?.addEventListener("submit", (ev) => {
   setConnState(ConnState.UNKNOWN);
   refreshAll();
 });
-document.getElementById("auth-retry")?.addEventListener("click", () => {
-  setConnState(ConnState.UNKNOWN);
-  refreshAll();
-});
+document.getElementById("auth-retry")?.addEventListener("click", () => { setConnState(ConnState.UNKNOWN); refreshAll(); });
 
-// Workflow step buttons → existing endpoints
-async function callStep(action, payload = {}) {
-  const map = {
-    "doctor": () => api.post("/api/doctor/run", {}),
-    "score": () => api.post("/api/tasks/score", {}).catch(() => api.get("/api/tasks")),
-    "queue": () => refreshAll(),
-    "plan-next": () => api.post("/api/runner/start", { mode: "plan", dryRun: true }),
-    "reload-tasks": () => refreshAll(),
-  };
-  const fn = map[action];
-  if (!fn) return;
-  return fn();
-}
-
-document.querySelectorAll('[data-action="doctor"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => {
-    const r = await callStep("doctor");
-    if (r?.runId) document.getElementById("log-run-select")?.dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-    showToast("Doctor lancé", "ok");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err")));
-});
-
-document.querySelectorAll('[data-action="score"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => { await callStep("score"); showToast("Tâches rechargées", "ok"); }).catch(() => {}));
-});
-document.querySelectorAll('[data-action="queue"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, refreshAll).catch(() => {}));
-});
-document.querySelectorAll('[data-action="reload-tasks"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, refreshAll).catch(() => {}));
-});
-document.querySelectorAll('[data-action="plan-next"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => {
-    const r = await callStep("plan-next");
-    if (r?.runId) document.getElementById("log-run-select")?.dispatchEvent(new CustomEvent("subscribe", { detail: r.runId }));
-    showToast("Plan next lancé", "ok");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err")));
-});
-
-document.querySelectorAll('[data-action="doctor-summary"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => {
+// Mission CTA
+async function runDoctor() {
+  try {
     const r = await api.get("/api/doctor/summary");
     if (r?.ok && r.summary) {
       lastDoctorSummary = r.summary;
       renderDoctor(r.summary);
-      showToast(r.summary.ok ? "Doctor green" : `Doctor ${r.summary.failed?.length ? "red" : "warn"}`, r.summary.ok ? "ok" : "warn");
+      logSummary.last = "Doctor finished";
+      logSummary.success = r.summary.ok ? "Doctor green" : null;
+      logSummary.error = r.summary.failed?.length ? `Doctor failed: ${r.summary.failed.join(", ")}` : null;
+      renderLogSummary(logSummary);
+      showToast(r.summary.ok ? "Doctor green" : "Doctor warn/red", r.summary.ok ? "ok" : "warn");
     } else {
       showToast(r?.reason ?? "Doctor failed", "err");
     }
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err")));
+  } catch (e) { showToast(redact(String(e?.message || e)), "err"); }
+}
+
+document.querySelectorAll('[data-action="doctor-summary"]').forEach((b) => {
+  b.addEventListener("click", () => runWithState(b, runDoctor).catch(() => {}));
 });
 
-document.querySelectorAll('[data-action="refresh-task"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => {
-    const r = await api.get("/api/tasks/best");
-    lastBestTask = r;
-    renderSelectedTask(r);
-    showToast(r?.ok ? `#${r.best?.number} sélectionnée` : (r?.reason ?? "aucune task"), r?.ok ? "ok" : "warn");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err")));
-});
-
-document.querySelectorAll('[data-action="prepare-best"]').forEach((b) => {
-  b.addEventListener("click", () => runWithState(b, async () => {
-    if (!lastBestTask?.best?.number) { showToast("Aucune task sélectionnée", "warn"); return; }
-    const r = await api.post("/api/v5/prepare-run", { issue: lastBestTask.best.number, mode: "plan" });
-    lastBestPrompt = r?.prompt ?? null;
-    const promptEl = document.getElementById("selected-task-prompt");
-    if (promptEl) {
-      promptEl.textContent = lastBestPrompt ?? "";
-      promptEl.classList.toggle("hidden", !lastBestPrompt);
-    }
-    const copyBtn = document.querySelector('[data-action="copy-best-prompt"]');
-    if (copyBtn) copyBtn.disabled = !lastBestPrompt;
-    showToast(`Prepared #${lastBestTask.best.number}`, "ok");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err")));
-});
-
-document.querySelectorAll('[data-action="copy-best-prompt"]').forEach((b) => {
-  b.addEventListener("click", () => {
-    if (!lastBestPrompt) return showToast("Prepare d'abord", "warn");
-    navigator.clipboard?.writeText(lastBestPrompt).then(() => showToast("Prompt copié — colle dans yu", "ok")).catch(() => {});
-  });
-});
-
-document.querySelectorAll('[data-action="scroll-logs"]').forEach((b) => {
-  b.addEventListener("click", () => {
-    document.querySelector('[data-tab="workspace"]')?.click();
-    document.getElementById("logs-section")?.scrollIntoView({ behavior: "smooth", block: "start" });
-  });
-});
-
-// V5 prompt block
-let lastV5Prompt = null;
-document.querySelector('[data-action="v5-prepare"]')?.addEventListener("click", async (ev) => {
+document.getElementById("mission-cta")?.addEventListener("click", async (ev) => {
   const btn = ev.currentTarget;
   await runWithState(btn, async () => {
-    const issue = Number(document.getElementById("v5-issue-prepare")?.value);
-    if (!Number.isInteger(issue) || issue <= 0) { showToast("Numéro d'issue invalide", "warn"); return; }
-    const r = await api.post("/api/v5/prepare-run", { issue, mode: "plan" });
-    lastV5Prompt = r?.prompt ?? null;
-    const view = document.getElementById("v5-prompt-view");
-    if (view) {
-      view.textContent = lastV5Prompt ?? "";
-      view.classList.toggle("hidden", !lastV5Prompt);
+    const m = findMode(activeModeId);
+    const ap = lastV5?.autopilot;
+    if (ap?.status === "waiting") {
+      const r = await resumeAutopilot(api);
+      showToast(r?.ok ? "Autopilot relancé" : (r?.reason ?? "—"), r?.ok ? "ok" : "warn");
+      refreshAll().catch(() => {});
+      return;
     }
-    showToast(`Prepared #${issue}`, "ok");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
-});
-document.querySelector('[data-action="v5-copy-prompt"]')?.addEventListener("click", () => {
-  if (!lastV5Prompt) return showToast("Prepare d'abord", "warn");
-  navigator.clipboard?.writeText(lastV5Prompt).then(() => showToast("Prompt copié", "ok")).catch(() => {});
-});
-document.querySelector('[data-action="v5-resume"]')?.addEventListener("click", async (ev) => {
-  await runWithState(ev.currentTarget, async () => {
-    const r = await api.post("/api/resume", {});
-    showToast(r?.canResume ? `Resume OK pour #${r.issue}` : `Bloqué : ${r?.reason ?? "?"}`, r?.canResume ? "ok" : "warn");
-  }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
-});
-
-// Autopilot CTAs
-function autopilotModeLabel(s) {
-  if (!s?.allowExec) return { label: "prompt-only", detail: "— flippe allowExec dans Settings pour exec réel." };
-  if (!s?.allowLoop) return { label: "run-one", detail: "— une PR puis stop." };
-  return { label: `loop max ${s.maxPrsPerRun ?? 2}`, detail: "— enchaîne jusqu'au budget PR/erreurs/temps." };
-}
-
-function applyModeLabel() {
-  const m = autopilotModeLabel(lastSettings);
-  const lbl = document.getElementById("autopilot-mode-label");
-  const det = document.getElementById("autopilot-mode-detail");
-  if (lbl) lbl.textContent = m.label;
-  if (det) det.textContent = m.detail;
-}
-
-let autopilotEvents = null;
-function subscribeAutopilotEvents() {
-  if (autopilotEvents) { try { autopilotEvents.close(); } catch {} autopilotEvents = null; }
-  if (!api.token) return;
-  const url = `/api/autopilot/events?token=${encodeURIComponent(api.token)}`;
-  try {
-    autopilotEvents = new EventSource(url);
-    autopilotEvents.addEventListener("state", (e) => {
-      try {
-        const ap = JSON.parse(e.data);
-        renderAutopilot({ ap, v5: lastV5, settings: lastSettings });
-      } catch {}
-    });
-    autopilotEvents.addEventListener("log", (e) => {
-      try {
-        const log = JSON.parse(e.data);
-        const view = document.getElementById("log-view");
-        if (view) { view.textContent += `[${log.stream}] ${log.chunk}`; if (document.getElementById("log-autoscroll")?.checked) view.scrollTop = view.scrollHeight; }
-      } catch {}
-    });
-  } catch { /* ignore */ }
-}
-
-document.getElementById("autopilot-start")?.addEventListener("click", async (ev) => {
-  await runWithState(ev.currentTarget, async () => {
-    const issueRaw = document.getElementById("v5-issue")?.value;
-    const issue = issueRaw ? Number(issueRaw) : null;
-    const mode = !lastSettings?.allowExec ? "plan" : (lastSettings?.allowLoop ? "loop" : "exec");
-    const r = await startAutopilot(api, { mode, issue: Number.isInteger(issue) && issue > 0 ? issue : null });
-    if (r?.ok && r.launched) subscribeAutopilotEvents();
-    if (r?.run) {
-      const promptEl = document.getElementById("autopilot-prompt");
-      if (r.prompt && promptEl) { promptEl.textContent = r.prompt; promptEl.classList.remove("hidden"); }
-      showToast(r.ok ? `Autopilot · #${r.run.issue ?? "?"}` : `${r.reason}`, r.ok ? "ok" : "warn");
+    if (ap?.status === "completed" && ap.lastPR?.url) {
+      window.open(ap.lastPR.url, "_blank", "noopener");
+      return;
+    }
+    if (m.full && lastReadiness && !lastReadiness.ready) {
+      openSettingsSection("safety");
+      showToast("Configure les items requis avant Full autopilot", "warn");
+      return;
+    }
+    if (m.requiresExec && !lastSettings?.allowExec) { openSettingsSection("safety"); showToast("Active allowExec", "warn"); return; }
+    if (m.requiresLoop && !lastSettings?.allowLoop) { openSettingsSection("safety"); showToast("Active allowLoop", "warn"); return; }
+    const customMax = Number(document.getElementById("mode-custom-value")?.value || 5);
+    const targetMax = m.custom ? customMax : m.maxPrs;
+    if (lastSettings && lastSettings.maxPrsPerRun !== targetMax) {
+      try { await api.put("/api/settings", { maxPrsPerRun: targetMax }); } catch {}
+    }
+    const apMode = m.mode;
+    const r = await startAutopilot(api, { mode: apMode, issue: null });
+    if (r?.run && r.prompt) {
+      lastBestPrompt = r.prompt;
+      navigator.clipboard?.writeText(r.prompt).catch(() => {});
+      showToast(`Prompt copié pour #${r.run.issue ?? "?"}`, "ok");
+    } else if (r?.ok) {
+      showToast(r.launched ? "Mission lancée" : "Mission préparée", "ok");
+      subscribeAutopilotEvents();
     } else {
       showToast(r?.reason ?? "Échec", "err");
     }
@@ -367,11 +277,10 @@ document.getElementById("autopilot-start")?.addEventListener("click", async (ev)
 document.getElementById("autopilot-stop")?.addEventListener("click", async (ev) => {
   await runWithState(ev.currentTarget, async () => {
     const r = await stopAutopilot(api);
-    showToast(r?.ok ? "Autopilot arrêté" : (r?.reason ?? "—"), r?.ok ? "ok" : "warn");
+    showToast(r?.ok ? "Autopilot stoppé" : (r?.reason ?? "—"), r?.ok ? "ok" : "warn");
     refreshAll().catch(() => {});
   }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
 });
-
 document.getElementById("autopilot-resume")?.addEventListener("click", async (ev) => {
   await runWithState(ev.currentTarget, async () => {
     const r = await resumeAutopilot(api);
@@ -379,6 +288,75 @@ document.getElementById("autopilot-resume")?.addEventListener("click", async (ev
     refreshAll().catch(() => {});
   }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
 });
+
+// Best task actions
+document.body.addEventListener("click", async (ev) => {
+  const btn = ev.target.closest("[data-best-action]");
+  if (!btn) return;
+  if (!lastBestTask?.best?.number) return;
+  const action = btn.dataset.bestAction;
+  if (action === "prepare") {
+    await runWithState(btn, async () => {
+      const r = await api.post("/api/v5/prepare-run", { issue: lastBestTask.best.number, mode: "plan" });
+      lastBestPrompt = r?.prompt ?? null;
+      const copyBtn = document.querySelector('[data-best-action="copy"]');
+      if (copyBtn) copyBtn.disabled = !lastBestPrompt;
+      showToast(`Prepared #${lastBestTask.best.number}`, "ok");
+    }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
+  } else if (action === "copy") {
+    if (!lastBestPrompt) return showToast("Prepare d'abord", "warn");
+    navigator.clipboard?.writeText(lastBestPrompt).then(() => showToast("Prompt copié", "ok")).catch(() => {});
+  } else if (action === "open" && lastBestTask.best.url) {
+    window.open(lastBestTask.best.url, "_blank", "noopener");
+  }
+});
+
+// Log drawer
+function mountLogDrawer() {
+  const drawer = document.getElementById("log-drawer");
+  document.getElementById("log-drawer-toggle")?.addEventListener("click", () => drawer.classList.toggle("open"));
+  document.querySelectorAll('[data-action="copy-logs"]').forEach((b) => {
+    b.addEventListener("click", () => {
+      const text = document.getElementById("log-view")?.textContent ?? "";
+      navigator.clipboard?.writeText(text).then(() => showToast("Logs copiés", "ok"));
+    });
+  });
+  document.querySelectorAll('[data-action="clear-logs"]').forEach((b) => {
+    b.addEventListener("click", () => { clearLogs(); showToast("Logs vidés"); });
+  });
+}
+
+// SSE autopilot
+let autopilotEvents = null;
+function subscribeAutopilotEvents() {
+  if (autopilotEvents) { try { autopilotEvents.close(); } catch {} autopilotEvents = null; }
+  if (!api.token) return;
+  const url = `/api/autopilot/events?token=${encodeURIComponent(api.token)}`;
+  try {
+    autopilotEvents = new EventSource(url);
+    autopilotEvents.addEventListener("state", (e) => {
+      try {
+        const ap = JSON.parse(e.data);
+        lastV5 = { ...(lastV5 || {}), autopilot: ap };
+        rerenderMission();
+        if (ap?.currentStep) {
+          logSummary.last = `Étape: ${ap.currentStep}`;
+          renderLogSummary(logSummary);
+        }
+        if (ap?.lastPR) {
+          logSummary.success = `PR #${ap.lastPR.number}`;
+          renderLogSummary(logSummary);
+        }
+      } catch {}
+    });
+    autopilotEvents.addEventListener("log", (e) => {
+      try {
+        const log = JSON.parse(e.data);
+        appendLogLine(`[${log.stream}] ${log.chunk}`);
+      } catch {}
+    });
+  } catch { /* ignore */ }
+}
 
 setConnState(api.token ? ConnState.UNKNOWN : ConnState.AUTH_REQUIRED);
 refreshAll();

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-<meta name="theme-color" content="#07060c" />
-<title>WebAppV1 · Cockpit</title>
+<meta name="theme-color" content="#06050b" />
+<title>Claude Autopilot · Mission Control</title>
 <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
@@ -13,19 +13,17 @@
   <div class="brand">
     <span class="logo" aria-hidden="true">W</span>
     <span class="name">WebAppV1</span>
-    <span class="tag">· Cockpit</span>
+    <span class="tag">· Mission Control</span>
   </div>
   <nav class="tabs" id="tabs" role="tablist">
-    <button data-tab="overview" class="active" role="tab">Overview</button>
+    <button data-tab="mission" class="active" role="tab">Mission</button>
     <button data-tab="workspace" role="tab">Workspace</button>
     <button data-tab="settings" role="tab">Settings</button>
   </nav>
   <div class="topbar-right">
-    <span class="dot" id="conn-dot" title="connection"></span>
+    <span class="orb" id="conn-orb" title="status"></span>
     <span id="conn-badge" class="badge">…</span>
-    <span id="mode-badge" class="badge dry">DRY-RUN</span>
-    <span id="lan-badge" class="badge hidden warn">LAN</span>
-    <span id="automerge-badge" class="badge hidden danger">AUTO-MERGE</span>
+    <span id="mode-badge" class="badge"></span>
   </div>
 </header>
 
@@ -48,78 +46,140 @@
 
 <main>
 
-<!-- ============ OVERVIEW ============ -->
-<section data-pane="overview" class="pane active">
+<!-- ============ MISSION ============ -->
+<section data-pane="mission" class="pane active">
 
-  <!-- Autopilot hero -->
-  <div class="card hero autopilot-hero" id="autopilot-card">
-    <div class="head">
-      <h2>Autopilot</h2>
-      <span id="autopilot-status-badge" class="badge">idle</span>
+  <div class="mission-hero" id="mission-hero">
+    <div class="mission-eyebrow">
+      <span class="orb" id="mission-orb"></span>
+      <span id="mission-eyebrow">Claude Autopilot</span>
     </div>
-    <p class="lead" id="autopilot-summary">
-      Pick the safest open task and hand it to Claude. Stays in dry-run until you flip <code>allowExec</code> in Settings.
-    </p>
+    <h1 class="mission-title" id="mission-title">Claude Autopilot</h1>
+    <p class="mission-subtitle" id="mission-subtitle">Préparation de la mission…</p>
 
-    <div class="blocker-banner hidden" id="autopilot-blocker">
-      <span aria-hidden="true">⚠</span>
-      <div>
-        <strong id="autopilot-blocker-title">Bloqué</strong>
-        <ul id="autopilot-blocker-list"></ul>
+    <div class="mission-cta-row">
+      <button id="mission-cta" class="primary huge" data-needs="auth">Start mission</button>
+      <div class="secondary-actions">
+        <button id="autopilot-stop" class="ghost" data-needs="auth">Stop</button>
+        <button id="autopilot-resume" class="ghost" data-needs="auth">Resume</button>
       </div>
     </div>
 
-    <div class="autopilot-cta">
-      <button id="autopilot-start" class="primary big" data-needs="auth">Start Autopilot</button>
-      <button id="autopilot-stop" class="ghost" data-needs="auth">Stop</button>
-      <button id="autopilot-resume" class="ghost" data-needs="auth">Resume</button>
-      <span class="issue-input">
-        Issue
-        <input id="v5-issue" type="number" min="1" placeholder="auto" />
-      </span>
+    <div class="blocker-banner hidden" id="mission-blocker">
+      <span aria-hidden="true">⚠</span>
+      <div>
+        <strong id="mission-blocker-title">Bloqué</strong>
+        <ul id="mission-blocker-list"></ul>
+      </div>
     </div>
 
-    <div id="autopilot-mode-hint" class="muted small" style="margin-top: 6px;">
-      Mode actuel : <strong id="autopilot-mode-label">prompt-only</strong>
-      <span id="autopilot-mode-detail">— flippe <code>allowExec</code> dans Settings pour exec réel.</span>
+    <div class="mode-rail" id="mode-rail" role="radiogroup" aria-label="Mode de mission"></div>
+    <div class="mode-custom-input" id="mode-custom-input">
+      <label class="muted small">Custom max tasks</label>
+      <input id="mode-custom-value" type="number" min="1" max="20" value="5" />
     </div>
 
-    <ul class="autopilot-meta" id="autopilot-stats">
-      <li><span class="label">Status</span><span class="value" data-key="status">idle</span></li>
-      <li><span class="label">Mode</span><span class="value" data-key="mode">—</span></li>
-      <li><span class="label">Issue</span><span class="value" data-key="issue">—</span></li>
-      <li><span class="label">PRs</span><span class="value" data-key="prs">0</span></li>
-      <li><span class="label">Errors</span><span class="value" data-key="errors">0</span></li>
-      <li><span class="label">Next</span><span class="value" data-key="next">—</span></li>
-      <li><span class="label">Auto-merge</span><span class="value" data-key="automerge">OFF</span></li>
+    <div class="mission-progress hidden-step" id="mission-progress">
+      <div class="mission-progress-head">
+        <div class="mission-progress-status">
+          <span class="orb running" id="progress-orb"></span>
+          <span id="progress-status-text">Claude is starting…</span>
+        </div>
+        <span class="badge running" id="progress-percent">0%</span>
+      </div>
+      <div class="mission-progress-bar">
+        <div class="mission-progress-fill shimmer" id="progress-fill"></div>
+      </div>
+      <ul class="timeline" id="timeline">
+        <li class="timeline-step" data-step="select"><span class="step-num">1</span><span class="step-name">Select</span></li>
+        <li class="timeline-step" data-step="branch"><span class="step-num">2</span><span class="step-name">Branch</span></li>
+        <li class="timeline-step" data-step="claude"><span class="step-num">3</span><span class="step-name">Coding</span></li>
+        <li class="timeline-step" data-step="tests"><span class="step-num">4</span><span class="step-name">Tests</span></li>
+        <li class="timeline-step" data-step="guard"><span class="step-num">5</span><span class="step-name">Guard</span></li>
+        <li class="timeline-step" data-step="pr"><span class="step-num">6</span><span class="step-name">PR</span></li>
+        <li class="timeline-step" data-step="done"><span class="step-num">7</span><span class="step-name">Done</span></li>
+      </ul>
+    </div>
+  </div>
+
+  <!-- Full autopilot checklist (only shown when mode = full) -->
+  <div class="card hidden" id="full-checklist-card">
+    <div class="section-header" style="margin: 0 0 12px;">
+      <h2>Full autopilot readiness</h2>
+      <span class="section-sub" id="full-checklist-summary">…</span>
+    </div>
+    <ul class="checklist" id="full-checklist"></ul>
+  </div>
+
+  <!-- Next task card -->
+  <div class="section-header">
+    <h2>Next up</h2>
+    <span class="section-sub">Issue que l'autopilot prendrait maintenant.</span>
+  </div>
+  <div id="next-task-host"></div>
+
+  <!-- Last activity / log summary -->
+  <div class="section-header">
+    <h2>Activité</h2>
+    <span class="section-sub">Résumé live de ce que fait Claude.</span>
+  </div>
+  <div class="log-summary" id="log-summary">
+    <div class="log-summary-row empty"><span class="label">Last</span><span class="value" data-key="last">—</span></div>
+    <div class="log-summary-row empty"><span class="label">Success</span><span class="value" data-key="success">—</span></div>
+    <div class="log-summary-row empty"><span class="label">Error</span><span class="value" data-key="error">—</span></div>
+  </div>
+
+  <div class="log-drawer" id="log-drawer">
+    <button class="log-drawer-toggle" id="log-drawer-toggle">
+      <span class="arrow">›</span>
+      <span>Technical logs</span>
+      <span class="muted small" style="margin-left: auto;" id="log-drawer-count">—</span>
+    </button>
+    <div class="log-drawer-body">
+      <div class="log-drawer-toolbar">
+        <select id="log-filter">
+          <option value="all">All</option>
+          <option value="autopilot">Autopilot</option>
+          <option value="claude">Claude</option>
+          <option value="git">Git</option>
+          <option value="test">Test</option>
+          <option value="guard">Guard</option>
+          <option value="error">Errors</option>
+        </select>
+        <button data-action="copy-logs">Copy</button>
+        <button data-action="clear-logs" class="ghost">Clear</button>
+        <label class="check"><input type="checkbox" id="log-autoscroll" checked> Auto-scroll</label>
+      </div>
+      <pre id="log-view" class="log-view" aria-live="polite"></pre>
+    </div>
+  </div>
+
+  <!-- Status grid -->
+  <div class="section-header">
+    <h2>System</h2>
+    <span class="section-sub">État du repo, des intégrations et du runtime.</span>
+  </div>
+  <div class="card">
+    <ul class="status-grid" id="status-grid">
+      <li class="status-pill" data-key="claude"><span class="orb"></span><span class="label">Claude</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="branch"><span class="orb"></span><span class="label">Branche</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="exec"><span class="orb"></span><span class="label">Exec</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="loop"><span class="orb"></span><span class="label">Loop</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="automerge"><span class="orb"></span><span class="label">Auto-merge</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="notion"><span class="orb"></span><span class="label">Notion</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="n8n"><span class="orb"></span><span class="label">n8n</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="whatsapp"><span class="orb"></span><span class="label">WhatsApp</span><span class="value" data-value>—</span></li>
+      <li class="status-pill" data-key="lan"><span class="orb"></span><span class="label">LAN</span><span class="value" data-value>—</span></li>
     </ul>
-
-    <pre id="autopilot-prompt" class="autopilot-prompt hidden" aria-live="polite"></pre>
   </div>
 
-  <!-- Selected task -->
-  <div class="section-header" style="margin-top: 28px;">
-    <h2>Task sélectionnée</h2>
-    <span class="section-sub">La meilleure issue safe que l'autopilot prendrait maintenant.</span>
-  </div>
-  <div class="card" id="selected-task-card">
-    <div id="selected-task-body" class="muted small">Chargement...</div>
-    <div class="row" style="margin-top: 14px;">
-      <button data-action="refresh-task">Find best task</button>
-      <button data-action="prepare-best" class="primary" data-needs="auth">Prepare run</button>
-      <button data-action="copy-best-prompt" data-needs="auth" disabled>Copy prompt</button>
-    </div>
-    <pre id="selected-task-prompt" class="autopilot-prompt hidden"></pre>
-    <details style="margin-top: 14px;">
-      <summary class="muted small" style="cursor: pointer;">Tasks bloquées (<span id="blocked-count">0</span>)</summary>
-      <ul id="blocked-tasks" class="small" style="margin: 8px 0 0; padding-left: 20px;"></ul>
-    </details>
-  </div>
+</section>
 
-  <!-- Doctor summary -->
-  <div class="section-header" style="margin-top: 28px;">
+<!-- ============ WORKSPACE ============ -->
+<section data-pane="workspace" class="pane">
+  <div class="section-header">
     <h2>Doctor</h2>
-    <span class="section-sub">État du repo et des phases. Cliquer Run pour rafraîchir.</span>
+    <span class="section-sub">État du repo et des phases.</span>
   </div>
   <div class="card" id="doctor-card">
     <div id="doctor-empty" class="muted small">Pas encore exécuté. Clique <strong>Run doctor</strong>.</div>
@@ -135,293 +195,131 @@
         <span id="doctor-phase-3" class="badge">P3</span>
         <span id="doctor-phase-4" class="badge">P4</span>
       </div>
-      <details style="margin-top: 12px;">
-        <summary class="muted small" style="cursor: pointer;">Recommandations</summary>
-        <ul id="doctor-recos" class="small" style="margin: 8px 0 0; padding-left: 20px;"></ul>
-      </details>
-      <details style="margin-top: 8px;">
-        <summary class="muted small" style="cursor: pointer;">Phase blockers</summary>
-        <ul id="doctor-blockers" class="small" style="margin: 8px 0 0; padding-left: 20px;"></ul>
-      </details>
     </div>
     <div class="row" style="margin-top: 14px;">
       <button data-action="doctor-summary" class="primary" data-needs="auth">Run doctor</button>
     </div>
   </div>
 
-  <!-- System status -->
-  <div class="section-header" style="margin-top: 28px;">
-    <h2>System</h2>
-    <span class="section-sub">État du repo, des intégrations et du runtime.</span>
+  <div class="section-header">
+    <h2>Tasks</h2>
+    <span class="section-sub">Safe + bloquées.</span>
   </div>
-
-  <div class="card">
-    <ul class="status-grid" id="status-grid">
-      <li class="status-pill" data-key="server"><span class="dot"></span><span class="label">Serveur</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="auth"><span class="dot"></span><span class="label">Auth</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="claude"><span class="dot"></span><span class="label">Claude</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="branch"><span class="dot"></span><span class="label">Branche</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="protection"><span class="dot"></span><span class="label">Main protected</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="exec"><span class="dot"></span><span class="label">Exec</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="loop"><span class="dot"></span><span class="label">Loop</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="automerge"><span class="dot"></span><span class="label">Auto-merge</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="notion"><span class="dot"></span><span class="label">Notion</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="n8n"><span class="dot"></span><span class="label">n8n</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="whatsapp"><span class="dot"></span><span class="label">WhatsApp</span><span class="value" data-value>—</span></li>
-      <li class="status-pill" data-key="lan"><span class="dot"></span><span class="label">LAN</span><span class="value" data-value>—</span></li>
-    </ul>
-
-    <details style="margin-top: 14px;">
-      <summary class="muted small" style="cursor: pointer;">Prochaines actions humaines</summary>
-      <ul class="small" id="next-actions" style="margin: 10px 0 0; padding-left: 20px;"><li class="muted">—</li></ul>
-    </details>
-  </div>
-
-  <!-- Metrics -->
-  <div class="section-header" style="margin-top: 28px;">
-    <h2>Métriques</h2>
-    <span class="section-sub">Issues, autonomie, dernier run.</span>
-  </div>
-  <div class="status-grid">
-    <div class="metric"><span class="label">Issues ouverts</span><span class="value" id="metric-issues">—</span><span class="sub" id="metric-auto">—</span></div>
-    <div class="metric"><span class="label">Questions humaines</span><span class="value" id="metric-questions">—</span><span class="sub">en attente</span></div>
-    <div class="metric"><span class="label">Doctor</span><span class="value" id="metric-doctor">—</span><span class="sub" id="metric-doctor-sub">—</span></div>
-    <div class="metric"><span class="label">Dernier run</span><span class="value" id="metric-latest">—</span><span class="sub" id="metric-latest-sub">—</span></div>
-  </div>
-
-  <!-- Phone access -->
-  <div class="section-header" style="margin-top: 28px;">
-    <h2>Accès téléphone</h2>
-    <span class="section-sub">URL à scanner depuis ton mobile sur le même Wi-Fi.</span>
-  </div>
-  <div class="card">
-    <p class="small">Local : <code id="phone-local">—</code></p>
-    <p class="small" style="margin-top: 6px;">LAN : <code id="phone-lan">—</code></p>
-    <p class="small mute" id="phone-hint" style="margin-top: 10px;">Active LAN dans Settings + relance avec <code>pnpm cockpit:lan</code>.</p>
-  </div>
-
-</section>
-
-<!-- ============ WORKSPACE ============ -->
-<section data-pane="workspace" class="pane">
+  <div id="task-board-host" class="task-board"></div>
 
   <div class="section-header">
-    <h2>Workflow</h2>
-    <span class="section-sub">Suis ces étapes dans l'ordre.</span>
-  </div>
-  <div class="workflow">
-    <div class="step-card">
-      <span class="step-num">1</span>
-      <h3>Vérifier le repo</h3>
-      <p>Doctor scan : phase gates, branch protection, blocker labels.</p>
-      <div class="step-actions">
-        <button data-action="doctor" class="primary" data-needs="auth">Run doctor</button>
-      </div>
-    </div>
-    <div class="step-card">
-      <span class="step-num">2</span>
-      <h3>Voir les tâches</h3>
-      <p>Score & queue les issues, ne garder que les safe.</p>
-      <div class="step-actions">
-        <button data-action="score" data-needs="auth">Score</button>
-        <button data-action="queue" data-needs="auth">Queue</button>
-      </div>
-    </div>
-    <div class="step-card">
-      <span class="step-num">3</span>
-      <h3>Préparer un run</h3>
-      <p>Prompt prêt à coller dans <code>yu</code> ou autopilot direct.</p>
-      <div class="step-actions">
-        <button data-action="plan-next" class="primary" data-needs="auth">Plan next task</button>
-      </div>
-    </div>
-    <div class="step-card">
-      <span class="step-num">4</span>
-      <h3>Suivre l'exécution</h3>
-      <p>Logs live + état des questions humaines.</p>
-      <div class="step-actions">
-        <button data-action="scroll-logs">Voir les logs</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Tasks -->
-  <div class="section-header" style="margin-top: 32px;">
-    <h2>Tâches</h2>
-    <span class="section-sub">Issues classées et filtrables.</span>
-  </div>
-  <div class="tasks-toolbar">
-    <input id="task-filter" type="search" placeholder="Filtrer titre / labels…" />
-    <select id="task-class">
-      <option value="">Toutes classifications</option>
-      <option>trivial</option><option>safe</option><option>review</option><option>risky</option><option>blocked</option>
-    </select>
-    <button data-action="reload-tasks">Recharger</button>
-  </div>
-  <div class="table-wrap">
-    <table id="tasks-table">
-      <thead>
-        <tr>
-          <th>#</th><th>Titre</th><th>Score</th><th>Classif.</th>
-          <th>Risk</th><th>Autonomy</th><th>Raison</th><th>Action</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
-
-  <!-- Questions -->
-  <div class="section-header" style="margin-top: 32px;">
     <h2>Questions humaines</h2>
     <span class="section-sub">Réponses publiées sur GitHub via n8n.</span>
   </div>
   <div id="questions-list"></div>
   <p class="muted small" id="questions-empty" style="display: none;">Aucune question en attente.</p>
-
-  <!-- Logs -->
-  <div class="section-header" style="margin-top: 32px;" id="logs-section">
-    <h2>Logs</h2>
-    <span class="section-sub">Stream live du run actif.</span>
-  </div>
-  <div class="logs-toolbar">
-    <select id="log-run-select"><option value="">Run en direct</option></select>
-    <button data-action="copy-logs">Copier</button>
-    <button data-action="clear-logs" class="ghost">Vider</button>
-    <label class="check"><input type="checkbox" id="log-autoscroll" checked> Auto-scroll</label>
-  </div>
-  <pre id="log-view" class="log-view" aria-live="polite"></pre>
-
-  <!-- Advanced (collapsed) -->
-  <details style="margin-top: 32px;">
-    <summary class="muted small" style="cursor: pointer; padding: 10px 0;">Outils avancés (runner manuel, prompt libre)</summary>
-
-    <div class="settings-group" style="margin-top: 14px;">
-      <h3>Runner manuel</h3>
-      <p class="group-sub">Pour piloter à la main quand l'autopilot ne convient pas.</p>
-      <form id="runner-form" class="settings-rows">
-        <div class="settings-row">
-          <div class="info"><strong>Mode</strong><span>plan = dry-run, exec = vraie action, loop = enchaîner</span></div>
-          <div class="control">
-            <label class="check"><input type="radio" name="mode" value="plan" checked> plan</label>
-            <label class="check"><input type="radio" name="mode" value="exec"> exec</label>
-            <label class="check"><input type="radio" name="mode" value="loop"> loop</label>
-          </div>
-        </div>
-        <div class="settings-row">
-          <div class="info"><strong>Issue cible</strong><span>numéro GitHub à exécuter</span></div>
-          <div class="control"><input type="number" name="issue" min="1" placeholder="#" /></div>
-        </div>
-        <div class="settings-row">
-          <div class="info"><strong>Budget</strong><span>max minutes / max PR par run</span></div>
-          <div class="control">
-            <input type="number" name="maxMinutes" min="1" max="240" value="20" /><input type="number" name="maxPRs" min="1" max="10" value="3" />
-          </div>
-        </div>
-        <div class="settings-row">
-          <div class="info"><strong>Démarrer</strong><span>respecte les flags allowExec / allowLoop</span></div>
-          <div class="control">
-            <button type="submit" class="primary">Lancer</button>
-            <button type="button" data-action="stop-runner" class="danger">Stop</button>
-          </div>
-        </div>
-        <p class="warn-line hidden" id="runner-warn" style="color: var(--warn);"></p>
-      </form>
-    </div>
-
-    <div class="settings-group">
-      <h3>Prompt libre</h3>
-      <p class="group-sub">Préset ou texte libre pour Claude Code.</p>
-      <div class="row" style="margin-bottom: 8px;">
-        <button data-preset="plan-next-task">Plan next task</button>
-        <button data-preset="run-one-safe-task">Run one safe</button>
-        <button data-preset="loop-safe-tasks">Loop safe dry-run</button>
-        <button data-preset="resume-after-answer">Resume after answer</button>
-        <button data-preset="analyze-blockage">Analyze blockage</button>
-      </div>
-      <textarea id="prompt-text" placeholder="Prompt libre pour Claude Code…"></textarea>
-      <div class="row" style="margin-top: 8px;">
-        <button id="prompt-send" class="primary">Envoyer</button>
-        <button id="prompt-clear" class="ghost">Clear</button>
-      </div>
-    </div>
-
-    <div class="settings-group">
-      <h3>V5 prepare-run</h3>
-      <p class="group-sub">Génère un prompt sans lancer Claude (mode prompt-only).</p>
-      <div class="row">
-        <label>Issue <input id="v5-issue-prepare" type="number" min="1" placeholder="ex: 41" /></label>
-        <button data-action="v5-prepare" data-needs="auth">Prepare run</button>
-        <button data-action="v5-copy-prompt" data-needs="auth">Copy prompt</button>
-        <button data-action="v5-resume" data-needs="auth">Resume</button>
-      </div>
-      <pre id="v5-prompt-view" class="log-view hidden" style="margin-top: 12px;"></pre>
-    </div>
-  </details>
-
 </section>
 
 <!-- ============ SETTINGS ============ -->
 <section data-pane="settings" class="pane">
+  <nav class="settings-nav" id="settings-nav">
+    <button data-section="mission" class="active">Mission mode</button>
+    <button data-section="safety">Safety</button>
+    <button data-section="integrations">Integrations</button>
+    <button data-section="mobile">Mobile / LAN</button>
+    <button data-section="advanced">Advanced</button>
+    <button data-section="danger">Danger zone</button>
+  </nav>
 
   <form id="settings-form">
 
-    <div class="settings-group">
-      <h3>Exécution</h3>
-      <p class="group-sub">Contrôle ce que l'autopilot peut faire.</p>
+    <!-- Mission mode -->
+    <div class="settings-section active" data-section="mission">
+      <h3>Mission mode</h3>
+      <p class="group-sub">Comportement par défaut quand tu cliques Start mission.</p>
       <div class="settings-rows">
         <label class="settings-row">
-          <span class="info"><strong>Dry-run par défaut</strong><span>Plan only · aucune action réelle.</span></span>
+          <span class="info"><strong>Dry-run par défaut</strong><span>Plan only — pas d'action réelle.</span></span>
           <span class="control"><span class="toggle"><input type="checkbox" name="dryRunDefault"></span></span>
         </label>
         <label class="settings-row">
-          <span class="info"><strong>Autoriser exec</strong><span>Autorise une vraie exécution, pas juste plan.</span></span>
-          <span class="control"><span class="toggle"><input type="checkbox" name="allowExec"></span></span>
-        </label>
-        <label class="settings-row">
-          <span class="info"><strong>Autoriser loop</strong><span>Autorise plusieurs tasks consécutives jusqu'à maxPRs.</span></span>
-          <span class="control"><span class="toggle"><input type="checkbox" name="allowLoop"></span></span>
+          <span class="info"><strong>Issue préférée</strong><span>L'autopilot tentera celle-ci en priorité.</span></span>
+          <span class="control"><input type="number" name="preferredIssue" min="1" placeholder="—" /></span>
         </label>
       </div>
     </div>
 
-    <div class="settings-group">
-      <h3>Budget</h3>
-      <p class="group-sub">Limites par run autopilot.</p>
+    <!-- Safety -->
+    <div class="settings-section" data-section="safety">
+      <h3>Safety</h3>
+      <p class="group-sub">Garde-fous d'exécution. Cumul = capacité maximale.</p>
       <div class="settings-rows">
         <label class="settings-row">
-          <span class="info"><strong>Max PRs / run</strong><span>1 → 10</span></span>
-          <span class="control"><input type="number" name="maxPrsPerRun" min="1" max="10" /></span>
+          <span class="info"><strong>Autoriser exec</strong><span>Permet à l'autopilot de lancer Claude pour de vrai.</span></span>
+          <span class="control"><span class="toggle"><input type="checkbox" name="allowExec"></span></span>
+        </label>
+        <label class="settings-row">
+          <span class="info"><strong>Autoriser loop</strong><span>Permet d'enchaîner plusieurs tasks par run.</span></span>
+          <span class="control"><span class="toggle"><input type="checkbox" name="allowLoop"></span></span>
+        </label>
+        <label class="settings-row">
+          <span class="info"><strong>Power mode · Auto-merge</strong><span>Auto-merge ultra safe. Seulement quand toutes les gates sont vertes.</span></span>
+          <span class="control"><span class="toggle power"><input type="checkbox" name="allowAutoMerge"></span></span>
+        </label>
+      </div>
+    </div>
+
+    <!-- Integrations -->
+    <div class="settings-section" data-section="integrations">
+      <h3>Integrations</h3>
+      <p class="group-sub">Notifications externes. Toutes optionnelles.</p>
+      <div class="settings-rows">
+        <div class="settings-row">
+          <span class="info"><strong>Notion</strong><span id="settings-notion-detail">…</span></span>
+          <span class="control"><span class="badge" id="settings-notion-badge">—</span></span>
+        </div>
+        <div class="settings-row">
+          <span class="info"><strong>n8n</strong><span id="settings-n8n-detail">…</span></span>
+          <span class="control"><span class="badge" id="settings-n8n-badge">—</span></span>
+        </div>
+        <div class="settings-row">
+          <span class="info"><strong>WhatsApp</strong><span id="settings-whatsapp-detail">…</span></span>
+          <span class="control"><span class="badge" id="settings-whatsapp-badge">—</span></span>
+        </div>
+      </div>
+      <p class="muted small" style="margin-top: 12px;">Pour configurer, édite <code>.local-control/v5.env</code>. Voir <code>docs/ops/notion-whatsapp-live.md</code>.</p>
+    </div>
+
+    <!-- Mobile -->
+    <div class="settings-section" data-section="mobile">
+      <h3>Mobile / LAN</h3>
+      <p class="group-sub">Accès depuis le téléphone sur le même Wi-Fi.</p>
+      <div class="settings-rows">
+        <label class="settings-row">
+          <span class="info"><strong>Activer LAN</strong><span>Sert sur 0.0.0.0 quand lancé avec <code>pnpm cockpit:lan</code>.</span></span>
+          <span class="control"><span class="toggle"><input type="checkbox" name="lanEnabled"></span></span>
+        </label>
+      </div>
+      <p class="muted small" style="margin-top: 12px;">Local : <code id="phone-local">—</code></p>
+      <p class="muted small">LAN : <code id="phone-lan">—</code></p>
+    </div>
+
+    <!-- Advanced -->
+    <div class="settings-section" data-section="advanced">
+      <h3>Advanced</h3>
+      <p class="group-sub">Budget par run et filtres autopilot.</p>
+      <div class="settings-rows">
+        <label class="settings-row">
+          <span class="info"><strong>Max PRs / run</strong><span>1 → 20</span></span>
+          <span class="control"><input type="number" name="maxPrsPerRun" min="1" max="20" /></span>
         </label>
         <label class="settings-row">
           <span class="info"><strong>Max minutes</strong><span>1 → 240</span></span>
           <span class="control"><input type="number" name="maxMinutes" min="1" max="240" /></span>
         </label>
         <label class="settings-row">
-          <span class="info"><strong>Stale days</strong><span>ignore les issues plus vieilles que N jours</span></span>
+          <span class="info"><strong>Max errors</strong><span>1 → 20</span></span>
+          <span class="control"><input type="number" name="maxErrors" min="1" max="20" /></span>
+        </label>
+        <label class="settings-row">
+          <span class="info"><strong>Stale days</strong><span>Ignore les issues plus vieilles.</span></span>
           <span class="control"><input type="number" name="staleDays" min="0" max="365" /></span>
         </label>
-        <label class="settings-row">
-          <span class="info"><strong>Issue préférée</strong><span>autopilot prendra celle-ci en priorité</span></span>
-          <span class="control"><input type="number" name="preferredIssue" min="1" placeholder="—" /></span>
-        </label>
-      </div>
-    </div>
-
-    <div class="settings-group">
-      <h3>Réseau</h3>
-      <p class="group-sub">Accès depuis le téléphone, via LAN.</p>
-      <div class="settings-rows">
-        <label class="settings-row">
-          <span class="info"><strong>Activer LAN</strong><span>Sert sur 0.0.0.0 si lancé avec <code>pnpm cockpit:lan</code>.</span></span>
-          <span class="control"><span class="toggle"><input type="checkbox" name="lanEnabled"></span></span>
-        </label>
-      </div>
-    </div>
-
-    <div class="settings-group">
-      <h3>Filtres autopilot</h3>
-      <p class="group-sub">Quelles tasks l'autopilot accepte.</p>
-      <div class="settings-rows">
         <label class="settings-row">
           <span class="info"><strong>Risk autorisés</strong><span>séparés par virgules</span></span>
           <span class="control"><input type="text" name="allowedRisk" placeholder="safe" /></span>
@@ -433,22 +331,17 @@
       </div>
     </div>
 
-    <div class="settings-group danger">
+    <!-- Danger zone -->
+    <div class="settings-section danger" data-section="danger">
       <h3 style="color: var(--danger);">Danger zone</h3>
-      <p class="group-sub">Auto-merge reste OFF jusqu'à ce que tu actives ce flag explicitement.</p>
-      <div class="settings-rows">
-        <label class="settings-row">
-          <span class="info"><strong>Autoriser auto-merge</strong><span>Capacité auto-merge ultra safe (CI green + risk:safe + ai:autonomous + protection ON).</span></span>
-          <span class="control"><span class="toggle danger"><input type="checkbox" name="allowAutoMerge"></span></span>
-        </label>
-      </div>
+      <p class="group-sub">Actions irréversibles. Réfléchis deux fois.</p>
+      <p class="muted small">Pour l'instant, rien ici n'est exposé via l'UI : auto-merge se trouve dans <strong>Safety</strong> (Power mode), pas ici.</p>
     </div>
 
     <div class="row" style="margin-top: 20px;">
       <button type="submit" class="primary">Enregistrer</button>
     </div>
   </form>
-
 </section>
 
 </main>

--- a/tools/local-control/public/lib/cockpit.js
+++ b/tools/local-control/public/lib/cockpit.js
@@ -1,18 +1,18 @@
-// Cockpit V5 — central rendering helpers for the new IA.
+// Cockpit V5 — central rendering helpers (Mission Control redesign).
 // Pure DOM, no fetch. Driven by app.js with backend payloads.
 
-export function renderTopbar({ conn, settings, lan }) {
-  const dot = document.getElementById('conn-dot');
-  if (dot) {
-    dot.classList.remove('ok', 'err', 'warn');
-    if (conn === 'connected') dot.classList.add('ok');
-    else if (conn === 'auth-required' || conn === 'offline') dot.classList.add('err');
+export function renderTopbar({ conn, settings }) {
+  const orb = document.getElementById('conn-orb');
+  if (orb) {
+    orb.classList.remove('ok', 'err', 'warn', 'running');
+    if (conn === 'connected') orb.classList.add('ok');
+    else if (conn === 'auth-required' || conn === 'offline') orb.classList.add('err');
   }
   const badge = document.getElementById('conn-badge');
   if (badge) {
     badge.textContent =
-      conn === 'connected' ? 'connecté' :
-      conn === 'auth-required' ? 'auth requise' :
+      conn === 'connected' ? 'connected' :
+      conn === 'auth-required' ? 'auth' :
       conn === 'offline' ? 'offline' : '…';
     badge.classList.remove('ok', 'err', 'warn');
     if (conn === 'connected') badge.classList.add('ok');
@@ -20,38 +20,23 @@ export function renderTopbar({ conn, settings, lan }) {
   }
   const mode = document.getElementById('mode-badge');
   if (mode && settings) {
-    const dry = !!settings.dryRunDefault;
-    mode.textContent = dry ? 'DRY-RUN' : 'LIVE';
-    mode.classList.toggle('dry', dry);
-    mode.classList.toggle('live', !dry);
+    if (!settings.allowExec) { mode.textContent = 'PROMPT-ONLY'; mode.className = 'badge info'; }
+    else if (!settings.allowLoop) { mode.textContent = 'RUN-ONE'; mode.className = 'badge running'; }
+    else { mode.textContent = `LOOP ${settings.maxPrsPerRun ?? 5}`; mode.className = 'badge running'; }
   }
-  document.getElementById('lan-badge')?.classList.toggle('hidden', !(lan === true || settings?.lanEnabled));
-  document.getElementById('automerge-badge')?.classList.toggle('hidden', !settings?.allowAutoMerge);
 }
 
-export function renderStatusGrid({ conn, settings, v5, network, dashboard }) {
-  const notion = v5?.notion ?? null;
-  const n8n = v5?.n8n ?? null;
-  const whatsapp = v5?.whatsapp ?? null;
+export function renderStatusGrid({ conn, settings, v5, network }) {
   const map = {
-    server: pill(conn === 'connected' ? 'ok' : 'err', conn === 'connected' ? 'En ligne' : 'Hors ligne'),
-    auth: pill(conn === 'auth-required' ? 'err' : conn === 'connected' ? 'ok' : 'warn',
-      conn === 'auth-required' ? 'Token requis' : conn === 'connected' ? 'OK' : '…'),
-    claude: v5 ? pill(v5.claudeAvailable ? 'ok' : 'err', v5.claudeAvailable ? (v5.claudeVersion || 'OK') : 'Indispo') : pill('warn', '…'),
-    branch: pill(dashboard?.branch === 'main' ? 'ok' : 'warn', dashboard?.branch ?? '—'),
-    protection: pill(
-      dashboard?.mainProtection?.enabled === true ? 'ok'
-      : dashboard?.mainProtection?.enabled === false ? 'err' : 'warn',
-      dashboard?.mainProtection?.enabled === true ? 'protected'
-      : dashboard?.mainProtection?.enabled === false ? 'off'
-      : 'not checked'),
-    exec: pill(settings?.allowExec ? 'warn' : 'ok', settings?.allowExec ? 'autorisé' : 'bloqué'),
-    loop: pill(settings?.allowLoop ? 'warn' : 'ok', settings?.allowLoop ? 'autorisé' : 'bloqué'),
-    automerge: pill(settings?.allowAutoMerge ? 'warn' : 'ok', settings?.allowAutoMerge ? 'ENABLED' : 'OFF'),
-    notion: pillForNotion(notion ?? { stage: v5?.notionConfigured ? 'configured' : 'missing-all', summary: v5?.notionConfigured ? 'configured' : 'not configured' }),
-    n8n: pillForN8n(n8n ?? { stage: 'unknown', summary: '…' }),
-    whatsapp: pillForWhatsapp(whatsapp ?? { configured: !!v5?.whatsappConfigured, via: v5?.whatsappVia }),
-    lan: pill(network?.lan ? 'ok' : 'warn', network?.lan ? (network.lanIp ?? 'on') : 'local only'),
+    claude: claudePill(v5),
+    branch: branchPill(),
+    exec: pill(settings?.allowExec ? 'warn' : 'ok', settings?.allowExec ? 'autorisé' : 'OFF'),
+    loop: pill(settings?.allowLoop ? 'warn' : 'ok', settings?.allowLoop ? 'autorisé' : 'OFF'),
+    automerge: pill(settings?.allowAutoMerge ? 'warn' : 'info', settings?.allowAutoMerge ? 'POWER ON' : 'off'),
+    notion: pillForNotion(v5?.notion),
+    n8n: pillForN8n(v5?.n8n),
+    whatsapp: pillForWhatsapp(v5?.whatsapp),
+    lan: pill(network?.lan ? 'ok' : 'info', network?.lan ? (network.lanIp ?? 'on') : 'local'),
   };
   const grid = document.getElementById('status-grid');
   if (!grid) return;
@@ -59,42 +44,59 @@ export function renderStatusGrid({ conn, settings, v5, network, dashboard }) {
     const k = li.dataset.key;
     const m = map[k];
     if (!m) continue;
-    li.classList.remove('ok', 'warn', 'err');
+    li.classList.remove('ok', 'warn', 'err', 'info');
     li.classList.add(m.cls);
     const v = li.querySelector('[data-value]');
     if (v) v.textContent = m.text;
-  }
-  // next actions
-  const next = document.getElementById('next-actions');
-  if (next) {
-    const actions = v5?.nextHumanActions ?? [];
-    next.innerHTML = actions.length
-      ? actions.map((a) => `<li>${escapeHtml(a)}</li>`).join('')
-      : '<li class="muted">Tout est prêt.</li>';
+    const orb = li.querySelector('.orb');
+    if (orb) {
+      orb.classList.remove('ok', 'warn', 'err', 'running');
+      if (m.cls === 'ok') orb.classList.add('ok');
+      else if (m.cls === 'warn') orb.classList.add('warn');
+      else if (m.cls === 'err') orb.classList.add('err');
+    }
   }
 }
 
 function pill(cls, text) { return { cls, text }; }
+function claudePill(v5) {
+  if (!v5) return pill('info', '…');
+  return v5.claudeAvailable ? pill('ok', v5.claudeVersion ? v5.claudeVersion.split(' ')[0] : 'available') : pill('err', 'indispo');
+}
+function branchPill() {
+  // Branch comes from /api/dashboard but we keep simple here — set by caller via renderStatusBranch
+  return pill('info', '…');
+}
 function pillForNotion(n) {
-  if (!n || n.stage === 'unknown') return pill('warn', '…');
-  if (n.stage === 'configured') return pill('ok', 'configured');
-  if (n.stage === 'missing-token') return pill('err', 'missing token');
-  if (n.stage === 'missing-database-id') return pill('err', 'missing DB id');
-  return pill('warn', n.summary || 'not configured');
+  if (!n || n.stage === 'unknown') return pill('info', '…');
+  if (n.stage === 'configured') return pill('ok', 'ready');
+  if (n.stage === 'missing-token') return pill('warn', 'missing token');
+  if (n.stage === 'missing-database-id') return pill('warn', 'missing DB id');
+  return pill('info', 'optional');
 }
 function pillForN8n(n) {
-  if (!n || n.stage === 'unknown') return pill('warn', '…');
-  if (n.stage === 'configured') return pill('ok', 'configured');
-  if (n.stage === 'partial-webhooks') return pill('warn', 'webhooks partiels');
-  if (n.stage === 'base-only') return pill('warn', 'base ok, webhooks ø');
-  if (n.stage === 'missing-secret') return pill('err', 'missing secret');
-  if (n.stage === 'missing-base') return pill('warn', 'base manquante');
-  return pill('warn', n.summary || 'not configured');
+  if (!n || n.stage === 'unknown') return pill('info', '…');
+  if (n.stage === 'configured') return pill('ok', 'ready');
+  if (n.stage === 'partial-webhooks') return pill('warn', 'partial');
+  if (n.stage === 'base-only') return pill('info', 'base ok');
+  if (n.stage === 'missing-secret') return pill('warn', 'missing secret');
+  return pill('info', 'optional');
 }
 function pillForWhatsapp(w) {
-  if (!w) return pill('warn', '…');
+  if (!w) return pill('info', '…');
   if (w.configured) return pill('ok', w.via || 'on');
-  return pill('warn', 'optionnel');
+  return pill('info', 'optional');
+}
+
+export function renderStatusBranch(dashboard) {
+  const li = document.querySelector('#status-grid [data-key="branch"]');
+  if (!li || !dashboard) return;
+  const v = li.querySelector('[data-value]');
+  if (v) v.textContent = dashboard.branch ?? '—';
+  li.classList.remove('ok', 'warn', 'err', 'info');
+  li.classList.add(dashboard.branch === 'main' ? 'ok' : 'warn');
+  const orb = li.querySelector('.orb');
+  if (orb) { orb.classList.remove('ok', 'warn', 'err', 'running'); orb.classList.add(dashboard.branch === 'main' ? 'ok' : 'warn'); }
 }
 
 export function renderDoctor(summary) {
@@ -121,7 +123,7 @@ export function renderDoctor(summary) {
   if (checks) {
     checks.innerHTML = (summary.checks || []).map((c) => {
       const cls = c.status === 'ok' ? 'ok' : c.status === 'fail' ? 'err' : c.status === 'warn' ? 'warn' : '';
-      return `<li class="status-pill ${cls}"><span class="dot"></span><span class="label">${escapeHtml(c.label)}</span><span class="value">${escapeHtml(c.detail ?? '—')}</span></li>`;
+      return `<li class="status-pill ${cls}"><span class="orb ${cls === 'ok' ? 'ok' : cls === 'warn' ? 'warn' : cls === 'err' ? 'err' : ''}"></span><span class="label">${escapeHtml(c.label)}</span><span class="value">${escapeHtml(c.detail ?? '—')}</span></li>`;
     }).join('');
   }
   const phaseMap = { phase1: 'doctor-phase-1', phase2: 'doctor-phase-2', phase3: 'doctor-phase-3', phase4: 'doctor-phase-4' };
@@ -133,147 +135,13 @@ export function renderDoctor(summary) {
     el.classList.remove('ok', 'warn');
     el.classList.add(ready ? 'ok' : 'warn');
   }
-  const recos = document.getElementById('doctor-recos');
-  if (recos) recos.innerHTML = (summary.recommendations ?? []).length ? summary.recommendations.map((r) => `<li>${escapeHtml(r)}</li>`).join('') : '<li class="muted">Aucune.</li>';
-  const blockers = document.getElementById('doctor-blockers');
-  if (blockers) {
-    blockers.innerHTML = (summary.blockers ?? []).length
-      ? summary.blockers.map((b) => `<li><strong>${escapeHtml(b.phase)}</strong> · ${escapeHtml(b.blocker)}</li>`).join('')
-      : '<li class="muted">Aucun blocker.</li>';
-  }
-}
-
-export function renderSelectedTask(result) {
-  const body = document.getElementById('selected-task-body');
-  const promptEl = document.getElementById('selected-task-prompt');
-  const copyBtn = document.querySelector('[data-action="copy-best-prompt"]');
-  const blockedList = document.getElementById('blocked-tasks');
-  const blockedCount = document.getElementById('blocked-count');
-  if (!body) return;
-  if (!result) { body.textContent = 'Pas encore chargé.'; return; }
-  if (!result.ok || !result.best) {
-    body.innerHTML = `<strong style="color: var(--warn);">Aucune task safe</strong><br><span class="muted">${escapeHtml(result.reason ?? 'rien à exécuter')}</span>`;
-    if (promptEl) { promptEl.textContent = ''; promptEl.classList.add('hidden'); }
-    if (copyBtn) copyBtn.disabled = true;
-  } else {
-    const best = result.best;
-    const run = result.runnability ?? {};
-    const runState = run.canExec ? '<span class="badge ok">exec</span>'
-      : run.canPlan ? '<span class="badge warn">plan-only</span>'
-      : '<span class="badge danger">bloqué</span>';
-    const blockers = (run.blockers ?? []).length
-      ? `<ul class="small" style="margin: 6px 0 0; padding-left: 20px;">${run.blockers.map((b) => `<li>${escapeHtml(b)}</li>`).join('')}</ul>`
-      : '';
-    body.innerHTML = `
-      <div style="display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap;">
-        <div>
-          <strong style="font-size: 16px;">#${best.number} · ${escapeHtml(best.title)}</strong>
-          <div class="muted small" style="margin-top: 4px;">Score ${best.score ?? '—'} · classification ${best.classification ?? '—'}</div>
-        </div>
-        ${runState}
-      </div>
-      <div class="muted small" style="margin-top: 10px;">${escapeHtml(best.reason)}</div>
-      ${blockers}
-    `;
-    if (copyBtn) copyBtn.disabled = false;
-  }
-  if (blockedList) {
-    blockedList.innerHTML = (result.blocked ?? []).map((b) => `<li>#${b.number} · ${escapeHtml(b.title || '')} — <span class="muted">${escapeHtml(b.reasons?.join(', ') ?? 'safe mais non sélectionnée')}</span></li>`).join('');
-    if (blockedCount) blockedCount.textContent = String(result.blocked?.length ?? 0);
-  }
-}
-
-export function renderMetrics(dashboard) {
-  if (!dashboard) return;
-  set('metric-issues', dashboard.openIssues ?? '—');
-  set('metric-auto', dashboard.autonomousTasks != null ? `${dashboard.autonomousTasks} autonomes` : '—');
-  set('metric-questions', dashboard.pendingQuestions ?? '—');
-  const dr = dashboard.doctor ?? {};
-  set('metric-doctor', dr.ok === true ? 'green' : dr.ok === false ? 'red' : '—');
-  set('metric-doctor-sub', (dr.blockers ?? []).length ? `${dr.blockers.length} blockers` : 'aucun blocker');
-  const lr = dashboard.latestRun ?? {};
-  set('metric-latest', lr.status ?? 'idle');
-  set('metric-latest-sub', lr.startedAt ? new Date(lr.startedAt).toLocaleTimeString() : '—');
-}
-
-function set(id, val) { const el = document.getElementById(id); if (el) el.textContent = val ?? '—'; }
-
-export function renderAutopilot({ ap, v5, settings }) {
-  const card = document.getElementById('autopilot-card');
-  if (!card) return;
-  const badge = document.getElementById('autopilot-status-badge');
-  const status = ap?.status ?? 'idle';
-  if (badge) {
-    badge.textContent = status === 'running' ? 'en cours' : status === 'waiting' ? 'attente humaine' : status === 'completed' ? 'terminé' : status === 'stopped' ? 'arrêté' : 'idle';
-    badge.classList.remove('ok', 'warn', 'danger', 'accent');
-    if (status === 'running') badge.classList.add('accent');
-    else if (status === 'waiting') badge.classList.add('warn');
-    else if (status === 'stopped') badge.classList.add('danger');
-    else if (status === 'completed') badge.classList.add('ok');
-  }
-  const stats = document.getElementById('autopilot-stats');
-  if (stats) {
-    setMeta(stats, 'status', status);
-    setMeta(stats, 'mode', ap?.mode ?? '—');
-    setMeta(stats, 'issue', ap?.issue ? `#${ap.issue}` : '—');
-    setMeta(stats, 'prs', String(ap?.prsCreated ?? 0));
-    setMeta(stats, 'errors', String(ap?.errors ?? 0));
-    setMeta(stats, 'next', ap?.nextAction ?? '—');
-    const am = v5?.autoMergeMode ?? (settings?.allowAutoMerge ? 'ENABLED' : 'OFF');
-    setMeta(stats, 'automerge', am);
-  }
-  const promptEl = document.getElementById('autopilot-prompt');
-  if (promptEl) {
-    if (ap?.lastPrompt) {
-      promptEl.textContent = ap.lastPrompt;
-      promptEl.classList.remove('hidden');
-    } else if (!ap || ap.status === 'idle') {
-      promptEl.classList.add('hidden');
-    }
-  }
-  // blocker banner
-  const banner = document.getElementById('autopilot-blocker');
-  const reasons = collectBlockers({ ap, v5, settings });
-  if (banner) {
-    if (reasons.length) {
-      banner.classList.remove('hidden');
-      banner.classList.toggle('danger', reasons.some((r) => r.kind === 'danger'));
-      const list = document.getElementById('autopilot-blocker-list');
-      if (list) list.innerHTML = reasons.map((r) => `<li>${escapeHtml(r.text)}</li>`).join('');
-      const title = document.getElementById('autopilot-blocker-title');
-      if (title) title.textContent = ap?.status === 'waiting' ? 'En attente humaine' : ap?.status === 'stopped' ? 'Arrêté' : 'Pré-requis manquants';
-    } else {
-      banner.classList.add('hidden');
-    }
-  }
-}
-
-function setMeta(root, key, val) {
-  const el = root.querySelector(`[data-key="${key}"]`);
-  if (el) el.textContent = String(val ?? '—');
-}
-
-function collectBlockers({ ap, v5, settings }) {
-  const out = [];
-  if (v5 && !v5.claudeAvailable) out.push({ kind: 'warn', text: `Claude CLI indispo : ${v5.claudeReason ?? 'CLAUDE_CODE_COMMAND non défini'}` });
-  if (settings && !settings.allowExec) out.push({ kind: 'info', text: 'allowExec désactivé — autopilot reste en mode prompt-only' });
-  if (ap?.status === 'stopped' && ap?.stopReason) out.push({ kind: 'danger', text: `Stoppé : ${ap.stopReason}` });
-  if (ap?.status === 'waiting' && ap?.pendingQuestionId) out.push({ kind: 'warn', text: `Question en attente : ${ap.pendingQuestionId}` });
-  if (ap?.errors >= 1) out.push({ kind: 'warn', text: `${ap.errors} erreur(s) accumulée(s)` });
-  return out;
 }
 
 export function renderPhone(network) {
   const local = document.getElementById('phone-local');
   const lan = document.getElementById('phone-lan');
-  const hint = document.getElementById('phone-hint');
   if (local) local.textContent = network?.localUrl ?? `http://127.0.0.1:${network?.port ?? 8787}`;
-  if (lan) lan.textContent = network?.lanUrl ?? '— (LAN désactivé)';
-  if (hint) {
-    hint.textContent = network?.lan
-      ? `LAN actif sur ${network.lanIp ?? '?'}. Scanne le code dans ton navigateur mobile.`
-      : 'Active LAN dans Settings + relance avec pnpm cockpit:lan.';
-  }
+  if (lan) lan.textContent = network?.lanUrl ?? '—';
 }
 
 export function showToast(msg, kind = '') {
@@ -296,6 +164,47 @@ export function bindToggles(form) {
     sync();
     input.addEventListener('change', sync);
   }
+}
+
+export function renderIntegrationSettings(v5) {
+  if (!v5) return;
+  const set = (id, badge, detail) => {
+    const b = document.getElementById(id + '-badge');
+    const d = document.getElementById(id + '-detail');
+    if (b) { b.textContent = badge.text; b.className = 'badge ' + badge.cls; }
+    if (d) d.textContent = detail || '';
+  };
+  const n = v5.notion ?? {};
+  const cl = n.stage === 'configured' ? { cls: 'ok', text: 'ready' } : n.stage === 'missing-token' ? { cls: 'warn', text: 'missing token' } : n.stage === 'missing-database-id' ? { cls: 'warn', text: 'missing DB id' } : { cls: 'info', text: 'optional' };
+  set('settings-notion', cl, n.summary);
+
+  const w = v5.n8n ?? {};
+  const wcl = w.stage === 'configured' ? { cls: 'ok', text: 'ready' } : w.stage === 'partial-webhooks' ? { cls: 'warn', text: 'partial' } : w.stage === 'base-only' ? { cls: 'info', text: 'base ok' } : w.stage === 'missing-secret' ? { cls: 'warn', text: 'missing secret' } : { cls: 'info', text: 'optional' };
+  set('settings-n8n', wcl, w.summary);
+
+  const wa = v5.whatsapp ?? {};
+  const wacl = wa.configured ? { cls: 'ok', text: wa.via || 'on' } : { cls: 'info', text: 'optional' };
+  set('settings-whatsapp', wacl, wa.configured ? `via ${wa.via ?? 'on'}` : 'mobile notifications');
+}
+
+export function mountSettingsNav() {
+  const nav = document.getElementById('settings-nav');
+  if (!nav) return;
+  nav.addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-section]');
+    if (!btn) return;
+    e.preventDefault();
+    for (const b of nav.querySelectorAll('button')) b.classList.toggle('active', b === btn);
+    for (const sec of document.querySelectorAll('.settings-section')) sec.classList.toggle('active', sec.dataset.section === btn.dataset.section);
+  });
+}
+
+export function openSettingsSection(section) {
+  document.querySelector('[data-tab="settings"]')?.click();
+  const nav = document.getElementById('settings-nav');
+  if (!nav) return;
+  for (const b of nav.querySelectorAll('button')) b.classList.toggle('active', b.dataset.section === section);
+  for (const sec of document.querySelectorAll('.settings-section')) sec.classList.toggle('active', sec.dataset.section === section);
 }
 
 function escapeHtml(s) {

--- a/tools/local-control/public/lib/mission.js
+++ b/tools/local-control/public/lib/mission.js
@@ -1,0 +1,316 @@
+// Mission Control — pure rendering helpers for the new IA.
+
+export const MISSION_MODES = Object.freeze([
+  { id: 'manual', name: 'Manual prompt', desc: 'Prépare un prompt à coller dans yu.', mode: 'plan', maxPrs: 1, loop: false, requiresExec: false },
+  { id: 'auto1', name: 'Auto · 1 task', desc: 'Une PR puis stop.', mode: 'exec', maxPrs: 1, loop: false, requiresExec: true },
+  { id: 'auto5', name: 'Auto · 5 tasks', desc: 'Loop jusqu\'à 5 PR. Défaut.', mode: 'loop', maxPrs: 5, loop: true, requiresExec: true, requiresLoop: true },
+  { id: 'loop10', name: 'Loop · 10 tasks', desc: 'Loop intensif jusqu\'à 10 PR.', mode: 'loop', maxPrs: 10, loop: true, requiresExec: true, requiresLoop: true },
+  { id: 'loop20', name: 'Loop · 20 tasks', desc: 'Loop max jusqu\'à 20 PR.', mode: 'loop', maxPrs: 20, loop: true, requiresExec: true, requiresLoop: true },
+  { id: 'custom', name: 'Custom loop', desc: 'Choisis ton budget.', mode: 'loop', maxPrs: 5, loop: true, requiresExec: true, requiresLoop: true, custom: true },
+  { id: 'full', name: 'Full autopilot', desc: 'Vérifie toute la checklist avant de lancer.', mode: 'loop', maxPrs: 5, loop: true, requiresExec: true, requiresLoop: true, full: true },
+]);
+
+export const DEFAULT_MODE_ID = 'auto5';
+
+const STEP_ORDER = ['preflight', 'select', 'branch', 'claude', 'tests', 'guard', 'pr', 'done'];
+const STEP_PERCENT = { preflight: 5, select: 12, branch: 22, claude: 50, tests: 70, guard: 85, pr: 95, done: 100 };
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+export function renderModeRail(activeId, onSelect) {
+  const rail = document.getElementById('mode-rail');
+  if (!rail) return;
+  rail.innerHTML = MISSION_MODES.map((m) => `
+    <button type="button" role="radio" class="mode-card${m.id === activeId ? ' active' : ''}${m.full ? ' danger' : ''}" data-mode="${m.id}" aria-checked="${m.id === activeId}">
+      <span class="mode-name">${escapeHtml(m.name)}</span>
+      <span class="mode-desc">${escapeHtml(m.desc)}</span>
+    </button>
+  `).join('');
+  for (const btn of rail.querySelectorAll('[data-mode]')) {
+    btn.addEventListener('click', () => onSelect && onSelect(btn.dataset.mode));
+  }
+  const customBox = document.getElementById('mode-custom-input');
+  if (customBox) customBox.classList.toggle('show', activeId === 'custom');
+}
+
+export function findMode(id) { return MISSION_MODES.find((m) => m.id === id) ?? MISSION_MODES.find((m) => m.id === DEFAULT_MODE_ID); }
+
+export function buildMissionState({ mode, settings, v5, ap, fullReadiness, customMax }) {
+  const m = findMode(mode);
+  const apStatus = ap?.status ?? 'idle';
+
+  const claudeOk = !!v5?.claudeAvailable;
+  const execOk = !!settings?.allowExec;
+  const loopOk = !!settings?.allowLoop;
+
+  const blockers = [];
+  if (m.requiresExec && !execOk) blockers.push({ kind: 'warn', text: 'Exec disabled — flippe Settings → Safety → Autoriser exec.' });
+  if (m.requiresLoop && !loopOk) blockers.push({ kind: 'warn', text: 'Loop disabled — flippe Settings → Safety → Autoriser loop.' });
+  if (m.requiresExec && !claudeOk) blockers.push({ kind: 'danger', text: `Claude CLI indispo : ${v5?.claudeReason ?? 'check CLAUDE_CODE_COMMAND'}` });
+  if (m.full && fullReadiness && !fullReadiness.ready) blockers.push({ kind: 'warn', text: fullReadiness.summary });
+
+  let title = 'Claude Autopilot';
+  let subtitle = 'Préparation de la mission…';
+  let ctaLabel = 'Start mission';
+  let ctaDisabled = false;
+  let orbClass = 'ok';
+  let eyebrow = 'Ready';
+
+  if (apStatus === 'running') {
+    title = ap?.issue ? `Claude is working on #${ap.issue}` : 'Claude is working';
+    subtitle = ap?.currentStep ? `Étape : ${ap.currentStep.replace(/-/g, ' ')}` : 'En cours…';
+    ctaLabel = 'En cours…';
+    ctaDisabled = true;
+    orbClass = 'running';
+    eyebrow = 'Mission en cours';
+  } else if (apStatus === 'waiting') {
+    title = 'Décision humaine requise';
+    subtitle = ap?.pendingQuestionId ? `Question : ${ap.pendingQuestionId}` : 'Réponds dans GitHub puis Resume.';
+    ctaLabel = 'Resume';
+    orbClass = 'warn';
+    eyebrow = 'En attente';
+  } else if (apStatus === 'completed') {
+    const prs = ap?.prsCreated ?? 0;
+    title = prs ? `Mission terminée · ${prs} PR créée${prs > 1 ? 's' : ''}` : 'Mission terminée';
+    subtitle = ap?.lastPR ? `Dernière PR : ${ap.lastPR.url ?? `#${ap.lastPR.number}`}` : 'Tu peux relancer une nouvelle mission.';
+    ctaLabel = ap?.lastPR ? 'Review PR' : 'Start mission';
+    orbClass = 'ok';
+    eyebrow = 'Mission complète';
+  } else if (apStatus === 'stopped') {
+    title = 'Mission stoppée';
+    subtitle = ap?.stopReason ? `Raison : ${ap.stopReason}` : 'Stoppée manuellement.';
+    ctaLabel = 'Start mission';
+    orbClass = 'warn';
+    eyebrow = 'Stoppé';
+  } else {
+    // idle / unknown
+    if (blockers.length) {
+      title = `${blockers.length} item${blockers.length > 1 ? 's' : ''} avant Full autopilot`;
+      subtitle = m.full ? 'Coche les items requis ci-dessous ou choisis un mode plus simple.' : blockers[0].text;
+      ctaLabel = blockers.some((b) => b.kind === 'danger') ? 'Configure missing items' : 'Start mission';
+      orbClass = 'warn';
+      eyebrow = 'Configuration requise';
+    } else {
+      const max = m.custom ? (Number(customMax) || 5) : m.maxPrs;
+      if (m.id === 'manual') {
+        title = 'Manual prompt';
+        subtitle = 'Génère un prompt à coller dans yu. Aucune action réelle.';
+        ctaLabel = 'Generate prompt';
+      } else if (m.maxPrs === 1) {
+        title = `Ready to run 1 safe task.`;
+        subtitle = 'Une PR puis stop.';
+      } else {
+        title = `Ready to run ${max} safe tasks.`;
+        subtitle = m.loop ? `Loop jusqu'à ${max} PR ou budget atteint.` : `${max} PR puis stop.`;
+      }
+    }
+  }
+
+  return {
+    mode: m,
+    title, subtitle, ctaLabel, ctaDisabled, orbClass, eyebrow,
+    blockers,
+  };
+}
+
+export function renderMissionHero(state) {
+  setText('mission-eyebrow', state.eyebrow);
+  setText('mission-title', state.title);
+  setText('mission-subtitle', state.subtitle);
+  const cta = document.getElementById('mission-cta');
+  if (cta) {
+    cta.textContent = state.ctaLabel;
+    cta.disabled = !!state.ctaDisabled;
+  }
+  const orbs = ['mission-orb'];
+  for (const id of orbs) {
+    const o = document.getElementById(id);
+    if (!o) continue;
+    o.classList.remove('ok', 'running', 'warn', 'err');
+    o.classList.add(state.orbClass);
+  }
+  const banner = document.getElementById('mission-blocker');
+  if (banner) {
+    if (state.blockers.length) {
+      banner.classList.remove('hidden');
+      banner.classList.toggle('danger', state.blockers.some((b) => b.kind === 'danger'));
+      banner.classList.toggle('info', state.blockers.every((b) => b.kind === 'info'));
+      const list = document.getElementById('mission-blocker-list');
+      if (list) list.innerHTML = state.blockers.map((b) => `<li>${escapeHtml(b.text)}</li>`).join('');
+    } else {
+      banner.classList.add('hidden');
+    }
+  }
+}
+
+export function renderMissionProgress(ap) {
+  const wrap = document.getElementById('mission-progress');
+  if (!wrap) return;
+  if (!ap || (ap.status !== 'running' && ap.status !== 'waiting')) {
+    wrap.classList.add('hidden-step');
+    return;
+  }
+  wrap.classList.remove('hidden-step');
+  const step = mapStep(ap.currentStep);
+  const pct = ap.status === 'completed' ? 100 : (STEP_PERCENT[step] ?? 5);
+  setText('progress-percent', `${pct}%`);
+  const fill = document.getElementById('progress-fill');
+  if (fill) fill.style.width = `${pct}%`;
+  setText('progress-status-text', humanStep(step, ap));
+  for (const li of document.querySelectorAll('.timeline-step')) {
+    li.classList.remove('done', 'active', 'failed');
+    const s = li.dataset.step;
+    const idx = ['select', 'branch', 'claude', 'tests', 'guard', 'pr', 'done'].indexOf(s);
+    const cur = ['select', 'branch', 'claude', 'tests', 'guard', 'pr', 'done'].indexOf(step);
+    if (cur < 0) continue;
+    if (idx < cur) li.classList.add('done');
+    else if (idx === cur) li.classList.add(ap.status === 'stopped' ? 'failed' : 'active');
+  }
+  const orb = document.getElementById('progress-orb');
+  if (orb) {
+    orb.classList.remove('ok', 'running', 'warn', 'err');
+    orb.classList.add(ap.status === 'waiting' ? 'warn' : 'running');
+  }
+}
+
+function mapStep(currentStep) {
+  if (!currentStep) return 'select';
+  if (currentStep.startsWith('preflight') || currentStep === 'preflight') return 'select';
+  if (currentStep === 'task-selected' || currentStep === 'reset-to-main') return 'select';
+  if (currentStep === 'create-branch') return 'branch';
+  if (currentStep === 'launching-claude' || currentStep === 'claude-exited' || currentStep === 'prompt-ready') return 'claude';
+  if (currentStep === 'task-guard') return 'guard';
+  if (currentStep === 'check-pr' || currentStep === 'pr-created' || currentStep === 'no-pr-no-question') return 'pr';
+  return 'select';
+}
+
+function humanStep(step, ap) {
+  switch (step) {
+    case 'select': return ap.status === 'waiting' ? 'Décision humaine requise.' : 'Sélection de la task safe…';
+    case 'branch': return 'Création de la branche dédiée…';
+    case 'claude': return 'Claude is coding…';
+    case 'tests': return 'Tests are running…';
+    case 'guard': return 'Task guard…';
+    case 'pr': return ap.lastPR ? 'PR ouverte.' : 'Vérification PR…';
+    case 'done': return 'Done.';
+    default: return 'En cours…';
+  }
+}
+
+export function renderFullChecklist(readiness, onAction) {
+  const card = document.getElementById('full-checklist-card');
+  const list = document.getElementById('full-checklist');
+  const summary = document.getElementById('full-checklist-summary');
+  if (!card || !list || !readiness) { if (card) card.classList.add('hidden'); return; }
+  card.classList.remove('hidden');
+  if (summary) summary.textContent = readiness.summary;
+  list.innerHTML = readiness.items.map((it) => {
+    const cls = it.status === 'ready' ? 'ready' : it.status === 'optional' ? 'optional' : it.status === 'blocked' ? 'blocked' : 'missing';
+    const action = it.action ? `<button type="button" data-checklist-action="${escapeHtml(it.action)}">Configure</button>` : '';
+    return `<li class="checklist-item ${cls}">
+      <span class="check-icon" aria-hidden="true"></span>
+      <span class="check-body">
+        <span class="check-label">${escapeHtml(it.label)}</span>
+        <span class="check-detail">${escapeHtml(it.detail || '')}</span>
+      </span>
+      ${action}
+    </li>`;
+  }).join('');
+  for (const btn of list.querySelectorAll('[data-checklist-action]')) {
+    btn.addEventListener('click', () => onAction && onAction(btn.dataset.checklistAction));
+  }
+}
+
+export function renderNextTask(result) {
+  const host = document.getElementById('next-task-host');
+  if (!host) return;
+  if (!result || !result.ok || !result.best) {
+    host.innerHTML = `<div class="card muted small">${escapeHtml(result?.reason ?? 'Aucune task safe.')}</div>`;
+    return;
+  }
+  const t = result.best;
+  const run = result.runnability ?? {};
+  const runState = run.canExec ? '<span class="task-tag safe">exec ok</span>' : run.canPlan ? '<span class="task-tag risk">plan-only</span>' : '<span class="task-tag blocked">bloqué</span>';
+  host.innerHTML = `
+    <div class="task-card next">
+      <div class="task-card-head">
+        <span class="task-num">#${t.number}</span>
+        <span class="task-score">score ${t.score ?? '—'}</span>
+      </div>
+      <div class="task-title">${escapeHtml(t.title)}</div>
+      <div class="task-meta">
+        ${runState}
+        ${t.classification ? `<span class="task-tag">${escapeHtml(t.classification)}</span>` : ''}
+      </div>
+      <div class="task-reason">${escapeHtml(t.reason || '')}</div>
+      <div class="task-actions">
+        <button type="button" data-best-action="prepare" class="primary" data-needs="auth">Prepare</button>
+        <button type="button" data-best-action="copy" data-needs="auth" disabled>Copy prompt</button>
+        ${t.url ? `<button type="button" data-best-action="open" data-needs="auth">View issue</button>` : ''}
+      </div>
+    </div>
+  `;
+}
+
+export function renderTaskBoard(result) {
+  const host = document.getElementById('task-board-host');
+  if (!host) return;
+  const items = [];
+  if (result?.ok && result.best) items.push({ ...result.best, _next: true });
+  for (const b of (result?.blocked ?? [])) items.push({ number: b.number, title: b.title, score: b.score, classification: b.classification, _blocked: true, reasons: b.reasons });
+  if (!items.length) {
+    host.innerHTML = `<div class="card muted small">Pas de tasks.</div>`;
+    return;
+  }
+  host.innerHTML = items.map((t) => {
+    const cls = t._next ? 'next' : t._blocked ? 'blocked' : '';
+    const tag = t._next ? '<span class="task-tag safe">next</span>' : t._blocked ? '<span class="task-tag blocked">bloquée</span>' : '<span class="task-tag">queue</span>';
+    const reason = t.reasons?.length ? t.reasons.join(', ') : (t.reason || '—');
+    return `<div class="task-card ${cls}">
+      <div class="task-card-head">
+        <span class="task-num">#${t.number}</span>
+        <span class="task-score">${t.score != null ? 'score ' + t.score : ''}</span>
+      </div>
+      <div class="task-title">${escapeHtml(t.title || '')}</div>
+      <div class="task-meta">${tag}${t.classification ? `<span class="task-tag">${escapeHtml(t.classification)}</span>` : ''}</div>
+      <div class="task-reason">${escapeHtml(reason)}</div>
+    </div>`;
+  }).join('');
+}
+
+export function renderLogSummary({ last, success, error }) {
+  const set = (key, val) => {
+    const row = document.querySelector(`#log-summary [data-key="${key}"]`);
+    if (!row) return;
+    row.parentElement?.classList.toggle('empty', !val);
+    row.textContent = val || '—';
+  };
+  set('last', last);
+  set('success', success);
+  set('error', error);
+}
+
+export function appendLogLine(text, kind = '') {
+  const view = document.getElementById('log-view');
+  if (!view) return;
+  const span = document.createElement('span');
+  span.className = 'log-line' + (kind ? ' ' + kind : '');
+  span.textContent = text;
+  view.appendChild(span);
+  if (document.getElementById('log-autoscroll')?.checked) view.scrollTop = view.scrollHeight;
+  const counter = document.getElementById('log-drawer-count');
+  if (counter) counter.textContent = `${view.children.length} lignes`;
+}
+
+export function clearLogs() {
+  const view = document.getElementById('log-view');
+  if (view) view.innerHTML = '';
+  const counter = document.getElementById('log-drawer-count');
+  if (counter) counter.textContent = '0 lignes';
+}
+
+function setText(id, val) { const el = document.getElementById(id); if (el) el.textContent = val ?? ''; }

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -1,24 +1,28 @@
-/* WebAppV1 Local Control — Cockpit V5
-   Design tokens: violet/black, premium feel, clear hierarchy. */
+/* WebAppV1 · Mission Control — premium violet/black design system */
 
 :root {
-  --bg: #07060c;
-  --bg-1: #0e0c18;
-  --bg-2: #14112a;
-  --bg-3: #1d1839;
-  --surface: rgba(20, 17, 42, 0.6);
-  --surface-strong: rgba(29, 24, 57, 0.8);
-  --border: rgba(126, 87, 255, 0.18);
-  --border-strong: rgba(126, 87, 255, 0.35);
-  --fg: #ece9ff;
-  --fg-dim: #968fbe;
-  --fg-mute: #6b6590;
+  --bg: #06050b;
+  --bg-1: #0c0a17;
+  --bg-2: #15122a;
+  --bg-3: #1f1a3d;
+  --surface: rgba(20, 17, 42, 0.55);
+  --surface-strong: rgba(29, 24, 57, 0.85);
+  --surface-glass: rgba(15, 12, 30, 0.7);
+  --border: rgba(140, 100, 255, 0.14);
+  --border-strong: rgba(140, 100, 255, 0.32);
+  --border-bright: rgba(180, 135, 255, 0.5);
+  --fg: #f1edff;
+  --fg-dim: #9a93c4;
+  --fg-mute: #65608a;
   --accent: #8b5cff;
   --accent-2: #b487ff;
+  --accent-3: #d4b3ff;
   --accent-soft: rgba(139, 92, 255, 0.12);
-  --accent-glow: rgba(139, 92, 255, 0.4);
+  --accent-glow: rgba(139, 92, 255, 0.45);
   --ok: #4ade80;
   --ok-soft: rgba(74, 222, 128, 0.12);
+  --info: #60a5fa;
+  --info-soft: rgba(96, 165, 250, 0.12);
   --warn: #fbbf24;
   --warn-soft: rgba(251, 191, 36, 0.12);
   --danger: #f87171;
@@ -27,20 +31,24 @@
   --r-md: 12px;
   --r-lg: 18px;
   --r-xl: 24px;
-  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.35);
-  --shadow-glow: 0 0 0 1px var(--border-strong), 0 12px 36px rgba(139, 92, 255, 0.18);
-  --transition: 160ms cubic-bezier(0.4, 0, 0.2, 1);
+  --r-2xl: 32px;
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 12px 32px rgba(0, 0, 0, 0.45);
+  --shadow-glow: 0 0 0 1px var(--border-strong), 0 16px 48px rgba(139, 92, 255, 0.25);
+  --shadow-glow-strong: 0 0 0 1px var(--border-bright), 0 24px 72px rgba(139, 92, 255, 0.35);
+  --t-fast: 120ms cubic-bezier(0.4, 0, 0.2, 1);
+  --t: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --t-slow: 360ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 * { box-sizing: border-box; }
-*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 4px; }
+*:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
 
 html, body {
   margin: 0; padding: 0;
   background: var(--bg);
   color: var(--fg);
-  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", "Segoe UI", system-ui, sans-serif;
   font-feature-settings: "ss01", "cv11";
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -49,15 +57,16 @@ html, body {
 body {
   min-height: 100vh;
   background:
-    radial-gradient(circle at 0% 0%, rgba(139, 92, 255, 0.12), transparent 40%),
-    radial-gradient(circle at 100% 100%, rgba(180, 135, 255, 0.08), transparent 50%),
+    radial-gradient(circle at 0% -10%, rgba(139, 92, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 100% 110%, rgba(180, 135, 255, 0.12), transparent 50%),
+    radial-gradient(circle at 50% 50%, rgba(96, 165, 250, 0.04), transparent 60%),
     var(--bg);
   background-attachment: fixed;
 }
 
-h1, h2, h3, h4 { margin: 0; font-weight: 600; letter-spacing: -0.01em; }
-h1 { font-size: 22px; }
-h2 { font-size: 17px; }
+h1, h2, h3, h4 { margin: 0; font-weight: 600; letter-spacing: -0.02em; }
+h1 { font-size: 28px; line-height: 1.15; }
+h2 { font-size: 20px; line-height: 1.25; }
 h3 { font-size: 14px; color: var(--fg-dim); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }
 h4 { font-size: 13px; }
 p { margin: 0; line-height: 1.55; }
@@ -73,7 +82,7 @@ code {
 
 /* Buttons */
 button {
-  display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
   background: var(--bg-2);
   color: var(--fg);
   border: 1px solid var(--border);
@@ -82,25 +91,36 @@ button {
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  transition: var(--transition);
+  transition: all var(--t);
   white-space: nowrap;
   font-family: inherit;
 }
 button:hover:not(:disabled) {
   background: var(--bg-3);
   border-color: var(--border-strong);
+  transform: translateY(-1px);
 }
+button:active:not(:disabled) { transform: translateY(0); }
 button.primary {
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
   border-color: transparent;
   color: white;
   font-weight: 600;
   box-shadow: 0 4px 16px var(--accent-glow);
+  position: relative;
+  overflow: hidden;
+}
+button.primary::before {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(135deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  transform: translateX(-100%);
+  transition: transform var(--t-slow);
 }
 button.primary:hover:not(:disabled) {
   filter: brightness(1.08);
-  box-shadow: 0 6px 22px var(--accent-glow);
+  box-shadow: 0 8px 28px var(--accent-glow);
 }
+button.primary:hover:not(:disabled)::before { transform: translateX(100%); }
 button.danger {
   background: var(--danger-soft);
   border-color: var(--danger);
@@ -108,20 +128,26 @@ button.danger {
 }
 button.ghost { background: transparent; }
 button.big {
-  padding: 14px 28px;
+  padding: 16px 32px;
   font-size: 15px;
   font-weight: 600;
   border-radius: var(--r-lg);
 }
-button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
+button.huge {
+  padding: 20px 40px;
+  font-size: 17px;
+  font-weight: 700;
+  border-radius: var(--r-xl);
+  box-shadow: 0 12px 36px var(--accent-glow), 0 0 0 1px rgba(255, 255, 255, 0.06) inset;
 }
-button.is-loading { opacity: 0.7; cursor: progress; }
+button.huge:hover:not(:disabled) {
+  box-shadow: 0 16px 48px var(--accent-glow), 0 0 0 1px rgba(255, 255, 255, 0.1) inset;
+  transform: translateY(-2px);
+}
+button:disabled { opacity: 0.4; cursor: not-allowed; transform: none !important; }
+button.is-loading { opacity: 0.8; cursor: progress; }
 button.is-loading::after { content: ""; width: 12px; height: 12px; border: 2px solid currentColor; border-top-color: transparent; border-radius: 50%; animation: spin 0.6s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
-button.is-success { border-color: var(--ok); color: var(--ok); }
-button.is-error { border-color: var(--danger); color: var(--danger); }
 
 /* Forms */
 input, select, textarea {
@@ -129,21 +155,21 @@ input, select, textarea {
   color: var(--fg);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
-  padding: 9px 12px;
+  padding: 10px 14px;
   font-size: 13px;
   font-family: inherit;
-  transition: var(--transition);
+  transition: all var(--t);
 }
 input:focus, select:focus, textarea:focus {
   border-color: var(--accent);
   background: var(--bg-2);
   outline: none;
+  box-shadow: 0 0 0 4px var(--accent-soft);
 }
 textarea { width: 100%; resize: vertical; min-height: 110px; font-family: "SF Mono", ui-monospace, Menlo, monospace; }
 label { font-size: 12px; color: var(--fg-dim); display: flex; flex-direction: column; gap: 6px; }
 label.check { flex-direction: row; align-items: center; gap: 10px; color: var(--fg); cursor: pointer; }
 label.check input[type="checkbox"] { accent-color: var(--accent); width: 16px; height: 16px; }
-label.check.danger { color: var(--danger); }
 
 /* Utils */
 .muted { color: var(--fg-dim); }
@@ -153,57 +179,85 @@ label.check.danger { color: var(--danger); }
 .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
 .stack { display: flex; flex-direction: column; gap: 12px; }
 .hidden { display: none !important; }
-.hr { border: 0; border-top: 1px solid var(--border); margin: 16px 0; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
 
 /* Topbar */
 .topbar {
   display: flex; align-items: center; gap: 16px;
-  padding: 12px 24px;
-  background: rgba(7, 6, 12, 0.8);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  padding: 14px 24px;
+  background: rgba(7, 5, 14, 0.7);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-bottom: 1px solid var(--border);
   position: sticky; top: 0; z-index: 30;
 }
 .brand {
-  display: flex; align-items: center; gap: 10px;
+  display: flex; align-items: center; gap: 12px;
   font-weight: 600; font-size: 14px;
 }
 .brand .logo {
-  width: 28px; height: 28px;
-  border-radius: 8px;
+  width: 32px; height: 32px;
+  border-radius: 10px;
   background: linear-gradient(135deg, var(--accent), var(--accent-2));
-  box-shadow: 0 0 20px var(--accent-glow);
+  box-shadow: 0 0 24px var(--accent-glow), inset 0 0 0 1px rgba(255, 255, 255, 0.15);
   display: flex; align-items: center; justify-content: center;
-  font-weight: 700; font-size: 14px; color: white;
+  font-weight: 700; font-size: 15px; color: white;
+  letter-spacing: -0.02em;
+  position: relative;
 }
-.brand .name { letter-spacing: -0.01em; }
+.brand .logo::after {
+  content: ""; position: absolute; inset: -3px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  filter: blur(12px); opacity: 0.4; z-index: -1;
+}
+.brand .name { letter-spacing: -0.01em; font-size: 15px; }
 .brand .tag { color: var(--fg-mute); font-weight: 400; font-size: 12px; }
 
 .tabs {
-  display: flex; gap: 4px; flex: 1; justify-content: center;
+  display: flex; gap: 2px; flex: 1; justify-content: center;
   background: var(--bg-1);
   padding: 4px;
   border-radius: var(--r-md);
   border: 1px solid var(--border);
+  max-width: 480px;
 }
 .tabs button {
-  background: transparent; border: 0; padding: 6px 18px;
+  background: transparent; border: 0; padding: 7px 18px;
   color: var(--fg-dim); font-weight: 500; font-size: 13px;
   border-radius: var(--r-sm);
+  flex: 1;
+  transform: none !important;
 }
+.tabs button:hover:not(.active) { color: var(--fg); background: rgba(255, 255, 255, 0.03); }
 .tabs button.active {
   background: var(--accent-soft);
   color: var(--fg);
   box-shadow: inset 0 0 0 1px var(--border-strong);
 }
-.tabs button:hover:not(.active) { color: var(--fg); }
 
 .topbar-right { display: flex; gap: 8px; align-items: center; }
-.dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-mute); transition: var(--transition); }
-.dot.ok { background: var(--ok); box-shadow: 0 0 10px var(--ok); }
-.dot.err { background: var(--danger); box-shadow: 0 0 10px var(--danger); }
-.dot.warn { background: var(--warn); box-shadow: 0 0 10px var(--warn); }
+
+/* Status orb (animated dot) */
+.orb {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: var(--fg-mute);
+  position: relative;
+  transition: background var(--t);
+}
+.orb.ok { background: var(--ok); box-shadow: 0 0 12px var(--ok); }
+.orb.running { background: var(--accent); box-shadow: 0 0 14px var(--accent-glow); animation: orbPulse 1.6s ease-in-out infinite; }
+.orb.warn { background: var(--warn); box-shadow: 0 0 12px var(--warn); }
+.orb.err { background: var(--danger); box-shadow: 0 0 12px var(--danger); animation: orbBlink 1s ease-in-out infinite; }
+@keyframes orbPulse {
+  0%, 100% { box-shadow: 0 0 12px var(--accent-glow); transform: scale(1); }
+  50% { box-shadow: 0 0 24px var(--accent-glow); transform: scale(1.15); }
+}
+@keyframes orbBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
 
 /* Badges */
 .badge {
@@ -218,21 +272,20 @@ label.check.danger { color: var(--danger); }
   border: 1px solid var(--border);
   color: var(--fg-dim);
 }
-.badge.ok { background: var(--ok-soft); border-color: var(--ok); color: var(--ok); }
-.badge.warn { background: var(--warn-soft); border-color: var(--warn); color: var(--warn); }
-.badge.danger { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
-.badge.accent { background: var(--accent-soft); border-color: var(--accent); color: var(--accent-2); }
-.badge.dry { background: var(--ok-soft); border-color: var(--ok); color: var(--ok); }
-.badge.live { background: var(--warn-soft); border-color: var(--warn); color: var(--warn); }
+.badge.ok { background: var(--ok-soft); border-color: rgba(74, 222, 128, 0.3); color: var(--ok); }
+.badge.running { background: var(--accent-soft); border-color: var(--border-strong); color: var(--accent-2); }
+.badge.info { background: var(--info-soft); border-color: rgba(96, 165, 250, 0.3); color: var(--info); }
+.badge.warn { background: var(--warn-soft); border-color: rgba(251, 191, 36, 0.3); color: var(--warn); }
+.badge.danger { background: var(--danger-soft); border-color: rgba(248, 113, 113, 0.3); color: var(--danger); }
 
 /* Layout */
-main { padding: 24px; max-width: 1280px; margin: 0 auto; }
+main { padding: 28px 24px; max-width: 1240px; margin: 0 auto; }
 .pane { display: none; }
-.pane.active { display: block; animation: fadeIn 240ms ease; }
-@keyframes fadeIn { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+.pane.active { display: block; animation: fadeIn 280ms cubic-bezier(0.4, 0, 0.2, 1); }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 
-.section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 14px; gap: 12px; flex-wrap: wrap; }
-.section-header h2 { display: flex; align-items: center; gap: 10px; }
+.section-header { display: flex; align-items: baseline; justify-content: space-between; margin: 32px 0 16px; gap: 12px; flex-wrap: wrap; }
+.section-header h2 { display: flex; align-items: center; gap: 12px; }
 .section-sub { color: var(--fg-dim); font-size: 13px; }
 
 /* Cards */
@@ -240,220 +293,327 @@ main { padding: 24px; max-width: 1280px; margin: 0 auto; }
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  padding: 20px;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  padding: 22px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   box-shadow: var(--shadow-sm);
-  transition: var(--transition);
 }
-.card.hero {
-  background: linear-gradient(135deg, rgba(139, 92, 255, 0.12), rgba(180, 135, 255, 0.05));
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-glow);
-}
-.card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
-.card-head h3 { color: var(--fg); text-transform: none; letter-spacing: -0.01em; font-size: 15px; }
-.card-eyebrow { font-size: 11px; color: var(--accent-2); text-transform: uppercase; letter-spacing: 0.1em; font-weight: 600; margin-bottom: 4px; }
 
-/* Status grid (compact) */
+/* ============ MISSION HERO ============ */
+.mission-hero {
+  position: relative;
+  padding: 36px 40px;
+  background:
+    radial-gradient(ellipse at 0% 0%, rgba(139, 92, 255, 0.18), transparent 50%),
+    radial-gradient(ellipse at 100% 100%, rgba(180, 135, 255, 0.12), transparent 50%),
+    var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-2xl);
+  box-shadow: var(--shadow-glow);
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+.mission-hero::before {
+  content: ""; position: absolute; top: -100px; right: -100px;
+  width: 400px; height: 400px;
+  background: radial-gradient(circle, var(--accent-glow), transparent 70%);
+  filter: blur(40px); opacity: 0.6;
+  pointer-events: none;
+}
+.mission-hero::after {
+  content: ""; position: absolute; bottom: -150px; left: -50px;
+  width: 350px; height: 350px;
+  background: radial-gradient(circle, rgba(180, 135, 255, 0.4), transparent 70%);
+  filter: blur(50px); opacity: 0.4;
+  pointer-events: none;
+}
+.mission-hero > * { position: relative; }
+
+.mission-eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 11px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--accent-2);
+  margin-bottom: 12px;
+}
+.mission-title {
+  font-size: 34px; font-weight: 700; letter-spacing: -0.03em;
+  background: linear-gradient(180deg, var(--fg) 0%, var(--accent-3) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.mission-subtitle {
+  font-size: 16px; color: var(--fg-dim);
+  margin-top: 8px;
+  max-width: 60ch;
+}
+
+.mission-cta-row {
+  display: flex; gap: 12px; align-items: center; flex-wrap: wrap;
+  margin-top: 28px;
+}
+.mission-cta-row .secondary-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+/* Mode selector */
+.mode-rail {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+.mode-card {
+  padding: 14px 16px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  cursor: pointer;
+  transition: all var(--t);
+  text-align: left;
+  display: flex; flex-direction: column; gap: 4px;
+  position: relative;
+}
+.mode-card:hover { border-color: var(--border-strong); background: var(--bg-2); transform: translateY(-2px); }
+.mode-card.active {
+  background: linear-gradient(135deg, var(--accent-soft), transparent);
+  border-color: var(--border-bright);
+  box-shadow: 0 0 0 1px var(--border-bright), 0 8px 24px var(--accent-glow);
+}
+.mode-card.active::after {
+  content: "✓"; position: absolute; top: 12px; right: 14px;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--accent); color: white;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 700;
+}
+.mode-card .mode-name { font-size: 13px; font-weight: 600; color: var(--fg); }
+.mode-card .mode-desc { font-size: 11px; color: var(--fg-dim); line-height: 1.4; }
+.mode-card.danger.active { border-color: rgba(251, 191, 36, 0.5); box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.3); }
+
+.mode-custom-input {
+  display: none; align-items: center; gap: 8px;
+  margin-top: 10px;
+  padding: 10px 14px;
+  background: var(--bg-1); border: 1px solid var(--border);
+  border-radius: var(--r-md);
+}
+.mode-custom-input.show { display: inline-flex; }
+.mode-custom-input input { width: 80px; padding: 6px 10px; }
+
+/* ============ MISSION PROGRESS ============ */
+.mission-progress {
+  margin-top: 24px;
+  padding: 20px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+}
+.mission-progress.hidden-step { display: none; }
+.mission-progress-head { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; align-items: center; }
+.mission-progress-status {
+  font-size: 14px; color: var(--fg);
+  display: flex; align-items: center; gap: 10px;
+}
+.mission-progress-bar {
+  position: relative; height: 6px;
+  background: var(--bg-3);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.mission-progress-fill {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  border-radius: 999px;
+  width: 0;
+  transition: width var(--t-slow);
+  box-shadow: 0 0 16px var(--accent-glow);
+}
+.mission-progress-fill.shimmer::after {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.4), transparent);
+  animation: shimmer 1.5s linear infinite;
+}
+@keyframes shimmer { 0% { transform: translateX(-100%); } 100% { transform: translateX(100%); } }
+
+.timeline {
+  display: flex; gap: 8px; margin-top: 16px;
+  list-style: none; padding: 0;
+  overflow-x: auto;
+}
+.timeline-step {
+  flex: 1; min-width: 80px;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-size: 11px;
+  display: flex; flex-direction: column; gap: 4px;
+  position: relative;
+  transition: all var(--t);
+}
+.timeline-step .step-num {
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: var(--bg-3);
+  color: var(--fg-mute);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 10px; font-weight: 700;
+}
+.timeline-step .step-name { color: var(--fg-dim); font-size: 11px; font-weight: 500; }
+.timeline-step.done { border-color: rgba(74, 222, 128, 0.3); background: var(--ok-soft); }
+.timeline-step.done .step-num { background: var(--ok); color: var(--bg); }
+.timeline-step.done .step-name { color: var(--ok); }
+.timeline-step.active { border-color: var(--border-bright); box-shadow: 0 0 0 1px var(--border-bright), 0 4px 16px var(--accent-glow); animation: stepPulse 2s ease-in-out infinite; }
+.timeline-step.active .step-num { background: var(--accent); color: white; }
+.timeline-step.active .step-name { color: var(--accent-2); }
+.timeline-step.failed { border-color: rgba(248, 113, 113, 0.3); background: var(--danger-soft); }
+.timeline-step.failed .step-num { background: var(--danger); color: var(--bg); }
+.timeline-step.failed .step-name { color: var(--danger); }
+@keyframes stepPulse {
+  0%, 100% { box-shadow: 0 0 0 1px var(--border-bright), 0 4px 16px var(--accent-glow); }
+  50% { box-shadow: 0 0 0 1px var(--border-bright), 0 8px 28px var(--accent-glow); }
+}
+
+/* ============ FULL AUTOPILOT CHECKLIST ============ */
+.checklist {
+  list-style: none; padding: 0; margin: 16px 0 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.checklist-item {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  transition: all var(--t);
+}
+.checklist-item:hover { border-color: var(--border-strong); }
+.checklist-item .check-icon {
+  width: 24px; height: 24px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 700;
+  flex-shrink: 0;
+}
+.checklist-item.ready .check-icon { background: var(--ok-soft); color: var(--ok); border: 1px solid var(--ok); }
+.checklist-item.ready .check-icon::after { content: "✓"; }
+.checklist-item.optional .check-icon { background: var(--info-soft); color: var(--info); border: 1px solid var(--info); }
+.checklist-item.optional .check-icon::after { content: "○"; }
+.checklist-item.missing .check-icon { background: var(--bg-3); color: var(--fg-mute); border: 1px solid var(--border); }
+.checklist-item.missing .check-icon::after { content: "—"; }
+.checklist-item.blocked .check-icon { background: var(--danger-soft); color: var(--danger); border: 1px solid var(--danger); }
+.checklist-item.blocked .check-icon::after { content: "✕"; }
+.checklist-item .check-body { flex: 1; min-width: 0; }
+.checklist-item .check-label { font-size: 13px; font-weight: 600; color: var(--fg); }
+.checklist-item .check-detail { font-size: 11px; color: var(--fg-dim); margin-top: 2px; }
+.checklist-item button { font-size: 11px; padding: 6px 12px; }
+
+/* ============ TASK CARDS ============ */
+.task-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+}
+.task-card {
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  transition: all var(--t);
+  display: flex; flex-direction: column; gap: 8px;
+  cursor: pointer;
+}
+.task-card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+.task-card.next { border-color: var(--border-bright); box-shadow: 0 0 0 1px var(--border-bright), 0 8px 24px var(--accent-glow); background: linear-gradient(135deg, var(--accent-soft), var(--surface)); }
+.task-card.blocked { opacity: 0.7; }
+.task-card-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.task-num { font-size: 11px; color: var(--accent-2); font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; }
+.task-score { font-size: 11px; color: var(--fg-mute); }
+.task-title { font-size: 14px; font-weight: 600; color: var(--fg); line-height: 1.3; }
+.task-meta { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+.task-tag { font-size: 10px; padding: 2px 8px; border-radius: 999px; background: var(--bg-2); color: var(--fg-dim); border: 1px solid var(--border); text-transform: lowercase; }
+.task-tag.safe { color: var(--ok); border-color: rgba(74, 222, 128, 0.3); background: var(--ok-soft); }
+.task-tag.risk { color: var(--warn); border-color: rgba(251, 191, 36, 0.3); background: var(--warn-soft); }
+.task-tag.blocked { color: var(--danger); border-color: rgba(248, 113, 113, 0.3); background: var(--danger-soft); }
+.task-reason { font-size: 11px; color: var(--fg-dim); line-height: 1.4; margin-top: 4px; }
+.task-actions { display: flex; gap: 6px; margin-top: 6px; }
+.task-actions button { font-size: 11px; padding: 6px 10px; }
+
+/* ============ STATUS GRID ============ */
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 10px;
+  gap: 8px;
   list-style: none;
   padding: 0; margin: 0;
 }
 .status-pill {
   display: flex; align-items: center; gap: 10px;
-  padding: 10px 12px;
+  padding: 10px 14px;
   background: var(--bg-1);
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   font-size: 12px;
 }
-.status-pill .label { color: var(--fg-dim); flex: 1; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+.status-pill .label { color: var(--fg-dim); flex: 1; font-size: 11px; }
 .status-pill .value { color: var(--fg); font-weight: 600; font-size: 12px; }
-.status-pill.ok { border-color: rgba(74, 222, 128, 0.3); }
-.status-pill.warn { border-color: rgba(251, 191, 36, 0.3); }
-.status-pill.err { border-color: rgba(248, 113, 113, 0.3); }
-.status-pill.ok .dot { background: var(--ok); }
-.status-pill.warn .dot { background: var(--warn); }
-.status-pill.err .dot { background: var(--danger); }
+.status-pill.ok { border-color: rgba(74, 222, 128, 0.2); }
+.status-pill.warn { border-color: rgba(251, 191, 36, 0.2); }
+.status-pill.err { border-color: rgba(248, 113, 113, 0.2); }
+.status-pill.info { border-color: rgba(96, 165, 250, 0.2); }
 
-/* Hero metrics */
-.metric {
-  display: flex; flex-direction: column; gap: 4px;
-  padding: 14px 16px;
+/* ============ LOG DRAWER ============ */
+.log-summary {
+  padding: 16px 20px;
   background: var(--bg-1);
   border: 1px solid var(--border);
-  border-radius: var(--r-md);
-}
-.metric .label { font-size: 11px; color: var(--fg-dim); text-transform: uppercase; letter-spacing: 0.06em; }
-.metric .value { font-size: 22px; font-weight: 700; color: var(--fg); letter-spacing: -0.02em; }
-.metric .sub { font-size: 11px; color: var(--fg-mute); }
-.metric.ok .value { color: var(--ok); }
-.metric.warn .value { color: var(--warn); }
-.metric.err .value { color: var(--danger); }
-
-/* Auth panel */
-.auth-panel {
-  position: fixed; inset: 0;
-  background: rgba(7, 6, 12, 0.85);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  display: flex; align-items: center; justify-content: center;
-  z-index: 100; padding: 16px;
-}
-.auth-panel.hidden { display: none !important; }
-.auth-card {
-  background: var(--surface-strong);
-  border: 1px solid var(--border-strong);
   border-radius: var(--r-lg);
-  padding: 28px;
-  max-width: 460px; width: 100%;
-  box-shadow: var(--shadow-md), var(--shadow-glow);
+  display: flex; flex-direction: column; gap: 6px;
 }
-.auth-card h2 { margin-bottom: 8px; font-size: 18px; }
-.auth-card form { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; }
-.auth-card input { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 13px; }
-.auth-card .actions { display: flex; gap: 8px; }
-.auth-card .actions button { flex: 1; }
+.log-summary-row { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.log-summary-row .label { color: var(--fg-dim); width: 80px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+.log-summary-row .value { color: var(--fg); flex: 1; font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.log-summary-row.empty .value { color: var(--fg-mute); font-family: inherit; font-style: italic; }
 
-/* Autopilot hero */
-.autopilot-hero { padding: 28px; }
-.autopilot-hero .head {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: 12px; margin-bottom: 16px; flex-wrap: wrap;
-}
-.autopilot-hero .head h2 {
-  font-size: 22px; letter-spacing: -0.02em;
-  display: flex; align-items: center; gap: 12px;
-}
-.autopilot-hero .head h2::before {
-  content: ""; width: 8px; height: 8px;
-  border-radius: 50%; background: var(--accent);
-  box-shadow: 0 0 12px var(--accent-glow);
-}
-.autopilot-hero p.lead { color: var(--fg-dim); font-size: 14px; max-width: 60ch; margin-bottom: 18px; }
-.autopilot-cta {
-  display: flex; gap: 10px; flex-wrap: wrap; align-items: center;
-  margin-bottom: 18px;
-}
-.autopilot-cta .issue-input {
-  background: var(--bg-1); border: 1px solid var(--border);
-  padding: 6px 12px; border-radius: var(--r-md);
-  display: inline-flex; align-items: center; gap: 8px;
-  font-size: 12px; color: var(--fg-dim);
-}
-.autopilot-cta .issue-input input {
-  background: transparent; border: 0; padding: 4px 0;
-  width: 80px; color: var(--fg); font-weight: 600;
-}
-.autopilot-cta .issue-input input:focus { outline: none; }
-.autopilot-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 10px;
-  list-style: none; padding: 0; margin: 0;
-}
-.autopilot-meta li {
-  background: var(--bg-1); border: 1px solid var(--border);
-  border-radius: var(--r-md); padding: 10px 12px;
-}
-.autopilot-meta .label { font-size: 10px; color: var(--fg-dim); text-transform: uppercase; letter-spacing: 0.06em; display: block; margin-bottom: 4px; }
-.autopilot-meta .value { font-weight: 600; font-size: 13px; color: var(--fg); }
-.autopilot-prompt {
-  background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  padding: 14px;
-  font-family: "SF Mono", ui-monospace, Menlo, monospace;
-  font-size: 12px;
-  white-space: pre-wrap; word-break: break-word;
-  max-height: 260px; overflow: auto;
-  margin-top: 16px;
-}
-
-.blocker-banner {
-  display: flex; align-items: flex-start; gap: 10px;
-  padding: 12px 14px;
-  background: var(--warn-soft);
-  border: 1px solid var(--warn);
-  border-radius: var(--r-md);
-  margin-bottom: 16px;
-  color: var(--warn);
-  font-size: 13px;
-}
-.blocker-banner.danger { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
-.blocker-banner ul { margin: 6px 0 0; padding-left: 20px; }
-.blocker-banner strong { color: var(--fg); }
-
-/* Workflow steps */
-.workflow {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 14px;
-}
-.step-card {
-  position: relative;
-  padding: 18px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  display: flex; flex-direction: column; gap: 8px;
-  min-height: 140px;
-}
-.step-card .step-num {
-  position: absolute; top: 14px; right: 14px;
-  width: 24px; height: 24px;
-  border-radius: 50%;
-  background: var(--accent-soft);
-  border: 1px solid var(--border-strong);
-  color: var(--accent-2);
-  font-size: 11px; font-weight: 700;
-  display: flex; align-items: center; justify-content: center;
-}
-.step-card h3 { color: var(--fg); text-transform: none; letter-spacing: -0.01em; font-size: 14px; }
-.step-card p { font-size: 12px; color: var(--fg-dim); }
-.step-card .step-actions { margin-top: auto; display: flex; gap: 6px; flex-wrap: wrap; }
-
-/* Tasks table */
-.tasks-toolbar { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
-.tasks-toolbar input, .tasks-toolbar select { flex: 1; min-width: 140px; }
-.table-wrap {
+.log-drawer {
+  margin-top: 12px;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
   overflow: hidden;
+  transition: all var(--t-slow);
 }
-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-th, td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border); }
-th { background: var(--bg-1); color: var(--fg-dim); font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
-tbody tr { transition: var(--transition); }
-tbody tr:hover { background: rgba(139, 92, 255, 0.06); }
-tbody tr:last-child td { border-bottom: 0; }
-tr.task-blocked { opacity: 0.55; }
-
-.task-reason-safe { color: var(--ok); font-size: 12px; }
-.task-reason-blocked { color: var(--danger); font-size: 12px; }
-.task-card-mobile { display: none; }
-
-/* Logs */
-.logs-toolbar {
-  display: flex; gap: 8px; margin-bottom: 10px; align-items: center; flex-wrap: wrap;
-  padding: 10px 12px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
+.log-drawer-toggle {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: 0; cursor: pointer;
+  color: var(--fg-dim);
+  font-size: 12px;
+  text-align: left;
 }
-.logs-toolbar select { flex: 1; min-width: 180px; }
+.log-drawer-toggle:hover { background: rgba(255, 255, 255, 0.03); }
+.log-drawer-toggle .arrow { display: inline-block; transition: transform var(--t); }
+.log-drawer.open .log-drawer-toggle .arrow { transform: rotate(90deg); }
+.log-drawer-body { display: none; padding: 16px; border-top: 1px solid var(--border); }
+.log-drawer.open .log-drawer-body { display: block; animation: fadeIn 200ms ease; }
+
+.log-drawer-toolbar { display: flex; gap: 6px; align-items: center; margin-bottom: 10px; flex-wrap: wrap; }
+.log-drawer-toolbar select { font-size: 11px; padding: 6px 10px; }
+.log-drawer-toolbar button { font-size: 11px; padding: 6px 12px; }
+
 .log-view {
   background: #050308;
   color: #d4d2ec;
   border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: 16px;
-  max-height: 60vh;
+  border-radius: var(--r-md);
+  padding: 14px;
+  max-height: 50vh;
   overflow: auto;
   font-family: "SF Mono", ui-monospace, Menlo, monospace;
   font-size: 12px;
@@ -465,135 +625,177 @@ tr.task-blocked { opacity: 0.55; }
 .log-line.error { color: var(--danger); }
 .log-line.warn { color: var(--warn); }
 .log-line.ok { color: var(--ok); }
-.log-group-count { color: var(--accent-2); font-weight: 600; }
-.run-id-tag { color: var(--accent-2); font-size: 11px; margin-left: 8px; opacity: 0.7; }
 
-/* Questions */
-.question {
+/* ============ SETTINGS ============ */
+.settings-nav {
+  display: flex; gap: 4px; flex-wrap: wrap;
+  margin-bottom: 20px;
+  background: var(--bg-1);
+  padding: 4px;
+  border-radius: var(--r-md);
+  border: 1px solid var(--border);
+}
+.settings-nav button {
+  background: transparent; border: 0; padding: 7px 14px;
+  color: var(--fg-dim); font-size: 12px; font-weight: 500;
+  border-radius: var(--r-sm);
+  transform: none !important;
+}
+.settings-nav button.active { background: var(--accent-soft); color: var(--fg); }
+
+.settings-section {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
-  padding: 18px;
-  margin-bottom: 12px;
+  padding: 22px;
+  margin-bottom: 14px;
+  display: none;
 }
-.question h4 { margin-bottom: 4px; font-size: 14px; }
-.question .options { display: flex; gap: 6px; flex-wrap: wrap; margin: 10px 0; }
-.question textarea { min-height: 80px; }
+.settings-section.active { display: block; animation: fadeIn 220ms ease; }
+.settings-section h3 { color: var(--fg); text-transform: none; letter-spacing: -0.01em; font-size: 16px; margin-bottom: 4px; }
+.settings-section .group-sub { font-size: 12px; color: var(--fg-dim); margin-bottom: 16px; }
+.settings-section.danger { border-color: rgba(248, 113, 113, 0.3); }
+.settings-section.power { border-color: var(--border-bright); background: linear-gradient(135deg, var(--accent-soft), var(--surface)); }
 
-/* Settings groups */
-.settings-group {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  padding: 20px;
-  margin-bottom: 16px;
-}
-.settings-group h3 { color: var(--fg); text-transform: none; letter-spacing: -0.01em; font-size: 14px; margin-bottom: 4px; }
-.settings-group .group-sub { font-size: 12px; color: var(--fg-dim); margin-bottom: 14px; }
-.settings-group.danger { border-color: rgba(248, 113, 113, 0.3); }
-.settings-rows {
-  display: flex; flex-direction: column; gap: 14px;
-}
+.settings-rows { display: flex; flex-direction: column; gap: 12px; }
 .settings-row {
   display: flex; align-items: flex-start; justify-content: space-between; gap: 16px;
-  padding: 12px 14px; background: var(--bg-1); border-radius: var(--r-md);
+  padding: 14px 16px;
+  background: var(--bg-1);
+  border-radius: var(--r-md);
   border: 1px solid var(--border);
+  transition: border-color var(--t);
 }
+.settings-row:hover { border-color: var(--border-strong); }
 .settings-row .info { flex: 1; }
 .settings-row .info strong { display: block; font-size: 13px; color: var(--fg); margin-bottom: 2px; }
-.settings-row .info span { font-size: 11px; color: var(--fg-dim); }
+.settings-row .info span { font-size: 11px; color: var(--fg-dim); line-height: 1.4; }
 .settings-row .control { display: flex; align-items: center; gap: 8px; }
 .settings-row input[type="number"], .settings-row input[type="text"] { width: 110px; }
+
 .toggle {
-  position: relative; width: 40px; height: 22px;
+  position: relative; width: 44px; height: 24px;
   background: var(--bg-3);
   border-radius: 999px;
   cursor: pointer;
-  transition: var(--transition);
+  transition: all var(--t);
   border: 1px solid var(--border);
+  flex-shrink: 0;
 }
 .toggle input { position: absolute; opacity: 0; }
 .toggle::after {
   content: ""; position: absolute; top: 2px; left: 2px;
-  width: 16px; height: 16px;
+  width: 18px; height: 18px;
   background: var(--fg-dim);
   border-radius: 50%;
-  transition: var(--transition);
+  transition: all var(--t);
 }
 .toggle.on { background: var(--accent-soft); border-color: var(--accent); }
-.toggle.on::after { transform: translateX(18px); background: var(--accent); }
-.toggle.danger.on { background: var(--danger-soft); border-color: var(--danger); }
-.toggle.danger.on::after { background: var(--danger); }
+.toggle.on::after { transform: translateX(20px); background: var(--accent); box-shadow: 0 0 12px var(--accent-glow); }
+.toggle.power.on { background: rgba(180, 135, 255, 0.18); border-color: var(--accent-2); }
+.toggle.power.on::after { background: var(--accent-2); }
 
-/* Confirm dialog */
-dialog {
-  background: var(--surface-strong);
-  color: var(--fg);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--r-lg);
-  padding: 24px;
-  max-width: 460px;
-  box-shadow: var(--shadow-md);
+/* ============ AUTH PANEL ============ */
+.auth-panel {
+  position: fixed; inset: 0;
+  background: rgba(7, 5, 14, 0.85);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100; padding: 16px;
 }
-dialog::backdrop { background: rgba(7, 6, 12, 0.7); backdrop-filter: blur(6px); }
-dialog h3 { margin-bottom: 8px; font-size: 16px; color: var(--fg); text-transform: none; letter-spacing: -0.01em; }
-dialog menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; margin: 16px 0 0; }
-dialog input { width: 100%; margin-top: 12px; }
-
-/* Toast */
-.toast {
-  position: fixed; bottom: 24px; right: 24px;
+.auth-panel.hidden { display: none !important; }
+.auth-card {
   background: var(--surface-strong);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--r-2xl);
+  padding: 32px;
+  max-width: 480px; width: 100%;
+  box-shadow: var(--shadow-glow-strong);
+  animation: fadeIn 280ms ease;
+}
+.auth-card h2 { margin-bottom: 8px; font-size: 22px; }
+.auth-card form { display: flex; flex-direction: column; gap: 12px; margin-top: 20px; }
+.auth-card input { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 13px; }
+.auth-card .actions { display: flex; gap: 8px; }
+.auth-card .actions button { flex: 1; }
+
+/* ============ TOAST ============ */
+#toast-host { position: fixed; bottom: 24px; right: 24px; display: flex; flex-direction: column; gap: 8px; z-index: 200; }
+.toast {
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
   border-radius: var(--r-md);
-  padding: 12px 16px;
+  padding: 12px 18px;
   font-size: 13px;
   color: var(--fg);
   box-shadow: var(--shadow-md);
-  z-index: 200;
-  animation: slideIn 200ms ease;
+  animation: slideIn 220ms cubic-bezier(0.4, 0, 0.2, 1);
   max-width: 360px;
+  display: flex; align-items: center; gap: 10px;
 }
 .toast.ok { border-color: var(--ok); color: var(--ok); }
 .toast.err { border-color: var(--danger); color: var(--danger); }
 .toast.warn { border-color: var(--warn); color: var(--warn); }
-@keyframes slideIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+.toast.info { border-color: var(--info); color: var(--info); }
+@keyframes slideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: none; } }
 
-/* Mobile */
+/* ============ DIALOG ============ */
+dialog {
+  background: var(--surface-strong);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-xl);
+  padding: 28px;
+  max-width: 480px;
+  box-shadow: var(--shadow-md);
+}
+dialog::backdrop { background: rgba(7, 5, 14, 0.7); backdrop-filter: blur(8px); }
+dialog h3 { margin-bottom: 8px; font-size: 17px; color: var(--fg); text-transform: none; letter-spacing: -0.01em; }
+dialog menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; margin: 18px 0 0; }
+dialog input { width: 100%; margin-top: 12px; }
+
+/* ============ BLOCKER BANNER ============ */
+.blocker-banner {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 14px 16px;
+  background: var(--warn-soft);
+  border: 1px solid var(--warn);
+  border-radius: var(--r-md);
+  margin-top: 16px;
+  color: var(--warn);
+  font-size: 13px;
+  animation: fadeIn 220ms ease;
+}
+.blocker-banner.danger { background: var(--danger-soft); border-color: var(--danger); color: var(--danger); }
+.blocker-banner.info { background: var(--info-soft); border-color: var(--info); color: var(--info); }
+.blocker-banner ul { margin: 6px 0 0; padding-left: 20px; }
+.blocker-banner strong { color: var(--fg); }
+
+/* ============ MOBILE ============ */
 @media (max-width: 820px) {
-  main { padding: 14px; }
-  .topbar { padding: 10px 14px; gap: 10px; }
-  .tabs { order: 3; width: 100%; flex: 1; }
-  .tabs button { flex: 1; padding: 8px 10px; font-size: 12px; }
+  main { padding: 16px 14px; }
+  .topbar { padding: 12px 14px; gap: 10px; flex-wrap: wrap; }
+  .tabs { order: 3; max-width: none; width: 100%; }
+  .tabs button { padding: 7px 8px; font-size: 12px; }
   .brand .tag { display: none; }
-  h1 { font-size: 18px; }
-  .autopilot-hero { padding: 20px; }
-  .autopilot-hero .head h2 { font-size: 18px; }
-  .autopilot-cta button.big { width: 100%; }
-  .autopilot-cta .issue-input { width: 100%; }
-  .autopilot-cta .issue-input input { flex: 1; width: auto; }
-  .workflow { grid-template-columns: 1fr; }
-  /* tasks: card layout on mobile */
-  .table-wrap { background: transparent; border: 0; border-radius: 0; }
-  table thead { display: none; }
-  table, tbody, tr, td { display: block; width: 100%; }
-  table tr {
-    background: var(--surface); border: 1px solid var(--border);
-    border-radius: var(--r-md); padding: 12px; margin-bottom: 10px;
-  }
-  table td { padding: 4px 0; border: 0; font-size: 13px; }
-  table td::before {
-    content: attr(data-label);
-    display: inline-block; width: 90px;
-    color: var(--fg-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em;
-  }
+  .mission-hero { padding: 24px 22px; }
+  .mission-title { font-size: 26px; }
+  .mission-cta-row .secondary-actions { width: 100%; }
+  .mission-cta-row button.huge { width: 100%; }
+  .mode-rail { grid-template-columns: 1fr; }
+  .task-board { grid-template-columns: 1fr; }
+  .timeline { overflow-x: auto; }
   .settings-row { flex-direction: column; align-items: stretch; }
   .settings-row .control { justify-content: flex-end; }
-  button { padding: 11px 16px; font-size: 14px; min-height: 44px; }
-  .toast { left: 14px; right: 14px; bottom: 14px; max-width: none; }
+  button { padding: 12px 16px; font-size: 14px; min-height: 44px; }
+  #toast-host { left: 14px; right: 14px; bottom: 14px; }
+  .toast { max-width: none; }
 }
 
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }
+  .orb.running { animation: none; }
+  .timeline-step.active { animation: none; }
 }

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -450,6 +450,33 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       } catch (e) { return send(res, 200, { configured: true, ok: false, reason: e.message }); }
     }
 
+    if (method === 'GET' && path === '/api/v5/full-readiness') {
+      const s = settings.get();
+      const { values: env } = loadV5Env(repoRoot);
+      const claude = v5StatusFromEnv({ env, repoRoot });
+      const notionCfg = evaluateNotionConfig(env);
+      const n8nCfg = evaluateN8nConfig(env);
+      const whatsappCfg = evaluateWhatsappConfig(env);
+      const items = [
+        { id: 'claude', label: 'Claude CLI', kind: 'required', status: claude.claudeAvailable ? 'ready' : 'missing', detail: claude.claudeAvailable ? (claude.claudeVersion || 'available') : (claude.claudeReason || 'not available'), action: claude.claudeAvailable ? null : 'install-claude' },
+        { id: 'protection', label: 'Branch protection', kind: 'required', status: 'unknown', detail: 'check via doctor', action: 'run-doctor' },
+        { id: 'allowExec', label: 'Exec allowed', kind: 'required', status: s.allowExec ? 'ready' : 'missing', detail: s.allowExec ? 'autorisé' : 'flippe le toggle Exec dans Settings', action: 'open-settings-safety' },
+        { id: 'allowLoop', label: 'Loop allowed', kind: 'required', status: s.allowLoop ? 'ready' : 'missing', detail: s.allowLoop ? 'autorisé' : 'flippe le toggle Loop dans Settings', action: 'open-settings-safety' },
+        { id: 'allowAutoMerge', label: 'Auto-merge (Power mode)', kind: 'optional', status: s.allowAutoMerge ? 'ready' : 'optional', detail: s.allowAutoMerge ? 'ENABLED' : 'optionnel — laisser OFF par défaut', action: 'open-settings-safety' },
+        { id: 'guard', label: 'Task guard', kind: 'required', status: 'unknown', detail: 'check via doctor', action: 'run-doctor' },
+        { id: 'notion', label: 'Notion', kind: 'optional', status: notionCfg.configured ? 'ready' : 'optional', detail: notionCfg.summary, action: notionCfg.configured ? null : 'open-settings-integrations' },
+        { id: 'n8n', label: 'n8n webhooks', kind: 'optional', status: n8nCfg.questionWebhookConfigured && n8nCfg.answerWebhookConfigured ? 'ready' : 'optional', detail: n8nCfg.summary, action: 'open-settings-integrations' },
+        { id: 'whatsapp', label: 'WhatsApp', kind: 'optional', status: whatsappCfg.configured ? 'ready' : 'optional', detail: whatsappCfg.configured ? `via ${whatsappCfg.via ?? 'on'}` : 'optionnel — notifications mobile', action: 'open-settings-integrations' },
+      ];
+      const requiredMissing = items.filter((i) => i.kind === 'required' && i.status !== 'ready' && i.status !== 'unknown');
+      return send(res, 200, {
+        items,
+        requiredMissingCount: requiredMissing.length,
+        ready: requiredMissing.length === 0,
+        summary: requiredMissing.length === 0 ? 'Full autopilot ready' : `${requiredMissing.length} required item(s) missing`,
+      });
+    }
+
     if (method === 'POST' && path === '/api/autopilot/start') {
       let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
       const mode = ['plan', 'exec', 'loop'].includes(body?.mode) ? body.mode : 'plan';

--- a/tools/local-control/settings.mjs
+++ b/tools/local-control/settings.mjs
@@ -18,7 +18,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
 });
 
 const VALIDATORS = {
-  maxPrsPerRun: (v) => Number.isInteger(v) && v >= 1 && v <= 10,
+  maxPrsPerRun: (v) => Number.isInteger(v) && v >= 1 && v <= 20,
   maxMinutes: (v) => Number.isInteger(v) && v >= 1 && v <= 240,
   maxErrors: (v) => Number.isInteger(v) && v >= 1 && v <= 20,
   dryRunDefault: (v) => typeof v === 'boolean',

--- a/tools/local-control/tests/mission.test.mjs
+++ b/tools/local-control/tests/mission.test.mjs
@@ -1,0 +1,133 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { MISSION_MODES, DEFAULT_MODE_ID, findMode, buildMissionState } from '../public/lib/mission.js';
+
+test('MISSION_MODES includes all 7 modes', () => {
+  const ids = MISSION_MODES.map((m) => m.id).sort();
+  assert.deepEqual(ids, ['auto1', 'auto5', 'custom', 'full', 'loop10', 'loop20', 'manual']);
+});
+
+test('DEFAULT_MODE_ID is auto5', () => {
+  assert.equal(DEFAULT_MODE_ID, 'auto5');
+});
+
+test('findMode returns default when id unknown', () => {
+  assert.equal(findMode('not-a-mode').id, 'auto5');
+});
+
+test('findMode("manual") does not require exec', () => {
+  const m = findMode('manual');
+  assert.equal(m.requiresExec, false);
+});
+
+test('findMode("auto5") requires exec and loop', () => {
+  const m = findMode('auto5');
+  assert.equal(m.requiresExec, true);
+  assert.equal(m.requiresLoop, true);
+  assert.equal(m.maxPrs, 5);
+});
+
+test('findMode("loop20") has 20 PRs cap', () => {
+  assert.equal(findMode('loop20').maxPrs, 20);
+});
+
+test('buildMissionState reports blockers when exec missing for auto5', () => {
+  const s = buildMissionState({
+    mode: 'auto5',
+    settings: { allowExec: false, allowLoop: false },
+    v5: { claudeAvailable: true },
+    ap: null,
+  });
+  assert.ok(s.blockers.find((b) => b.text.includes('Exec disabled')));
+  assert.ok(s.blockers.find((b) => b.text.includes('Loop disabled')));
+});
+
+test('buildMissionState ready text for auto5 when settings ok', () => {
+  const s = buildMissionState({
+    mode: 'auto5',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: null,
+  });
+  assert.equal(s.blockers.length, 0);
+  assert.match(s.title, /Ready to run 5 safe tasks/);
+});
+
+test('buildMissionState shows manual prompt title for manual mode', () => {
+  const s = buildMissionState({
+    mode: 'manual',
+    settings: { allowExec: false },
+    v5: { claudeAvailable: true },
+    ap: null,
+  });
+  assert.match(s.title, /Manual prompt/);
+  assert.match(s.ctaLabel, /Generate prompt/);
+});
+
+test('buildMissionState reflects waiting state', () => {
+  const s = buildMissionState({
+    mode: 'auto5',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: { status: 'waiting', pendingQuestionId: 'q-7' },
+  });
+  assert.match(s.title, /Décision humaine/);
+  assert.equal(s.orbClass, 'warn');
+  assert.equal(s.ctaLabel, 'Resume');
+});
+
+test('buildMissionState reflects running state with issue', () => {
+  const s = buildMissionState({
+    mode: 'auto5',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: { status: 'running', issue: 41, currentStep: 'launching-claude' },
+  });
+  assert.match(s.title, /#41/);
+  assert.equal(s.orbClass, 'running');
+  assert.equal(s.ctaDisabled, true);
+});
+
+test('buildMissionState shows completed PR count', () => {
+  const s = buildMissionState({
+    mode: 'auto5',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: { status: 'completed', prsCreated: 3, lastPR: { number: 42, url: 'http://x/42' } },
+  });
+  assert.match(s.title, /3 PR/);
+  assert.equal(s.ctaLabel, 'Review PR');
+});
+
+test('buildMissionState full mode triggers checklist message when readiness not ready', () => {
+  const s = buildMissionState({
+    mode: 'full',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: null,
+    fullReadiness: { ready: false, summary: '2 required item(s) missing' },
+  });
+  assert.ok(s.blockers.length);
+  assert.match(s.subtitle, /checklist|Coche/);
+});
+
+test('buildMissionState custom mode honours customMax', () => {
+  const s = buildMissionState({
+    mode: 'custom',
+    settings: { allowExec: true, allowLoop: true },
+    v5: { claudeAvailable: true },
+    ap: null,
+    customMax: 12,
+  });
+  assert.match(s.title, /12 safe tasks/);
+});
+
+test('buildMissionState claude missing → danger blocker', () => {
+  const s = buildMissionState({
+    mode: 'auto1',
+    settings: { allowExec: true, allowLoop: false },
+    v5: { claudeAvailable: false, claudeReason: 'not in PATH' },
+    ap: null,
+  });
+  assert.ok(s.blockers.find((b) => b.kind === 'danger'));
+});

--- a/tools/local-control/v5-server.test.mjs
+++ b/tools/local-control/v5-server.test.mjs
@@ -194,3 +194,18 @@ test('GET /api/tasks/best returns 200 with structured payload', async () => {
     assert.ok('ok' in r.data);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+test('GET /api/v5/full-readiness lists items with statuses', async () => {
+  const root = tmpRepo();
+  writeFileSync(join(root, '.local-control', 'v5.env'), 'CLAUDE_CODE_COMMAND=yu\n');
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/v5/full-readiness', { token: tok });
+    assert.equal(r.status, 200);
+    assert.ok(Array.isArray(r.data.items));
+    assert.ok(r.data.items.find((i) => i.id === 'allowExec'));
+    assert.ok(r.data.items.find((i) => i.id === 'notion'));
+    assert.equal(typeof r.data.requiredMissingCount, 'number');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Résumé du redesign

Le cockpit local-control est entièrement refait en **Mission Control** premium violet/noir. L'idée centrale : tout l'écran d'accueil tourne autour d'**un bouton et un mode**.

## Choix visuels

- **Palette** violet/noir/anthracite avec 4 teintes de surface, 3 nuances d'accent, 4 couleurs d'état (vert ready, violet running, bleu info, rouge danger réel, jaune warn).
- **Hero** avec gradient violet + glow animé + status orb pulsant.
- **Cartes** glass (`backdrop-filter: blur`) sur fond sombre, ombres profondes, bordures fines.
- **Toggles** custom violet (Power mode pour auto-merge, pas rouge par défaut).
- **Boutons primary** en gradient avec shimmer au hover.
- **Animations** sobres : orb pulse, progress shimmer, timeline step pulse, fade in panes, slide in toasts. Respecte `prefers-reduced-motion`.
- **Typographie** denser, ss01/cv11, h1 avec gradient text.

## Nouvelle navigation

Réduit de 7 onglets à **3 sections** :

1. **Mission** — Hero + mode rail + progress + checklist + next task + activity + status grid
2. **Workspace** — Doctor + task board (cards) + questions
3. **Settings** — 6 sous-sections (Mission mode / Safety / Integrations / Mobile / Advanced / Danger zone) avec side nav

## Modes disponibles

| Mode | Effet | Settings requis |
|---|---|---|
| Manual prompt | génère prompt à coller dans yu | aucun |
| Auto · 1 task | une PR puis stop | allowExec |
| **Auto · 5 tasks** (défaut) | loop jusqu'à 5 PR | allowExec + allowLoop |
| Loop · 10 tasks | loop intensif | allowExec + allowLoop |
| Loop · 20 tasks | loop max | allowExec + allowLoop |
| Custom loop | choix du budget | allowExec + allowLoop |
| Full autopilot | vérifie checklist complète | tout dont auto-merge |

## Full autopilot checklist

Quand on choisit **Full autopilot**, une carte Readiness apparaît avec 9 items :
- Claude CLI · required
- Branch protection · required
- Exec allowed · required
- Loop allowed · required
- Power mode · auto-merge · optional
- Task guard · required
- Notion · optional (bleu si manquant, pas rouge)
- n8n webhooks · optional
- WhatsApp · optional

Chaque item a un statut explicite (`ready` / `missing` / `optional` / `blocked`) + un bouton **Configure** qui ouvre directement la bonne section de Settings.

## Tests

- **146 backend** (était 137) — +1 server test pour `/api/v5/full-readiness`.
- **83 UI** (était 68) — +15 mission state tests.
- 76 task-tooling toujours verts.
- typecheck / lint / test / build verts.
- Smoke live confirmé : HTML 22693 octets, `/api/v5/full-readiness` retourne 9 items avec statuses précis, `/api/tasks/best` retourne #41, status grid affiche les bons orbs.

## Test plan

- [ ] `pnpm cockpit` → page Mission Control charge avec hero violet animé.
- [ ] Mode rail interactif : cliquer un mode change titre + sous-titre + CTA.
- [ ] Sélectionner **Full autopilot** → checklist apparaît avec items colorés.
- [ ] Settings → 6 sections avec side nav, toggle Power (auto-merge) violet pas rouge.
- [ ] Sur mobile (resize 400px) : mode cards en colonne, hero responsive, tabs en bas.
- [ ] Activer un autopilot → progress bar + timeline animées en live.
- [ ] Drawer logs : ouverture smooth, filter dropdown, copy/clear.

## Sécurité

Aucune régression :
- Auth token toujours requise.
- Auto-merge OFF par défaut, gates strictes inchangées.
- `.claude/` jamais touché. `.local-control/` gitignored.
- Aucun secret loggé.
- Pas de force-push, pas de --admin, pas de push direct main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)