### PR TITLE
feat(cockpit): final premium polish

### DIFF
--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -138,6 +138,8 @@ function openChecklistAction(action) {
   if (action === "open-settings-safety") return openSettingsSection("safety");
   if (action === "open-settings-integrations") return openSettingsSection("integrations");
   if (action === "run-doctor") return runDoctor();
+  if (action === "install-claude") return showToast("Installe Claude Code CLI puis relance le cockpit.", "info");
+  if (action === "open-github-protection") { window.open("https://github.com/Yuume2/WebAppV1/settings/branches", "_blank", "noopener"); return; }
   showToast(`Action: ${action}`, "info");
 }
 

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -50,6 +50,7 @@
 <section data-pane="mission" class="pane active">
 
   <div class="mission-hero" id="mission-hero">
+    <div class="floating-orbs" aria-hidden="true"></div>
     <div class="mission-eyebrow">
       <span class="orb" id="mission-orb"></span>
       <span id="mission-eyebrow">Claude Autopilot</span>

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -793,9 +793,173 @@ dialog input { width: 100%; margin-top: 12px; }
   .toast { max-width: none; }
 }
 
+/* ============ PREMIUM POLISH (final pass) ============ */
+
+body::before {
+  content: ""; position: fixed; inset: 0;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(139, 92, 255, 0.05), transparent 25%),
+    radial-gradient(circle at 80% 70%, rgba(180, 135, 255, 0.04), transparent 30%);
+  pointer-events: none; z-index: -1;
+  animation: bgDrift 30s ease-in-out infinite alternate;
+}
+@keyframes bgDrift { 0% { transform: translate(0, 0); } 100% { transform: translate(-20px, -10px); } }
+
+.mission-hero {
+  background-image:
+    radial-gradient(ellipse at 0% 0%, rgba(139, 92, 255, 0.18), transparent 50%),
+    radial-gradient(ellipse at 100% 100%, rgba(180, 135, 255, 0.12), transparent 50%),
+    linear-gradient(rgba(139, 92, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 92, 255, 0.025) 1px, transparent 1px),
+    var(--surface-strong);
+  background-size: auto, auto, 32px 32px, 32px 32px, auto;
+}
+.mission-hero .floating-orbs { position: absolute; inset: 0; pointer-events: none; overflow: hidden; border-radius: inherit; }
+.mission-hero .floating-orbs::before,
+.mission-hero .floating-orbs::after {
+  content: ""; position: absolute; border-radius: 50%;
+  filter: blur(60px); opacity: 0.5;
+  animation: floatOrb 12s ease-in-out infinite alternate;
+}
+.mission-hero .floating-orbs::before {
+  width: 280px; height: 280px;
+  background: radial-gradient(circle, var(--accent), transparent 70%);
+  top: -80px; right: -60px;
+}
+.mission-hero .floating-orbs::after {
+  width: 220px; height: 220px;
+  background: radial-gradient(circle, var(--accent-2), transparent 70%);
+  bottom: -60px; left: -40px;
+  animation-delay: -6s; animation-duration: 14s;
+}
+@keyframes floatOrb { 0% { transform: translate(0, 0) scale(1); } 100% { transform: translate(20px, -20px) scale(1.1); } }
+
+.brand .logo {
+  background: linear-gradient(135deg, #a875ff, #6a3aff, #b487ff);
+  background-size: 200% 200%;
+  animation: logoShift 6s ease-in-out infinite alternate;
+}
+@keyframes logoShift { 0% { background-position: 0% 0%; } 100% { background-position: 100% 100%; } }
+
+.mode-card { background: linear-gradient(180deg, var(--bg-1), var(--bg-2)); }
+.mode-card::before {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(135deg, transparent, rgba(139, 92, 255, 0.06), transparent);
+  border-radius: inherit;
+  opacity: 0; transition: opacity var(--t);
+  pointer-events: none;
+}
+.mode-card:hover::before { opacity: 1; }
+.mode-card.active {
+  background: linear-gradient(135deg, var(--accent-soft) 0%, rgba(139, 92, 255, 0.04) 60%, transparent 100%);
+}
+.mode-card.active::before { opacity: 1; }
+
+.status-pill { transition: all var(--t); }
+.status-pill:hover { border-color: var(--border-strong); transform: translateY(-1px); }
+.status-pill.ok { box-shadow: inset 0 0 0 1px rgba(74, 222, 128, 0.1); }
+.status-pill.warn { box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.1); }
+.status-pill.err { box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.15); animation: pillBlink 2s ease-in-out infinite; }
+.status-pill.info { box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.1); }
+@keyframes pillBlink {
+  0%, 100% { box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.15); }
+  50% { box-shadow: inset 0 0 0 1px rgba(248, 113, 113, 0.3); }
+}
+
+.timeline { position: relative; }
+.timeline-step + .timeline-step::before {
+  content: ""; position: absolute; left: -8px; top: 50%;
+  width: 8px; height: 1px; background: var(--border);
+}
+.timeline-step.done + .timeline-step::before { background: var(--ok); }
+.timeline-step.active + .timeline-step::before { background: var(--accent); }
+
+.mission-progress-fill {
+  background: linear-gradient(90deg, var(--accent) 0%, var(--accent-2) 50%, var(--accent) 100%);
+  background-size: 200% 100%;
+  animation: progressGradient 3s linear infinite;
+}
+@keyframes progressGradient { 0% { background-position: 0% 0%; } 100% { background-position: 200% 0%; } }
+
+.toast { position: relative; padding-left: 14px; }
+.toast::before {
+  content: ""; width: 4px; align-self: stretch;
+  background: var(--fg-mute); border-radius: 999px;
+  margin-right: 4px; flex-shrink: 0;
+}
+.toast.ok::before { background: var(--ok); box-shadow: 0 0 12px var(--ok); }
+.toast.err::before { background: var(--danger); box-shadow: 0 0 12px var(--danger); }
+.toast.warn::before { background: var(--warn); box-shadow: 0 0 12px var(--warn); }
+.toast.info::before { background: var(--info); box-shadow: 0 0 12px var(--info); }
+
+.mission-title {
+  background: linear-gradient(180deg, #ffffff 0%, var(--accent-3) 80%, var(--accent-2) 100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 0 0 60px rgba(180, 135, 255, 0.15);
+}
+
+.tabs button { position: relative; z-index: 1; }
+.tabs button.active { color: white; }
+.tabs button.active::before {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(180deg, rgba(139, 92, 255, 0.18), rgba(139, 92, 255, 0.08));
+  border-radius: var(--r-sm);
+  z-index: -1;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 4px 12px var(--accent-glow);
+}
+
+.skeleton {
+  background: linear-gradient(90deg, var(--bg-1), var(--bg-2), var(--bg-1));
+  background-size: 200% 100%;
+  animation: skeletonPulse 1.4s linear infinite;
+  border-radius: var(--r-md);
+  height: 56px;
+}
+@keyframes skeletonPulse { 0% { background-position: 0% 0%; } 100% { background-position: 200% 0%; } }
+
+.auth-card { animation: authEnter 360ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+@keyframes authEnter {
+  0% { opacity: 0; transform: scale(0.92) translateY(12px); }
+  100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.settings-nav button.active {
+  background: linear-gradient(135deg, var(--accent-soft), transparent);
+  color: var(--fg);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.toggle::after { transition: transform var(--t-fast) cubic-bezier(0.34, 1.56, 0.64, 1), background var(--t); }
+
+.section-header { position: relative; padding-bottom: 8px; }
+.section-header::after {
+  content: ""; position: absolute; bottom: 0; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--border-strong), transparent);
+  opacity: 0.4;
+}
+
+.empty-state {
+  padding: 48px 24px; text-align: center; color: var(--fg-mute); font-size: 13px;
+}
+.empty-state .icon {
+  width: 44px; height: 44px; margin: 0 auto 14px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--accent-2); font-size: 18px;
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }
   .orb.running { animation: none; }
   .timeline-step.active { animation: none; }
+  body::before { animation: none; }
+  .mission-hero .floating-orbs::before, .mission-hero .floating-orbs::after { animation: none; }
+  .mission-progress-fill { animation: none; }
+  .brand .logo { animation: none; }
 }

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -159,11 +159,13 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       const info = gitInfo(repoRoot);
       const active = runner.activeIds()[0] ?? null;
       const last = state.list(1)[0] ?? null;
+      const repo = repoNameWithOwner(repoRoot);
+      const protection = repo ? fetchBranchProtection(repo, 'main') : { protected: false, source: null };
       return send(res, 200, {
         branch: info.branch,
         gitStatus: { clean: !info.dirty, ahead: 0, behind: 0, files: [] },
         doctor: { ok: null, phase: null, blockers: [], checkedAt: null },
-        mainProtection: { enabled: null, type: 'unknown', checks: [] },
+        mainProtection: { enabled: !!protection.protected, type: protection.source ?? 'unknown', checks: [] },
         phaseGates: { phase1: 'unknown', phase2: 'unknown', phase3: 'unknown' },
         openIssues: null,
         autonomousTasks: null,
@@ -459,7 +461,18 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       const whatsappCfg = evaluateWhatsappConfig(env);
       const items = [
         { id: 'claude', label: 'Claude CLI', kind: 'required', status: claude.claudeAvailable ? 'ready' : 'missing', detail: claude.claudeAvailable ? (claude.claudeVersion || 'available') : (claude.claudeReason || 'not available'), action: claude.claudeAvailable ? null : 'install-claude' },
-        { id: 'protection', label: 'Branch protection', kind: 'required', status: 'unknown', detail: 'check via doctor', action: 'run-doctor' },
+        ...(() => {
+          const repo = repoNameWithOwner(repoRoot);
+          const p = repo ? fetchBranchProtection(repo, 'main') : { protected: false, source: null };
+          return [{
+            id: 'protection',
+            label: 'Branch protection',
+            kind: 'required',
+            status: p.protected ? 'ready' : 'missing',
+            detail: p.protected ? `protected via ${p.source}` : 'main protection désactivée',
+            action: p.protected ? null : 'open-github-protection',
+          }];
+        })(),
         { id: 'allowExec', label: 'Exec allowed', kind: 'required', status: s.allowExec ? 'ready' : 'missing', detail: s.allowExec ? 'autorisé' : 'flippe le toggle Exec dans Settings', action: 'open-settings-safety' },
         { id: 'allowLoop', label: 'Loop allowed', kind: 'required', status: s.allowLoop ? 'ready' : 'missing', detail: s.allowLoop ? 'autorisé' : 'flippe le toggle Loop dans Settings', action: 'open-settings-safety' },
         { id: 'allowAutoMerge', label: 'Auto-merge (Power mode)', kind: 'optional', status: s.allowAutoMerge ? 'ready' : 'optional', detail: s.allowAutoMerge ? 'ENABLED' : 'optionnel — laisser OFF par défaut', action: 'open-settings-safety' },

--- a/tools/local-control/v5-server.test.mjs
+++ b/tools/local-control/v5-server.test.mjs
@@ -209,3 +209,30 @@ test('GET /api/v5/full-readiness lists items with statuses', async () => {
     assert.equal(typeof r.data.requiredMissingCount, 'number');
   } finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+test('GET /api/v5/full-readiness marks integrations as optional', async () => {
+  const root = tmpRepo();
+  writeFileSync(join(root, '.local-control', 'v5.env'), 'CLAUDE_CODE_COMMAND=yu\n');
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/v5/full-readiness', { token: tok });
+    const optionalIds = r.data.items.filter((i) => i.kind === 'optional').map((i) => i.id).sort();
+    assert.ok(optionalIds.includes('notion'));
+    assert.ok(optionalIds.includes('n8n'));
+    assert.ok(optionalIds.includes('whatsapp'));
+    assert.ok(optionalIds.includes('allowAutoMerge'));
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('GET /api/dashboard exposes mainProtection.enabled as boolean', async () => {
+  const root = tmpRepo();
+  try {
+    const app = buildApp({ repoRoot: root });
+    const tok = app.settings.get().authToken;
+    const r = await call(app, 'GET', '/api/dashboard', { token: tok });
+    assert.equal(r.status, 200);
+    assert.equal(typeof r.data.mainProtection.enabled, 'boolean');
+    assert.equal(typeof r.data.mainProtection.type, 'string');
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Ce qui change

Passe finale "product-grade" sur le cockpit Mission Control. Audit + corrections + polish visuel + corrections backend.

### Backend corrigé
- **`/api/dashboard`** probe vraiment la branch protection (`gh api repos/.../branches/main/protection` + fallback rulesets). `mainProtection.enabled` devient un vrai boolean, `mainProtection.type` reporte `classic` / `ruleset` / `unknown`.
- **`/api/v5/full-readiness`** consomme la même probe → l'item *Branch protection* devient `ready` ou `missing` avec un détail explicite (`protected via ruleset` / `main protection désactivée`) au lieu de rester bloqué sur `unknown`.
- Confirmé en live : `mainProtection: {enabled: True, type: 'ruleset'}`.

### Polish visuel premium
- **Floating orbs** animés dans le hero mission (deux disques flous violet/lavande qui dérivent en sens opposés sur 12-14s).
- **Background drift** sur `body` (gradients radial qui glissent sur 30s).
- **Grid pattern** subtil dans le hero (32px grid violet).
- **Mission title** avec gradient vertical 3 stops + soft text-shadow.
- **Logo** avec gradient 3 couleurs animé.
- **Tabs** avec pill glowing derrière le tab actif.
- **Mode cards** avec overlay gradient au hover + active state plus marqué.
- **Status pills** avec hover lift, border inset coloré, blink sur les erreurs.
- **Timeline** gagne des connecteurs horizontaux qui se colorent selon l'étape (vert si done, violet si active).
- **Progress bar** sweep gradient animé.
- **Toasts** avec barre latérale colorée + glow.
- **Auth card** avec entrance spring.
- **Toggle** avec easing spring sur le pouce.
- **Section headers** avec ligne séparatrice gradient.

### Comportement
- **Checklist Configure** gère 5 actions (settings-safety, settings-integrations, run-doctor, install-claude, open-github-protection).
- *open-github-protection* ouvre directement les Branch protection settings GitHub dans un nouvel onglet.

### Accessibilité
- Toutes les nouvelles animations respectent `prefers-reduced-motion`.

## Tests

- **148 backend** (+2) — vérifient que `mainProtection.enabled` est bien un boolean et que les intégrations sont marquées `kind: 'optional'`.
- 83 UI · 76 task-tooling.
- typecheck / lint / test / build verts.
- Smoke live : `/api/dashboard` reporte `protected via ruleset`, `/api/v5/full-readiness` montre 4 required ready, 1 required unknown (guard, normal sans Run doctor), 4 optional avec details précis. HTML contient bien `floating-orbs`.

## Test plan

- [ ] `pnpm cockpit` → hero mission a une lueur violette qui flotte doucement.
- [ ] Tabs actifs ont un pill glow.
- [ ] Mode cards : hover montre une lueur violette traversante.
- [ ] Settings → toggles ont un easing spring quand on les flippe.
- [ ] Avec `allowExec=true` + `allowLoop=true` + Full autopilot mode → checklist montre Branch protection en `ready` (vert) avec détail "protected via ruleset".
- [ ] Toasts ont une barre latérale colorée.
- [ ] Resize 400px : hero reste lisible, mode cards en colonne.
- [ ] `prefers-reduced-motion: reduce` dans DevTools → toutes les animations s'arrêtent.

## Sécurité

Aucune régression : auth token toujours requis, auto-merge OFF par défaut, redaction des secrets, `.claude/` jamais touché, `.local-control/` gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)