### PR TITLE
feat(cockpit): rethink autopilot UX, manual questions, and mission reporting

### DIFF
--- a/docs/ops/cockpit.md
+++ b/docs/ops/cockpit.md
@@ -215,6 +215,61 @@ Pour brancher n8n plus tard : ajouter `N8N_BASE_URL`, `N8N_WEBHOOK_SECRET`,
 Pour WhatsApp : `WHATSAPP_PROVIDER=twilio` + `TWILIO_ACCOUNT_SID/AUTH_TOKEN` +
 `WHATSAPP_FROM/TO` (ou `WHATSAPP_PROVIDER=n8n` pour passer par n8n).
 
+## V20 — répondre à une human question depuis le cockpit
+
+Quand Claude pose une question (commentaire `<!-- claude-question v1` sur
+l'issue), la mission passe en `waiting`. Le cockpit affiche alors une carte
+**Décision humaine** complète :
+
+- titre clair issu du markdown du commentaire
+- contexte (« Pourquoi je demande »)
+- options sous forme de boutons (clic = pré-remplit la zone de réponse)
+- recommandation Claude mise en valeur si présente
+- zone de texte libre + bouton « Envoyer la réponse et reprendre »
+- raccourci `Cmd/Ctrl+Enter` pour envoyer
+
+L'envoi appelle `POST /api/autopilot/answer-question` qui :
+
+1. Poste un commentaire `<!-- claude-answer qid:... -->` sur l'issue via `gh`.
+2. Poste une `<!-- claude-resolution -->` (best-effort).
+3. Appelle `engine.resume({ answeredQid })` pour faire repartir la loop.
+
+Le tout se fait sans n8n, sans Notion. Le bridge externe reste optionnel.
+
+### Stale waiting state
+
+Si tu redémarres le serveur cockpit pendant qu'un run était en `waiting`, le
+process perd `activeRun`. Le rapport persiste (`/api/autopilot/status` renvoie
+`isLive: false, stale: true`) et la carte question affiche un mode dégradé :
+bouton **Envoyer la réponse (run précédent)** qui poste sur GitHub uniquement,
+et bouton **Reset run** pour repartir d'une mission propre.
+
+## V20 — voir les runs récents
+
+Une nouvelle section **Derniers runs** liste les missions terminées avec :
+
+- outcome (completed / partial / failed / stopped / waiting)
+- résumé court
+- 1ère PR cliquable
+- date + durée
+
+Backend : `GET /api/autopilot/recent` renvoie 8 runs max, filtre les runs actifs.
+
+## V20 — état des PR
+
+Chaque PR créée capture `number`, `url`, `title`, `branch`, `issueNumber` à la
+création. Bouton **Refresh PR status** dans le rapport final qui appelle
+`POST /api/autopilot/pr-status` ; ça rappelle `gh pr view` pour chaque PR et
+ajoute `state` (open / merged / closed / draft). Les badges de la PR list
+prennent les couleurs : open=vert, merged=violet, closed=rouge, draft=jaune.
+
+## V20 — activity ticker
+
+Sous le CTA principal, un bandeau live affiche en français ce que fait
+Claude **maintenant** : `Préflight…`, `Création de la branche…`,
+`Claude is coding…`, `Vérification PR…`, etc. + un compteur done/failed quand
+le run est unattended.
+
 ## Sécurité
 
 - Auth token requise (Bearer ou query `?token=`).

--- a/tools/local-control/autopilot-loop.test.mjs
+++ b/tools/local-control/autopilot-loop.test.mjs
@@ -158,3 +158,41 @@ test('buildMissionReport handles waiting state', () => {
   assert.equal(rep.outcome, 'waiting');
   assert.match(rep.nextAction, /Answer pending question/);
 });
+
+import { markWaitingOnQuestion, parseClaudeQuestionBody } from './autopilot.mjs';
+import { test as t2 } from 'node:test';
+t2('markWaitingOnQuestion captures full question payload', () => {
+  const r = buildAutopilotState({ mode: 'loop' });
+  markWaitingOnQuestion(r, 'q-9-1', { issue: 9, question: 'Ship?', why: 'race', options: ['A) yes', 'B) no'], recommendation: 'A', githubUrl: 'http://x' });
+  assert.equal(r.status, 'waiting');
+  assert.equal(r.pendingQuestionId, 'q-9-1');
+  assert.equal(r.pendingQuestion.issue, 9);
+  assert.match(r.pendingQuestion.question, /Ship\?/);
+  assert.deepEqual(r.pendingQuestion.options, ['A) yes', 'B) no']);
+  assert.equal(r.pendingQuestion.recommendation, 'A');
+});
+
+t2('parseClaudeQuestionBody extracts options and recommendation', () => {
+  const body = [
+    '<!-- claude-question v1',
+    'qid: q-12-3',
+    'taskIssue: 12',
+    'blockLevel: hard',
+    '-->',
+    '',
+    '**Q (#12)** : Foo or bar?',
+    '',
+    '**Pourquoi je demande** : ambiguous spec.',
+    '',
+    '**Options**',
+    '- A) foo',
+    '- B) bar',
+    '',
+    '**Recommandation Claude** : B',
+  ].join('\n');
+  const p = parseClaudeQuestionBody(body);
+  assert.equal(p.meta.qid, 'q-12-3');
+  assert.match(p.question, /Foo or bar/);
+  assert.deepEqual(p.options, ['A) foo', 'B) bar']);
+  assert.equal(p.recommendation, 'B');
+});

--- a/tools/local-control/autopilot.mjs
+++ b/tools/local-control/autopilot.mjs
@@ -133,6 +133,7 @@ export function buildAutopilotState({ id, mode, issue, branch, settingsSnapshot,
     completedAt: null,
     stopReason: null,
     pendingQuestionId: null,
+    pendingQuestion: null,
     prsCreated: 0,
     prUrl: null,
     prNumber: null,
@@ -339,9 +340,22 @@ export function markStopped(run, reason) {
   return run;
 }
 
-export function markWaitingOnQuestion(run, qid) {
+export function markWaitingOnQuestion(run, qid, question = null) {
   run.status = 'waiting';
   run.pendingQuestionId = qid;
+  run.pendingQuestion = question
+    ? {
+        qid,
+        issue: question.issue ?? run.issue ?? null,
+        question: question.question ?? null,
+        why: question.why ?? null,
+        options: Array.isArray(question.options) ? question.options : [],
+        recommendation: question.recommendation ?? null,
+        githubUrl: question.githubUrl ?? null,
+        blockLevel: question.blockLevel ?? null,
+        capturedAt: new Date().toISOString(),
+      }
+    : (run.pendingQuestion ?? { qid, issue: run.issue ?? null });
   run.resumeAvailable = true;
   run.nextAction = `answer question ${qid}`;
   return run;
@@ -370,6 +384,7 @@ export function exportRunSummary(run) {
     completedAt: run.completedAt,
     stopReason: run.stopReason,
     pendingQuestionId: run.pendingQuestionId,
+    pendingQuestion: run.pendingQuestion ?? null,
     prsCreated: run.prsCreated,
     prUrl: run.prUrl ?? run.lastPR?.url ?? null,
     prNumber: run.prNumber ?? run.lastPR?.number ?? null,
@@ -460,6 +475,68 @@ export function findOpenPRForBranch(repoRoot, branch) {
   } catch { return null; }
 }
 
+export function parseClaudeQuestionBody(body) {
+  if (!body || !body.startsWith('<!-- claude-question v1')) return null;
+  const close = body.indexOf('-->');
+  if (close === -1) return null;
+  const headerInner = body.slice('<!-- claude-question v1'.length, close);
+  const meta = {};
+  for (const raw of headerInner.split('\n')) {
+    const line = raw.trim();
+    const kv = line.match(/^([a-zA-Z][\w]*)\s*:\s*(.*)$/);
+    if (kv) meta[kv[1]] = kv[2];
+  }
+  const text = body.slice(close + 3).trim();
+  // mini-parser inline (mirror tools/task-questions.mjs:parseQuestionPayload)
+  const lines = text.split('\n');
+  let section = null;
+  let question = null, why = null, recommendation = null;
+  let firstStrongLine = null, firstLooseLine = null;
+  const options = [];
+  for (const raw of lines) {
+    const line = raw.trim();
+    const m = line.match(/^\*\*Q\s*\(#?\d*\)?\*\*\s*:\s*(.*)$/i);
+    if (m) { question = m[1]; section = 'q'; continue; }
+    const w = line.match(/^\*\*Pourquoi je demande\*\*\s*:\s*(.*)$/i);
+    if (w) { why = w[1]; section = 'why'; continue; }
+    if (/^\*\*Options\*\*/i.test(line)) { section = 'options'; continue; }
+    const rec = line.match(/^\*\*Recommandation\s+Claude\*\*\s*:\s*(.*)$/i);
+    if (rec) { recommendation = rec[1]; section = 'rec'; continue; }
+    if (line && firstLooseLine == null) firstLooseLine = line;
+    if (firstStrongLine == null && /^\*\*[^*]+\*\*/.test(line)) firstStrongLine = line.replace(/^\*\*([^*]+)\*\*\s*:?\s*/, '$1');
+    if (section === 'options' && /^([-*]|[A-Z]\))\s+/.test(line)) options.push(line.replace(/^([-*])\s+/, '').trim());
+    else if (section === 'q' && line && !line.startsWith('**')) question = (question ? question + ' ' : '') + line;
+    else if (section === 'why' && line && !line.startsWith('**')) why = (why ? why + ' ' : '') + line;
+    else if (section === 'rec' && line && !line.startsWith('**')) recommendation = (recommendation ? recommendation + ' ' : '') + line;
+  }
+  if (!question && firstStrongLine) question = firstStrongLine;
+  if (!question && firstLooseLine) question = firstLooseLine.slice(0, 200);
+  return { meta, text, question, why, options, recommendation };
+}
+
+export function fetchPRSnapshot(repoRoot, prNumber) {
+  if (!Number.isInteger(prNumber) || prNumber <= 0) return null;
+  const r = spawnSync('gh', ['pr', 'view', String(prNumber), '--json', 'number,url,title,state,isDraft,mergedAt,closedAt,headRefName'], {
+    cwd: repoRoot, encoding: 'utf8',
+  });
+  if (r.status !== 0) return null;
+  try {
+    const j = JSON.parse(r.stdout);
+    let state = String(j.state || '').toLowerCase();
+    if (j.mergedAt) state = 'merged';
+    return {
+      number: j.number,
+      url: j.url,
+      title: j.title,
+      state,
+      isDraft: !!j.isDraft,
+      mergedAt: j.mergedAt ?? null,
+      closedAt: j.closedAt ?? null,
+      branch: j.headRefName ?? null,
+    };
+  } catch { return null; }
+}
+
 export function findClaudeQuestionOnIssue(repoRoot, issueNum) {
   const r = spawnSync('gh', ['api', `repos/{owner}/{repo}/issues/${issueNum}/comments`], {
     cwd: repoRoot, encoding: 'utf8', maxBuffer: 4 * 1024 * 1024,
@@ -469,10 +546,22 @@ export function findClaudeQuestionOnIssue(repoRoot, issueNum) {
     const arr = JSON.parse(r.stdout);
     if (!Array.isArray(arr)) return null;
     for (const c of arr.slice().reverse()) {
-      if (typeof c.body === 'string' && c.body.startsWith('<!-- claude-question v1')) {
-        const qid = (c.body.match(/qid:\s*([\w-]+)/) ?? [])[1] ?? `q-${c.id}`;
-        return { id: qid, url: c.html_url };
-      }
+      const parsed = parseClaudeQuestionBody(c.body || '');
+      if (!parsed) continue;
+      const qid = parsed.meta.qid || `q-${c.id}`;
+      return {
+        id: qid,
+        qid,
+        url: c.html_url,
+        githubUrl: c.html_url,
+        issue: Number(parsed.meta.taskIssue ?? issueNum),
+        blockLevel: parsed.meta.blockLevel ?? null,
+        question: parsed.question ?? null,
+        why: parsed.why ?? null,
+        options: parsed.options,
+        recommendation: parsed.recommendation ?? null,
+        text: parsed.text,
+      };
     }
   } catch { /* ignore */ }
   return null;
@@ -745,9 +834,9 @@ export class AutopilotEngine {
     }
     const q = findClaudeQuestionOnIssue(this.repoRoot, issueNum);
     if (q) {
-      markWaitingOnQuestion(run, q.id);
+      markWaitingOnQuestion(run, q.id, q);
       this._persist(); this._emit('state', exportRunSummary(run));
-      return { kind: 'waiting', fatal: false, qid: q.id };
+      return { kind: 'waiting', fatal: false, qid: q.id, question: q };
     }
     runStep(run, 'no-pr-no-question');
     recordError(run, new Error('claude did not open PR and posted no question'));
@@ -779,6 +868,7 @@ export class AutopilotEngine {
       return { ok: false, reason: 'pending question not answered' };
     }
     run.pendingQuestionId = null;
+    run.pendingQuestion = null;
     run.status = 'running';
     run.nextAction = 'continue';
     runStep(run, 'resumed');
@@ -787,6 +877,12 @@ export class AutopilotEngine {
   }
 
   current() { return this.activeRun ? exportRunSummary(this.activeRun) : null; }
+
+  latest() {
+    if (this.activeRun) return exportRunSummary(this.activeRun);
+    if (!this.store) return null;
+    try { return exportRunSummary(this.store.latest()); } catch { return null; }
+  }
 
   history({ limit = 20 } = {}) {
     if (!this.store) return [];
@@ -803,6 +899,62 @@ export class AutopilotEngine {
       const r = this.store.load(runId);
       return r ? exportRunSummary(r) : null;
     } catch { return null; }
+  }
+
+  async answerQuestion({ qid, answer, issue = null }) {
+    const run = this.activeRun;
+    if (!run) return { ok: false, reason: 'no active run' };
+    if (run.status !== 'waiting') return { ok: false, reason: `run status is ${run.status}` };
+    const expectedQid = run.pendingQuestionId;
+    if (qid && expectedQid && qid !== expectedQid) return { ok: false, reason: 'qid mismatch' };
+    const trimmed = String(answer ?? '').trim();
+    if (!trimmed) return { ok: false, reason: 'answer required' };
+    const targetIssue = issue ?? run.pendingQuestion?.issue ?? run.issue ?? null;
+    if (!Number.isInteger(targetIssue) || targetIssue <= 0) return { ok: false, reason: 'cannot determine issue' };
+    const targetQid = qid || expectedQid;
+    if (!targetQid) return { ok: false, reason: 'no pending question id' };
+    const args = ['tools/task-questions.mjs', 'answer', '--qid', targetQid, '--issue', String(targetIssue), '--answer', trimmed, '--json'];
+    const r = spawnSync('node', args, { cwd: this.repoRoot, encoding: 'utf8' });
+    if (r.status !== 0) {
+      const err = redactSecrets((r.stderr || r.stdout || '').toString().slice(-400), [run.settingsSnapshot?.authToken].filter(Boolean));
+      recordError(run, new Error('answer post failed: ' + err));
+      this._persist(); this._emit('state', exportRunSummary(run));
+      return { ok: false, reason: err || 'answer post failed' };
+    }
+    if (!Array.isArray(run.questionLog)) run.questionLog = [];
+    run.questionLog.push({ qid: targetQid, issue: targetIssue, answer: trimmed.slice(0, 4000), at: new Date().toISOString() });
+    if (this.notifier) {
+      try { await this.notifier.notify('question_required', { runId: run.id, qid: targetQid, status: 'answered' }); } catch {}
+    }
+    return this.resume({ answeredQid: targetQid });
+  }
+
+  refreshPrStatus({ runId = null } = {}) {
+    const target = runId ? this.getRun(runId) : (this.activeRun ? exportRunSummary(this.activeRun) : (this.store?.latest() ? exportRunSummary(this.store.latest()) : null));
+    if (!target) return { ok: false, reason: 'no run available' };
+    const list = Array.isArray(target.createdPrs) ? target.createdPrs : [];
+    if (!list.length) return { ok: true, prs: [] };
+    const updated = [];
+    for (const entry of list) {
+      const snap = fetchPRSnapshot(this.repoRoot, Number(entry.number));
+      updated.push({ ...entry, ...(snap ?? {}), refreshedAt: new Date().toISOString() });
+    }
+    // Also persist back to active run if matches
+    if (this.activeRun?.id === target.id) {
+      this.activeRun.createdPrs = updated;
+      if (this.activeRun.missionReport) this.activeRun.missionReport.createdPrs = updated;
+      this._persist();
+    } else if (this.store && target.id) {
+      try {
+        const raw = this.store.load(target.id);
+        if (raw) {
+          raw.createdPrs = updated;
+          if (raw.missionReport) raw.missionReport.createdPrs = updated;
+          this.store.save(raw);
+        }
+      } catch { /* ignore */ }
+    }
+    return { ok: true, prs: updated };
   }
 
   reset() {

--- a/tools/local-control/public/app.js
+++ b/tools/local-control/public/app.js
@@ -18,6 +18,7 @@ import {
   MISSION_MODES, DEFAULT_MODE_ID, findMode,
   renderModeRail, buildMissionState, renderMissionHero, renderMissionProgress,
   renderUnattendedRun, buildPrLinksText,
+  renderActivityTicker, renderQuestionCard, renderRecentRuns,
   renderFullChecklist, renderNextTask, renderTaskBoard,
   renderLogSummary, appendLogLine, clearLogs,
   renderMissionResult, buildDiagnostic,
@@ -101,8 +102,13 @@ async function refreshAll() {
     try {
       const apStatus = await api.get("/api/autopilot/status");
       lastLatestRun = apStatus?.latest ?? null;
+      lastIsLive = !!apStatus?.isLive;
       if (apStatus?.autopilot) lastV5 = { ...(lastV5 || {}), autopilot: apStatus.autopilot };
     } catch {}
+    try {
+      const recent = await api.get("/api/autopilot/recent");
+      lastRecentRuns = Array.isArray(recent?.items) ? recent.items : [];
+    } catch { lastRecentRuns = []; }
     setConnState(ConnState.CONNECTED);
     renderStatusGrid({ conn: "connected", settings, v5, network });
     if (dash) renderStatusBranch(dash);
@@ -139,12 +145,17 @@ function rerenderMission() {
   const ap = lastV5?.autopilot ?? lastLatestRun ?? null;
   renderMissionProgress(ap);
   renderUnattendedRun(ap);
+  renderActivityTicker(ap);
+  renderQuestionCard(ap, { isLive: lastIsLive });
   renderMissionResult(ap);
+  renderRecentRuns(lastRecentRuns);
   if (m.full) renderFullChecklist(lastReadiness, openChecklistAction);
   else document.getElementById("full-checklist-card")?.classList.add("hidden");
 }
 
 let lastLatestRun = null;
+let lastRecentRuns = [];
+let lastIsLive = false;
 
 function openChecklistAction(action) {
   if (action === "open-settings-safety") return openSettingsSection("safety");
@@ -305,6 +316,72 @@ document.getElementById("autopilot-resume")?.addEventListener("click", async (ev
   }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
 });
 
+// Question card — option click pre-fills the textarea
+document.body.addEventListener("click", (ev) => {
+  const opt = ev.target.closest("[data-q-option]");
+  if (!opt) return;
+  const ta = document.getElementById("q-answer-input");
+  if (ta) { ta.value = opt.dataset.qOption || ""; ta.focus(); }
+});
+
+// Question card — stale: post to /api/questions/answer (no resume)
+document.body.addEventListener("click", async (ev) => {
+  const btn = ev.target.closest('[data-q-action="submit-stale"]');
+  if (!btn) return;
+  ev.preventDefault();
+  const ap = lastV5?.autopilot ?? lastLatestRun ?? null;
+  const ta = document.getElementById("q-answer-input");
+  const text = String(ta?.value || "").trim();
+  if (!text) { showToast("Réponse vide", "warn"); return; }
+  if (!ap?.pendingQuestionId) { showToast("Aucune question", "warn"); return; }
+  await runWithState(btn, async () => {
+    const r = await api.post("/api/questions/answer", {
+      qid: ap.pendingQuestionId,
+      answer: text,
+      issue: ap.pendingQuestion?.issue ?? ap.issue ?? null,
+    });
+    if (r?.ok) {
+      showToast("Réponse postée sur GitHub", "ok");
+      if (ta) ta.value = "";
+      refreshAll().catch(() => {});
+    } else showToast(r?.reason || "Échec", "err");
+  }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
+});
+
+// Question card — submit answer + auto-resume
+document.body.addEventListener("click", async (ev) => {
+  const btn = ev.target.closest('[data-q-action="submit"]');
+  if (!btn) return;
+  ev.preventDefault();
+  const ap = lastV5?.autopilot ?? lastLatestRun ?? null;
+  const ta = document.getElementById("q-answer-input");
+  const text = String(ta?.value || "").trim();
+  if (!text) { showToast("Réponse vide", "warn"); return; }
+  if (!ap?.pendingQuestionId) { showToast("Aucune question en attente", "warn"); return; }
+  await runWithState(btn, async () => {
+    const r = await api.post("/api/autopilot/answer-question", {
+      qid: ap.pendingQuestionId,
+      answer: text,
+      issue: ap.pendingQuestion?.issue ?? ap.issue ?? null,
+    });
+    if (r?.ok) {
+      showToast("Réponse envoyée — mission relancée", "ok");
+      if (ta) ta.value = "";
+      refreshAll().catch(() => {});
+    } else {
+      showToast(r?.reason ?? "Échec de l'envoi", "err");
+    }
+  }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
+});
+
+// Cmd/Ctrl+Enter inside the answer textarea triggers submit
+document.body.addEventListener("keydown", (ev) => {
+  if (ev.target?.id === "q-answer-input" && (ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+    ev.preventDefault();
+    document.querySelector('[data-q-action="submit"]')?.click();
+  }
+});
+
 // Mission result actions
 document.body.addEventListener("click", async (ev) => {
   const rb = ev.target.closest("[data-result-action]");
@@ -322,6 +399,14 @@ document.body.addEventListener("click", async (ev) => {
       const text = buildPrLinksText(ap) || ap?.prUrl || "";
       if (!text) { showToast("Aucune PR à copier", "warn"); return; }
       navigator.clipboard?.writeText(text).then(() => showToast("PR links copiés", "ok")).catch(() => showToast("Copie échouée", "warn"));
+      return;
+    }
+    if (action === "refresh-pr-status") {
+      await runWithState(rb, async () => {
+        const r = await api.post("/api/autopilot/pr-status", {});
+        if (r?.ok) { showToast("Statuts PR mis à jour", "ok"); await refreshAll(); }
+        else showToast(r?.reason ?? "Échec", "warn");
+      }).catch((e) => showToast(redact(String(e?.message || e)), "err"));
       return;
     }
     if (action === "copy-diagnostic") {

--- a/tools/local-control/public/index.html
+++ b/tools/local-control/public/index.html
@@ -80,6 +80,11 @@
       <input id="mode-custom-value" type="number" min="1" max="20" value="5" />
     </div>
 
+    <div class="activity-ticker idle" id="activity-ticker">
+      <span class="pulse" aria-hidden="true"></span>
+      <span class="ticker-text">Cockpit ready.</span>
+    </div>
+
     <div class="mission-progress hidden-step" id="mission-progress">
       <div class="mission-progress-head">
         <div class="mission-progress-status">
@@ -103,11 +108,21 @@
     </div>
   </div>
 
+  <!-- Inline human-question card (visible when status=waiting) -->
+  <div class="card question-card hidden" id="mission-question"></div>
+
   <!-- Live unattended run summary (visible during running unattended loop) -->
   <div class="card mission-unattended hidden" id="mission-unattended"></div>
 
   <!-- Mission result (visible when run is finished/failed/stopped) -->
   <div class="card mission-result hidden" id="mission-result"></div>
+
+  <!-- Recent runs (last completed missions) -->
+  <div class="section-header">
+    <h2>Derniers runs</h2>
+    <span class="section-sub">Historique des missions récentes.</span>
+  </div>
+  <div class="recent-runs hidden" id="recent-runs"></div>
 
   <!-- Full autopilot checklist (only shown when mode = full) -->
   <div class="card hidden" id="full-checklist-card">

--- a/tools/local-control/public/lib/mission.js
+++ b/tools/local-control/public/lib/mission.js
@@ -390,7 +390,8 @@ export function renderUnattendedRun(ap) {
   const prList = prs.length ? prs.map((p) => `
     <li class="pr-item">
       <a href="${escapeHtml2(p.url || '#')}" target="_blank" rel="noopener">PR #${p.number ?? '?'}</a>
-      <span class="muted small">${escapeHtml2(p.title || '')}</span>
+      <span class="pr-state ${prStateClass(p)}">${escapeHtml2(prStateLabel(p))}</span>
+      <span class="pr-title">${escapeHtml2(p.title || '')}</span>
     </li>
   `).join('') : '<li class="muted small">Aucune PR pour l\'instant.</li>';
   const currentLine = ap.issue
@@ -442,7 +443,8 @@ export function renderMissionResult(ap) {
         ${created.map((p) => `
           <li class="pr-item">
             <a href="${escapeHtml2(p.url || '#')}" target="_blank" rel="noopener">PR #${p.number ?? '?'}</a>
-            <span class="muted small">${escapeHtml2(p.title || '')}</span>
+            <span class="pr-state ${prStateClass(p)}">${escapeHtml2(prStateLabel(p))}</span>
+            <span class="pr-title">${escapeHtml2(p.title || '')}</span>
           </li>
         `).join('')}
       </ul>
@@ -495,6 +497,7 @@ export function renderMissionResult(ap) {
       ${created.length === 1 ? `<button data-result-action="open-pr" class="primary">Open PR</button>` : ''}
       ${created.length > 1 ? `<button data-result-action="open-all-prs" class="primary">Open all PRs</button>` : ''}
       ${created.length ? `<button data-result-action="copy-pr-links">Copy PR links</button>` : ''}
+      ${created.length ? `<button data-result-action="refresh-pr-status" class="ghost">Refresh PR status</button>` : ''}
       ${failed.length ? `<button data-result-action="retry">Retry failed</button>` : ''}
       <button data-result-action="copy-diagnostic">Copy diagnostic</button>
       <button data-result-action="open-logs" class="ghost">Open logs</button>
@@ -543,4 +546,163 @@ export function buildDiagnostic(ap) {
     ...(ap.log ?? []).slice(-10).map((l) => `- ${l.at} · ${l.step}${l.error ? ' · ERR: ' + l.error : ''}`),
   ];
   return lines.join('\n');
+}
+
+export function prStateClass(p) {
+  const s = String(p?.state ?? '').toLowerCase();
+  if (s === 'merged') return 'merged';
+  if (s === 'open') return p?.isDraft ? 'draft' : 'open';
+  if (s === 'closed') return 'closed';
+  if (s === 'draft') return 'draft';
+  return 'unknown';
+}
+export function prStateLabel(p) {
+  const s = String(p?.state ?? '').toLowerCase();
+  if (s === 'merged') return 'merged';
+  if (s === 'open') return p?.isDraft ? 'draft' : 'open';
+  if (s === 'closed') return 'closed';
+  if (s === 'draft') return 'draft';
+  return '—';
+}
+
+function _esc(s) { return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
+
+export function buildActivityTickerState(ap) {
+  if (!ap || ap.status === 'idle' || !ap.status) {
+    return { tone: 'idle', text: 'Cockpit ready. Lance une mission pour démarrer.', meta: '' };
+  }
+  if (ap.status === 'waiting') {
+    return { tone: 'warn', text: ap.pendingQuestion?.question ? `Décision humaine : ${truncate(ap.pendingQuestion.question, 80)}` : 'Décision humaine requise.', meta: ap.pendingQuestionId ?? '' };
+  }
+  if (ap.status === 'failed') {
+    return { tone: 'err', text: humanFailureReason(ap), meta: ap.stopReason ?? '' };
+  }
+  if (ap.status === 'stopped') {
+    return { tone: 'warn', text: ap.stopReason ? `Stoppé · ${ap.stopReason}` : 'Mission stoppée.', meta: '' };
+  }
+  if (ap.status === 'completed') {
+    const created = (ap.missionReport?.createdPrs ?? ap.createdPrs ?? []).length;
+    return { tone: 'idle', text: created ? `Mission terminée · ${created} PR créée${created > 1 ? 's' : ''}.` : 'Mission terminée.', meta: '' };
+  }
+  // running
+  const step = ap.currentStep || 'preflight';
+  const labels = {
+    preflight: 'Préflight…',
+    'preflight-ok': 'Préflight OK, sélection de la task…',
+    'task-selected': `Task sélectionnée${ap.issue ? ' #' + ap.issue : ''}`,
+    'reset-to-main': 'Sync main…',
+    'create-branch': 'Création de la branche…',
+    'launching-claude': 'Lancement Claude…',
+    'claude-running': 'Claude is coding…',
+    'claude-exited': 'Claude a fini, vérification…',
+    'task-guard': 'Task guard en cours…',
+    'check-pr': 'Vérification PR…',
+    'pr-created': 'PR créée 🎉',
+    'no-pr-no-question': 'Pas de PR détectée.',
+    resumed: 'Reprise après réponse humaine…',
+  };
+  const completed = (ap.completedIssues ?? []).length;
+  const failed = (ap.failedIssues ?? []).length;
+  const meta = ap.unattended ? `${completed} done · ${failed} failed${ap.plannedTasks ? ` · ${ap.plannedTasks} target` : ''}` : (ap.issue ? `#${ap.issue}` : '');
+  return { tone: 'live', text: labels[step] || `Étape : ${step.replace(/-/g, ' ')}`, meta };
+}
+
+function truncate(s, n) { const t = String(s ?? ''); return t.length > n ? t.slice(0, n - 1) + '…' : t; }
+
+export function renderActivityTicker(ap) {
+  const host = document.getElementById('activity-ticker');
+  if (!host) return;
+  const s = buildActivityTickerState(ap);
+  host.classList.remove('idle', 'warn', 'err');
+  if (s.tone === 'idle') host.classList.add('idle');
+  if (s.tone === 'warn') host.classList.add('warn');
+  if (s.tone === 'err') host.classList.add('err');
+  host.innerHTML = `
+    <span class="pulse" aria-hidden="true"></span>
+    <span class="ticker-text">${_esc(s.text)}</span>
+    ${s.meta ? `<span class="ticker-meta">${_esc(s.meta)}</span>` : ''}
+  `;
+}
+
+export function renderQuestionCard(ap, opts = {}) {
+  const host = document.getElementById('mission-question');
+  if (!host) return;
+  const q = ap?.pendingQuestion;
+  const isWaiting = ap?.status === 'waiting';
+  if (!isWaiting || !q) {
+    host.classList.add('hidden');
+    host.innerHTML = '';
+    host.dataset.renderedQid = '';
+    return;
+  }
+  host.classList.remove('hidden');
+  const isLive = opts.isLive !== false;
+  const qidKey = `${q.qid || ap.pendingQuestionId || ''}|${isLive ? 'live' : 'stale'}`;
+  // Skip re-render if the question and mode are unchanged AND the user has typed
+  // something in the textarea (avoid wiping in-progress answer during polling).
+  if (host.dataset.renderedQid === qidKey) {
+    const ta = document.getElementById('q-answer-input');
+    if (ta && ta.value && ta.value.length > 0) return;
+  }
+  const optionsHtml = (q.options ?? []).map((opt) => {
+    const recommended = q.recommendation && (opt === q.recommendation || opt.startsWith(String(q.recommendation).trim()));
+    return `<button type="button" class="q-option ${recommended ? 'recommended' : ''}" data-q-option="${_esc(opt)}">
+      <span>${_esc(opt)}</span>
+      ${recommended ? '<span class="recommended-tag">recommandé</span>' : ''}
+    </button>`;
+  }).join('');
+  const recBlock = q.recommendation && !(q.options ?? []).some((o) => o === q.recommendation || o.startsWith(String(q.recommendation).trim()))
+    ? `<div class="q-recommendation">💡 Recommandation Claude : ${_esc(q.recommendation)}</div>`
+    : '';
+  host.innerHTML = `
+    <div class="q-head">
+      <span class="q-eyebrow">Décision humaine</span>
+      ${q.blockLevel ? `<span class="badge warn">${_esc(q.blockLevel)}</span>` : ''}
+      <span class="q-issue">${q.issue ? '#' + q.issue : ''} · ${_esc(q.qid || ap.pendingQuestionId || '')}</span>
+    </div>
+    <h3 class="q-title">${_esc(q.question || 'Claude a posé une question.')}</h3>
+    ${q.why ? `<p class="q-why">${_esc(q.why)}</p>` : ''}
+    ${optionsHtml ? `<div class="q-options">${optionsHtml}</div>` : ''}
+    ${recBlock}
+    <label class="q-answer-label" for="q-answer-input">Ta réponse</label>
+    <textarea id="q-answer-input" class="q-answer" placeholder="Réponds en quelques mots… (Cmd/Ctrl+Enter pour envoyer)"></textarea>
+    <div class="q-actions">
+      ${isLive
+        ? `<button type="button" class="primary" data-q-action="submit">Envoyer la réponse et reprendre</button>`
+        : `<button type="button" class="primary" data-q-action="submit-stale">Envoyer la réponse (run précédent)</button>
+           <button type="button" class="ghost" data-result-action="reset">Reset run</button>`}
+      ${q.githubUrl ? `<a class="ghost" href="${_esc(q.githubUrl)}" target="_blank" rel="noopener" data-q-action="open-github">Voir sur GitHub</a>` : ''}
+      <span class="q-hint">${isLive ? (q.options?.length ? 'Clique sur une option pour la pré-remplir.' : '') : 'Run hors-mémoire — réponse postée sur GitHub uniquement.'}</span>
+    </div>
+  `;
+  host.dataset.renderedQid = qidKey;
+}
+
+export function renderRecentRuns(items) {
+  const host = document.getElementById('recent-runs');
+  if (!host) return;
+  if (!items || !items.length) { host.classList.add('hidden'); host.innerHTML = ''; return; }
+  host.classList.remove('hidden');
+  host.innerHTML = items.map((r) => {
+    const outcome = r.outcome || r.status || 'unknown';
+    const dur = r.durationMs ? ` · ${formatDuration(r.durationMs)}` : '';
+    const when = r.completedAt ? new Date(r.completedAt).toLocaleString() : (r.startedAt ? new Date(r.startedAt).toLocaleString() : '—');
+    const pr = r.firstPr?.url ? `<a href="${_esc(r.firstPr.url)}" target="_blank" rel="noopener" class="rr-pr">PR #${r.firstPr.number ?? '?'}</a>` : (r.prsCreated ? `<span class="muted small">${r.prsCreated} PR</span>` : '<span class="muted small">—</span>');
+    return `<div class="recent-run">
+      <span class="rr-outcome ${_esc(outcome)}">${_esc(outcome)}</span>
+      <span class="rr-summary">${_esc(r.summary || `${r.completedIssues ?? 0} done · ${r.failedCount ?? 0} failed`)}</span>
+      ${pr}
+      <span class="rr-meta">${_esc(when)}${_esc(dur)}</span>
+    </div>`;
+  }).join('');
+}
+
+function formatDuration(ms) {
+  if (!ms || ms < 0) return '';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60); const sr = s % 60;
+  if (m < 60) return `${m}m ${sr}s`;
+  const h = Math.floor(m / 60); const mr = m % 60;
+  return `${h}h ${mr}m`;
 }

--- a/tools/local-control/public/styles.css
+++ b/tools/local-control/public/styles.css
@@ -976,3 +976,169 @@ body::before {
 .mission-result .result-link:hover { text-decoration: underline; }
 .mission-result .result-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 14px; }
 .mission-progress-fill.failed { background: linear-gradient(90deg, var(--danger), #ff6b6b); animation: none; }
+
+/* === v20 cockpit additions === */
+
+/* Aurora hero — animated soft gradient layer behind mission hero */
+.mission-hero { position: relative; overflow: hidden; }
+.mission-hero::before {
+  content: "";
+  position: absolute; inset: -2px;
+  background:
+    radial-gradient(circle at 20% 30%, rgba(139, 92, 255, 0.32), transparent 55%),
+    radial-gradient(circle at 80% 70%, rgba(212, 179, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 50% 110%, rgba(96, 165, 250, 0.18), transparent 65%);
+  filter: blur(28px) saturate(140%);
+  z-index: 0;
+  animation: aurora-drift 18s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+.mission-hero > * { position: relative; z-index: 1; }
+@keyframes aurora-drift {
+  0%   { transform: translate3d(0, 0, 0) scale(1); }
+  50%  { transform: translate3d(2%, -1%, 0) scale(1.05); }
+  100% { transform: translate3d(-1%, 1%, 0) scale(1.02); }
+}
+@media (prefers-reduced-motion: reduce) { .mission-hero::before { animation: none; } }
+
+/* Activity ticker — what claude is doing right now */
+.activity-ticker {
+  display: flex; align-items: center; gap: 10px;
+  margin-top: 14px; padding: 10px 14px;
+  background: rgba(20, 17, 42, 0.4);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-size: 12px; color: var(--fg-dim);
+  min-height: 38px;
+}
+.activity-ticker .pulse {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--accent-glow);
+  animation: pulse-dot 1.6s ease-out infinite;
+}
+.activity-ticker.idle .pulse { background: var(--fg-mute); animation: none; box-shadow: none; }
+.activity-ticker.warn .pulse { background: var(--warn); }
+.activity-ticker.err .pulse { background: var(--danger); animation: none; }
+.activity-ticker .ticker-text { color: var(--fg); font-weight: 500; }
+.activity-ticker .ticker-meta { margin-left: auto; color: var(--fg-mute); font-variant-numeric: tabular-nums; }
+@keyframes pulse-dot {
+  0%   { box-shadow: 0 0 0 0 var(--accent-glow); }
+  70%  { box-shadow: 0 0 0 12px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+@media (prefers-reduced-motion: reduce) { .activity-ticker .pulse { animation: none; } }
+
+/* Question card — inline human decision UI */
+.question-card {
+  margin-top: 16px;
+  padding: 22px 22px 18px;
+  background: linear-gradient(180deg, rgba(251, 191, 36, 0.08), rgba(20, 17, 42, 0.55));
+  border: 1px solid rgba(251, 191, 36, 0.32);
+  border-radius: var(--r-lg);
+  position: relative;
+  box-shadow: 0 12px 32px rgba(251, 191, 36, 0.08), 0 0 0 1px rgba(251, 191, 36, 0.18);
+}
+.question-card::before {
+  content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  background: linear-gradient(90deg, transparent, var(--warn), transparent);
+  border-radius: var(--r-lg) var(--r-lg) 0 0;
+}
+.question-card .q-head { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.question-card .q-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: 0.1em; color: var(--warn); font-weight: 600; }
+.question-card .q-issue { color: var(--fg-mute); font-size: 12px; margin-left: auto; font-variant-numeric: tabular-nums; }
+.question-card h3.q-title { color: var(--fg); text-transform: none; letter-spacing: -0.01em; font-size: 18px; margin-bottom: 8px; }
+.question-card .q-why { color: var(--fg-dim); font-size: 13px; margin-bottom: 14px; line-height: 1.55; }
+.question-card .q-options { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
+.question-card .q-option {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px; background: rgba(15, 12, 30, 0.6); border: 1px solid var(--border);
+  border-radius: var(--r-md); cursor: pointer; transition: var(--t);
+  text-align: left; color: var(--fg); font-size: 13px;
+}
+.question-card .q-option:hover { border-color: var(--border-strong); background: rgba(139, 92, 255, 0.08); }
+.question-card .q-option.recommended { border-color: rgba(139, 92, 255, 0.5); }
+.question-card .q-option .recommended-tag { margin-left: auto; font-size: 10px; padding: 3px 8px; border-radius: 99px; background: var(--accent-soft); color: var(--accent-2); font-weight: 600; }
+.question-card .q-recommendation { padding: 10px 14px; background: var(--accent-soft); border-radius: var(--r-md); font-size: 12px; color: var(--accent-3); margin-bottom: 14px; }
+.question-card .q-answer-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-dim); display: block; margin-bottom: 6px; }
+.question-card textarea.q-answer {
+  width: 100%; min-height: 80px; padding: 12px 14px; resize: vertical;
+  background: rgba(15, 12, 30, 0.6); border: 1px solid var(--border); border-radius: var(--r-md);
+  color: var(--fg); font: inherit; font-size: 13px; line-height: 1.5;
+}
+.question-card textarea.q-answer:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+.question-card .q-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; align-items: center; }
+.question-card .q-actions .q-hint { color: var(--fg-mute); font-size: 11px; margin-left: auto; }
+
+/* PR list with state badges */
+.pr-list, .pr-list-live { list-style: none; padding: 0; margin: 8px 0 0; display: flex; flex-direction: column; gap: 8px; }
+.pr-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px; background: rgba(15, 12, 30, 0.6);
+  border: 1px solid var(--border); border-radius: var(--r-md);
+  font-size: 13px;
+}
+.pr-item a { color: var(--accent-2); font-weight: 600; text-decoration: none; }
+.pr-item a:hover { text-decoration: underline; }
+.pr-state {
+  font-size: 10px; padding: 3px 8px; border-radius: 99px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em; font-variant-numeric: tabular-nums;
+}
+.pr-state.open    { background: rgba(74, 222, 128, 0.15); color: var(--ok); }
+.pr-state.merged  { background: rgba(139, 92, 255, 0.18); color: var(--accent-2); }
+.pr-state.closed  { background: rgba(248, 113, 113, 0.15); color: var(--danger); }
+.pr-state.draft   { background: rgba(251, 191, 36, 0.15); color: var(--warn); }
+.pr-state.unknown { background: rgba(101, 96, 138, 0.15); color: var(--fg-mute); }
+.pr-item .pr-title { color: var(--fg-dim); flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Recent runs */
+.recent-runs { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+.recent-run {
+  display: grid; grid-template-columns: auto 1fr auto auto; gap: 12px; align-items: center;
+  padding: 12px 14px; background: rgba(15, 12, 30, 0.55);
+  border: 1px solid var(--border); border-radius: var(--r-md);
+  font-size: 12px;
+}
+.recent-run .rr-outcome {
+  font-size: 10px; padding: 3px 8px; border-radius: 99px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.recent-run .rr-outcome.completed { background: rgba(74, 222, 128, 0.15); color: var(--ok); }
+.recent-run .rr-outcome.partial   { background: rgba(251, 191, 36, 0.15); color: var(--warn); }
+.recent-run .rr-outcome.failed    { background: rgba(248, 113, 113, 0.15); color: var(--danger); }
+.recent-run .rr-outcome.stopped   { background: rgba(101, 96, 138, 0.15); color: var(--fg-mute); }
+.recent-run .rr-outcome.waiting   { background: rgba(96, 165, 250, 0.15); color: var(--info); }
+.recent-run .rr-summary { color: var(--fg-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.recent-run .rr-meta { color: var(--fg-mute); font-variant-numeric: tabular-nums; }
+.recent-run .rr-pr { color: var(--accent-2); font-weight: 600; text-decoration: none; }
+
+/* Unattended live card refinement */
+.mission-unattended {
+  background: linear-gradient(180deg, rgba(139, 92, 255, 0.06), rgba(20, 17, 42, 0.55));
+  border-color: rgba(139, 92, 255, 0.24);
+}
+.mission-unattended .unattended-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.mission-unattended .unattended-current { color: var(--fg); font-weight: 500; margin-bottom: 10px; }
+.mission-unattended .unattended-stats { display: flex; flex-wrap: wrap; gap: 16px; padding: 10px 14px; background: rgba(15, 12, 30, 0.4); border-radius: var(--r-md); margin-bottom: 12px; font-size: 12px; }
+.mission-unattended .unattended-stats strong { color: var(--accent-2); margin-right: 4px; font-size: 14px; }
+.mission-unattended .unattended-actions { display: flex; gap: 8px; margin-top: 8px; }
+
+/* Mission result polish */
+.mission-result h3 { font-size: 18px; }
+.mission-result .result-summary { color: var(--fg-dim); margin: 4px 0 16px; line-height: 1.55; }
+.mission-result .result-section { margin-top: 14px; }
+.mission-result .result-section-title { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--fg-dim); margin-bottom: 8px; font-weight: 600; }
+.mission-result .failed-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.mission-result .failed-item { padding: 10px 14px; background: rgba(248, 113, 113, 0.06); border-left: 3px solid var(--danger); border-radius: var(--r-sm); font-size: 12px; }
+.mission-result .failed-num { font-weight: 600; color: var(--danger); margin-right: 8px; }
+.mission-result .failed-reason { color: var(--fg-dim); }
+.mission-result .failed-detail { margin-top: 6px; color: var(--fg-mute); font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 11px; line-height: 1.45; word-break: break-word; }
+.mission-result .skipped-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--fg-mute); }
+.mission-result .result-next { font-size: 14px; color: var(--fg); font-weight: 500; padding: 12px 14px; background: var(--accent-soft); border-radius: var(--r-md); }
+
+/* Section transitions */
+.card { transition: opacity 200ms ease, transform 200ms ease; }
+.card.hidden { display: none; }
+
+/* Heartbeat dot for system pill */
+.status-pill .orb.live { animation: pulse-dot 2s ease-out infinite; }

--- a/tools/local-control/server.mjs
+++ b/tools/local-control/server.mjs
@@ -337,25 +337,38 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
     }
 
     if (method === 'GET' && path === '/api/questions') {
-      const r = spawnSync('pnpm', ['task:questions:list', '--json'], { cwd: repoRoot, encoding: 'utf8' });
+      const r = spawnSync('node', ['tools/task-questions.mjs', 'list', '--json'], { cwd: repoRoot, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 });
       const tok = settings.get().authToken;
-      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'questions failed', [tok]));
-      try { return send(res, 200, JSON.parse(r.stdout)); }
-      catch { return send(res, 200, []); }
+      if (r.status !== 0) {
+        return send(res, 200, { items: [], error: redactSecrets((r.stderr || 'questions failed').slice(0, 400), [tok]) });
+      }
+      try {
+        const parsed = JSON.parse(r.stdout);
+        const items = Array.isArray(parsed) ? parsed : (parsed?.items ?? []);
+        return send(res, 200, { items });
+      } catch {
+        return send(res, 200, { items: [] });
+      }
     }
 
     if (method === 'POST' && path === '/api/questions/answer') {
       let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
-      const id = String(body?.id ?? '');
+      const id = String(body?.id ?? body?.qid ?? '');
       const answer = String(body?.answer ?? '');
+      const issue = Number(body?.issue ?? 0);
       if (!/^[A-Za-z0-9_\-:]+$/.test(id)) return sendErr(res, 422, 'invalid question id');
       if (!answer || answer.length > 8000) return sendErr(res, 422, 'invalid answer');
-      const r = spawnSync('pnpm', ['task:questions', 'answer', '--id', id, '--answer', answer], {
-        cwd: repoRoot, encoding: 'utf8',
-      });
+      const args = ['tools/task-questions.mjs', 'answer', '--qid', id, '--answer', answer, '--json'];
+      if (Number.isInteger(issue) && issue > 0) args.push('--issue', String(issue));
+      const r = spawnSync('node', args, { cwd: repoRoot, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 });
       const tok = settings.get().authToken;
-      if (r.status !== 0) return sendErr(res, 500, redactSecrets(r.stderr || 'answer failed', [tok]));
-      return send(res, 200, { ok: true, runId: null });
+      if (r.status !== 0) return sendErr(res, 500, redactSecrets((r.stderr || r.stdout || 'answer failed').slice(0, 400), [tok]));
+      try {
+        const parsed = JSON.parse(r.stdout);
+        return send(res, 200, parsed);
+      } catch {
+        return send(res, 200, { ok: true, qid: id });
+      }
     }
 
     if (method === 'POST' && path === '/api/automerge/check') {
@@ -525,10 +538,13 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
     if (method === 'GET' && path === '/api/autopilot/status') {
       const ap = getAutopilot();
       const current = ap.current();
+      const latest = ap.latest();
       const history = ap.history({ limit: 10 });
-      const latest = current ?? history[0] ?? null;
       const missionReport = (current?.missionReport ?? latest?.missionReport ?? null);
-      return send(res, 200, { autopilot: current, latest, history, missionReport });
+      const visibleRun = current ?? latest;
+      const isLive = !!current;
+      const stale = !current && (latest?.status === 'waiting' || latest?.status === 'running');
+      return send(res, 200, { autopilot: visibleRun, latest, history, missionReport, isLive, stale });
     }
     if (method === 'GET' && path === '/api/autopilot/notifier') {
       const n = getNotifier();
@@ -540,6 +556,45 @@ export function buildApp({ repoRoot = REPO_ROOT_DEFAULT } = {}) {
       const r = ap.getRun(id);
       if (!r) return sendErr(res, 404, 'run not found');
       return send(res, 200, r);
+    }
+    if (method === 'POST' && path === '/api/autopilot/answer-question') {
+      let body; try { body = await readBody(req); } catch (e) { return sendErr(res, 422, e.message); }
+      const qid = String(body?.qid ?? body?.id ?? '');
+      const answer = String(body?.answer ?? '');
+      const issue = Number(body?.issue ?? 0);
+      if (!qid || !/^[A-Za-z0-9_\-:]+$/.test(qid)) return sendErr(res, 422, 'invalid qid');
+      if (!answer.trim() || answer.length > 8000) return sendErr(res, 422, 'invalid answer');
+      const ap = getAutopilot();
+      const r = await ap.answerQuestion({ qid, answer, issue: Number.isInteger(issue) && issue > 0 ? issue : null });
+      return send(res, r.ok ? 200 : 409, r);
+    }
+    if (method === 'GET' && path === '/api/autopilot/recent') {
+      const ap = getAutopilot();
+      const activeId = ap.current()?.id ?? null;
+      const history = ap.history({ limit: 12 }).filter((h) => h.id !== activeId && h.status !== 'running');
+      const items = history.slice(0, 8).map((h) => ({
+        id: h.id,
+        status: h.status,
+        outcome: h.missionReport?.outcome ?? null,
+        startedAt: h.startedAt,
+        completedAt: h.completedAt,
+        durationMs: h.completedAt && h.startedAt ? Math.max(0, new Date(h.completedAt).getTime() - new Date(h.startedAt).getTime()) : null,
+        prsCreated: h.prsCreated ?? 0,
+        failedCount: (h.failedIssues ?? []).length,
+        completedIssues: (h.completedIssues ?? []).length,
+        plannedTasks: h.plannedTasks ?? null,
+        unattended: !!h.unattended,
+        summary: h.missionReport?.summary ?? null,
+        prs: h.createdPrs ?? [],
+        firstPr: (h.createdPrs ?? [])[0] ?? null,
+      }));
+      return send(res, 200, { items });
+    }
+    if (method === 'POST' && path === '/api/autopilot/pr-status') {
+      let body; try { body = await readBody(req); } catch { body = {}; }
+      const ap = getAutopilot();
+      const r = ap.refreshPrStatus({ runId: body?.runId ?? null });
+      return send(res, r.ok ? 200 : 409, r);
     }
     if (method === 'POST' && path === '/api/autopilot/reset') {
       const ap = getAutopilot();

--- a/tools/local-control/tests/cockpit-v20.test.mjs
+++ b/tools/local-control/tests/cockpit-v20.test.mjs
@@ -1,0 +1,182 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+function setupDom() {
+  const byId = new Map();
+  function el() {
+    const node = {
+      tagName: 'DIV',
+      id: '',
+      className: '',
+      _innerHTML: '',
+      get innerHTML() { return this._innerHTML; },
+      set innerHTML(v) { this._innerHTML = String(v); },
+      classList: {
+        _set: new Set(),
+        add(...cs) { for (const c of cs) this._set.add(c); },
+        remove(...cs) { for (const c of cs) this._set.delete(c); },
+        contains(c) { return this._set.has(c); },
+        toggle(c, v) { if (v == null ? !this._set.has(c) : v) this.add(c); else this.remove(c); },
+      },
+      dataset: {},
+      style: {},
+      _children: [],
+      appendChild(c) { this._children.push(c); return c; },
+    };
+    return node;
+  }
+  function ensure(id) {
+    if (!byId.has(id)) { const n = el(); n.id = id; byId.set(id, n); }
+    return byId.get(id);
+  }
+  globalThis.document = {
+    getElementById(id) { return byId.has(id) ? byId.get(id) : null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+  };
+  return { ensure };
+}
+
+test('renderActivityTicker idle when no run', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('activity-ticker');
+  const { renderActivityTicker } = await import('../public/lib/mission.js?t=at1');
+  renderActivityTicker(null);
+  assert.ok(host.classList.contains('idle'));
+  assert.match(host.innerHTML, /Cockpit ready/);
+});
+
+test('renderActivityTicker live during running unattended run', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('activity-ticker');
+  const { renderActivityTicker } = await import('../public/lib/mission.js?t=at2');
+  renderActivityTicker({
+    status: 'running', currentStep: 'claude-running', issue: 7,
+    unattended: true, plannedTasks: 5,
+    completedIssues: [{ number: 1 }], failedIssues: [],
+  });
+  assert.match(host.innerHTML, /Claude is coding/);
+  assert.match(host.innerHTML, /1 done/);
+});
+
+test('renderActivityTicker warn during waiting state', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('activity-ticker');
+  const { renderActivityTicker } = await import('../public/lib/mission.js?t=at3');
+  renderActivityTicker({
+    status: 'waiting', pendingQuestionId: 'q-9-1',
+    pendingQuestion: { question: 'Should we ship X?', issue: 9 },
+  });
+  assert.ok(host.classList.contains('warn'));
+  assert.match(host.innerHTML, /Décision humaine/);
+  assert.match(host.innerHTML, /q-9-1/);
+});
+
+test('renderQuestionCard shows full payload, options, recommendation', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('mission-question');
+  const { renderQuestionCard } = await import('../public/lib/mission.js?t=qc1');
+  renderQuestionCard({
+    status: 'waiting',
+    pendingQuestionId: 'q-12-3',
+    pendingQuestion: {
+      qid: 'q-12-3', issue: 12, blockLevel: 'soft',
+      question: 'Foo or bar?', why: 'ambiguous spec.',
+      options: ['A) foo', 'B) bar'],
+      recommendation: 'B) bar',
+      githubUrl: 'http://example/issue/12',
+    },
+  });
+  assert.equal(host.classList.contains('hidden'), false);
+  assert.match(host.innerHTML, /Foo or bar/);
+  assert.match(host.innerHTML, /ambiguous spec/);
+  assert.match(host.innerHTML, /A\) foo/);
+  assert.match(host.innerHTML, /B\) bar/);
+  assert.match(host.innerHTML, /recommandé/);
+  assert.match(host.innerHTML, /q-answer-input/);
+  assert.match(host.innerHTML, /Voir sur GitHub/);
+});
+
+test('renderQuestionCard hides when not waiting', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('mission-question');
+  const { renderQuestionCard } = await import('../public/lib/mission.js?t=qc2');
+  renderQuestionCard({ status: 'running' });
+  assert.ok(host.classList.contains('hidden'));
+});
+
+test('renderRecentRuns lists outcomes and PR links', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('recent-runs');
+  const { renderRecentRuns } = await import('../public/lib/mission.js?t=rr1');
+  renderRecentRuns([
+    {
+      id: 'a', outcome: 'partial', summary: '2 PR · 1 failed',
+      completedAt: new Date(Date.now() - 60_000).toISOString(),
+      durationMs: 90_000, prsCreated: 2, completedIssues: 2, failedCount: 1,
+      firstPr: { number: 100, url: 'http://x/100' },
+    },
+    {
+      id: 'b', outcome: 'completed', summary: 'Mission terminée : 1 PR créée.',
+      completedAt: new Date(Date.now() - 300_000).toISOString(),
+      durationMs: 300_000, prsCreated: 1, completedIssues: 1, failedCount: 0,
+      firstPr: { number: 99, url: 'http://x/99' },
+    },
+  ]);
+  assert.equal(host.classList.contains('hidden'), false);
+  assert.match(host.innerHTML, /partial/);
+  assert.match(host.innerHTML, /completed/);
+  assert.match(host.innerHTML, /PR #100/);
+  assert.match(host.innerHTML, /PR #99/);
+});
+
+test('renderRecentRuns hides when no items', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('recent-runs');
+  const { renderRecentRuns } = await import('../public/lib/mission.js?t=rr2');
+  renderRecentRuns([]);
+  assert.ok(host.classList.contains('hidden'));
+});
+
+test('PR state helpers map correctly', async () => {
+  const { prStateClass, prStateLabel } = await import('../public/lib/mission.js?t=ps1');
+  assert.equal(prStateClass({ state: 'merged' }), 'merged');
+  assert.equal(prStateLabel({ state: 'merged' }), 'merged');
+  assert.equal(prStateClass({ state: 'open' }), 'open');
+  assert.equal(prStateClass({ state: 'open', isDraft: true }), 'draft');
+  assert.equal(prStateClass({ state: 'closed' }), 'closed');
+  assert.equal(prStateClass({}), 'unknown');
+  assert.equal(prStateLabel({}), '—');
+});
+
+test('renderMissionResult includes Refresh PR status when PRs exist', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('mission-result');
+  const { renderMissionResult } = await import('../public/lib/mission.js?t=mr-r1');
+  renderMissionResult({
+    status: 'completed', issue: 1, completedAt: new Date().toISOString(),
+    prsCreated: 1, prUrl: 'http://x/1', prNumber: 1,
+    createdPrs: [{ number: 1, url: 'http://x/1', title: 'a', state: 'open' }],
+    failedIssues: [], skippedIssues: [],
+    missionReport: {
+      outcome: 'completed', summary: 'OK', nextAction: 'Review',
+      createdPrs: [{ number: 1, url: 'http://x/1', title: 'a', state: 'open' }],
+      failedIssues: [], skippedIssues: [], prsCreated: 1,
+    },
+  });
+  assert.match(host.innerHTML, /Refresh PR status/);
+  assert.match(host.innerHTML, /pr-state open/);
+});
+
+test('renderQuestionCard stale mode shows fallback button + Reset', async () => {
+  const { ensure } = setupDom();
+  const host = ensure('mission-question');
+  const { renderQuestionCard } = await import('../public/lib/mission.js?t=qc-stale');
+  renderQuestionCard({
+    status: 'waiting',
+    pendingQuestionId: 'q-12-old',
+    pendingQuestion: { qid: 'q-12-old', issue: 12, question: 'OK?', options: [], recommendation: null },
+  }, { isLive: false });
+  assert.match(host.innerHTML, /Envoyer la réponse \(run précédent\)/);
+  assert.match(host.innerHTML, /Reset run/);
+});

--- a/tools/task-questions.mjs
+++ b/tools/task-questions.mjs
@@ -71,6 +71,44 @@ export function parseQuestionComment(commentBody) {
   return { meta, text };
 }
 
+export function parseQuestionPayload(text) {
+  if (!text) return { question: null, why: null, options: [], recommendation: null };
+  const lines = String(text).split('\n');
+  let section = null;
+  let question = null;
+  let why = null;
+  let recommendation = null;
+  const options = [];
+  let firstStrongLine = null;
+  let firstLooseLine = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (firstLooseLine == null) firstLooseLine = line;
+    const m = line.match(/^\*\*Q\s*\(#?\d*\)?\*\*\s*:\s*(.*)$/i);
+    if (m) { question = m[1]; section = 'q'; continue; }
+    const w = line.match(/^\*\*Pourquoi je demande\*\*\s*:\s*(.*)$/i) || line.match(/^###?\s+Why$/i);
+    if (w) { why = w[1] ?? null; section = 'why'; continue; }
+    if (/^(\*\*Options\*\*|###?\s+Options\b)/i.test(line)) { section = 'options'; continue; }
+    const rec = line.match(/^\*\*Recommandation\s+Claude\*\*\s*:\s*(.*)$/i) || line.match(/^###?\s+Recommendation\b/i);
+    if (rec) { recommendation = rec[1] ?? null; section = 'rec'; continue; }
+    // strong heading like **Foo** at start of body becomes question fallback
+    if (firstStrongLine == null && /^\*\*[^*]+\*\*/.test(line)) firstStrongLine = line.replace(/^\*\*([^*]+)\*\*\s*:?\s*/, '$1');
+    if (section === 'options' && /^([-*]|[A-Z]\))\s+/.test(line)) {
+      options.push(line.replace(/^([-*]|[A-Z]\))\s+/, (s) => s.trim().match(/^[A-Z]\)/) ? s : '').trim());
+    } else if (section === 'q' && line && !line.startsWith('**')) {
+      question = (question ? question + ' ' : '') + line;
+    } else if (section === 'why' && line && !line.startsWith('**')) {
+      why = (why ? why + ' ' : '') + line;
+    } else if (section === 'rec' && line && !line.startsWith('**')) {
+      recommendation = (recommendation ? recommendation + ' ' : '') + line;
+    }
+  }
+  if (!question && firstStrongLine) question = firstStrongLine;
+  if (!question && firstLooseLine) question = firstLooseLine.slice(0, 200);
+  return { question, why, options, recommendation };
+}
+
 export function parseAnswerComment(commentBody) {
   if (!commentBody || !commentBody.startsWith(ANSWER_MARKER)) return null;
   const close = commentBody.indexOf('-->');
@@ -180,7 +218,46 @@ function getArg(args, name) {
 
 function cmdList(args) {
   const issue = getArg(args, '--issue');
+  const wantJson = args.includes('--json');
   const issues = issue ? [Number(issue)] : fetchOpenIssueNumbers();
+  if (wantJson) {
+    const items = [];
+    for (const n of issues) {
+      const qs = listQuestionsOnIssue(n);
+      const ans = listAnswersOnIssue(n);
+      const answeredQids = new Set(ans.map((a) => a.qid));
+      for (const q of qs) {
+        const payload = parseQuestionPayload(q.text);
+        const qid = q.meta.qid || (q.commentId ? `q-${n}-c${q.commentId}` : `q-${n}-anon`);
+        const status = q.meta.status || (answeredQids.has(qid) ? 'answered' : 'pending');
+        items.push({
+          id: qid,
+          qid,
+          issue: Number(q.meta.taskIssue ?? n),
+          blockLevel: q.meta.blockLevel ?? null,
+          status,
+          createdAt: q.meta.createdAt ?? null,
+          defaultIfNoAnswer: q.meta.defaultIfNoAnswer ?? null,
+          defaultDelayHours: q.meta.defaultDelayHours ? Number(q.meta.defaultDelayHours) : null,
+          text: q.text,
+          question: payload.question,
+          why: payload.why,
+          options: payload.options,
+          recommendation: payload.recommendation,
+          githubUrl: q.htmlUrl,
+          author: q.author ?? null,
+          answers: ans.filter((a) => a.qid === q.meta.qid).map((a) => ({
+            text: a.text,
+            author: a.author ?? null,
+            createdAt: a.createdAt ?? null,
+            githubUrl: a.htmlUrl,
+          })),
+        });
+      }
+    }
+    process.stdout.write(JSON.stringify({ items }, null, 2) + '\n');
+    return;
+  }
   let total = 0;
   for (const n of issues) {
     const qs = listQuestionsOnIssue(n);
@@ -262,6 +339,36 @@ function cmdAnswers(args) {
   }
 }
 
+function cmdAnswer(args) {
+  const qid = getArg(args, '--qid') ?? getArg(args, '--id');
+  const answer = getArg(args, '--answer');
+  let issue = Number(getArg(args, '--issue') ?? 0);
+  const DRY = args.includes('--dry-run');
+  const wantJson = args.includes('--json');
+  if (!qid || !answer) die('--qid (or --id) and --answer required');
+  if (!issue) {
+    const m = String(qid).match(/^q-(\d+)-/);
+    if (!m) die('cannot derive issue from qid; pass --issue N');
+    issue = Number(m[1]);
+  }
+  const body = `<!-- claude-answer qid: ${qid} -->\n\n${answer}`;
+  if (DRY) {
+    if (wantJson) process.stdout.write(JSON.stringify({ ok: true, dryRun: true, qid, issue, body }) + '\n');
+    else { console.log(c.cyan('DRY-RUN: would post:')); console.log(body); }
+    return;
+  }
+  const r = postComment(issue, body);
+  if (!r.ok) {
+    if (wantJson) { process.stdout.write(JSON.stringify({ ok: false, qid, issue, error: r.err.slice(0, 500) }) + '\n'); process.exit(1); }
+    die(`failed to post answer: ${r.err}`);
+  }
+  // Best-effort resolution comment so cmdList can mark answered.
+  const note = `Answer recorded for ${qid} via cockpit.`;
+  postComment(issue, `<!-- claude-resolution qid: ${qid} -->\n\n${note}`);
+  if (wantJson) process.stdout.write(JSON.stringify({ ok: true, qid, issue }) + '\n');
+  else console.log(c.green(`✓ answer posted for ${qid} on #${issue}`));
+}
+
 function cmdResolve(args) {
   const qid = getArg(args, '--qid');
   const issue = Number(getArg(args, '--issue') ?? 0);
@@ -290,6 +397,7 @@ function main() {
   else if (cmd === 'read') cmdRead(rest);
   else if (cmd === 'answers') cmdAnswers(rest);
   else if (cmd === 'resolve') cmdResolve(rest);
+  else if (cmd === 'answer') cmdAnswer(rest);
   else die(`unknown command: ${cmd}`);
 }
 

--- a/tools/task-questions.test.mjs
+++ b/tools/task-questions.test.mjs
@@ -86,3 +86,49 @@ describe('buildQuestionBody', () => {
     assert.doesNotMatch(body, /\*\*Options\*\*/);
   });
 });
+
+import { parseQuestionPayload } from './task-questions.mjs';
+
+describe('parseQuestionPayload', () => {
+  it('extracts question, why, options, recommendation', () => {
+    const text = [
+      '**Q (#41)** : Should we ship X?',
+      '',
+      '**Pourquoi je demande** : impact on cache layer.',
+      '',
+      '**Options**',
+      '- A) ship as is',
+      '- B) defer to next sprint',
+      '',
+      '**Recommandation Claude** : option A',
+      '',
+    ].join('\n');
+    const p = parseQuestionPayload(text);
+    assert.match(p.question, /ship X/);
+    assert.match(p.why, /cache layer/);
+    assert.deepEqual(p.options, ['A) ship as is', 'B) defer to next sprint']);
+    assert.match(p.recommendation, /option A/);
+  });
+
+  it('returns empty fields when text is empty', () => {
+    const p = parseQuestionPayload('');
+    assert.equal(p.question, null);
+    assert.deepEqual(p.options, []);
+    assert.equal(p.recommendation, null);
+  });
+
+  it('handles question without options or recommendation', () => {
+    const p = parseQuestionPayload('**Q (#9)** : OK?\n\n**Pourquoi je demande** : safety.');
+    assert.match(p.question, /OK\?/);
+    assert.match(p.why, /safety/);
+    assert.deepEqual(p.options, []);
+    assert.equal(p.recommendation, null);
+  });
+
+  it('handles multi-line question body', () => {
+    const text = '**Q (#1)** : line one\nline two';
+    const p = parseQuestionPayload(text);
+    assert.match(p.question, /line one/);
+    assert.match(p.question, /line two/);
+  });
+});


### PR DESCRIPTION
## Diagnostic produit

Le cockpit local-control techniquement marchait mais ne *donnait pas l'impression* que Claude bossait pour de vrai. Trois douleurs :

1. **Human questions inutilisables** : le panneau Questions ne renvoyait rien parce que `task:questions:list --json` n'existe pas ; et `answer` n'existait pas non plus.
2. **Pas de présence live** : pas de ticker d'activité, l'utilisateur devait deviner ce que faisait Claude.
3. **Pas d'historique** : à la fin d'un loop, on perdait la vue d'ensemble (PR créées, échecs, runs précédents).

V20 remet ces trois axes au centre.

## Changements UX / design

- **Activity ticker** sous le CTA — heartbeat + label FR par étape (Préflight…, Claude is coding…, Vérification PR…) + compteur done/failed pour les unattended runs.
- **Décision humaine** : carte inline complète avec titre, contexte, options en boutons (clic = pré-remplit la zone de réponse), recommandation Claude mise en valeur, textarea + bouton « Envoyer la réponse et reprendre », raccourci `Cmd/Ctrl+Enter`. La polling ne wipe pas le texte en cours.
- **Mode stale** : si le serveur est redémarré pendant un waiting, l'UI bascule sur un mode dégradé (post sur GitHub seulement + bouton Reset run).
- **Mission report** enrichi : badges de status PR (open/merged/closed/draft), bouton Refresh PR status, Open all PRs / Copy PR links / Retry failed.
- **Derniers runs** : section listant les 8 dernières missions terminées (outcome, résumé, 1ère PR cliquable, date + durée).
- **Aurora drift** sur le hero + pulse pour le ticker. Respecte `prefers-reduced-motion`.

## Changements techniques

### Backend
- `tools/task-questions.mjs` :
  - `list --json` produit un payload structuré (qid réel ou synthétisé via `commentId`, issue, blockLevel, question, why, options, recommendation, githubUrl, answers).
  - Nouveau `answer --qid X --answer "..."` qui poste `claude-answer` + `claude-resolution` (best-effort) via `gh`.
  - Parser FR/EN tolérant : fallback sur la première ligne en gras / loose si pas de `**Q (#X)** :`.
- `autopilot.mjs` :
  - `markWaitingOnQuestion(run, qid, fullPayload)` capture la question complète.
  - `findClaudeQuestionOnIssue` parse le markdown du commentaire et renvoie issue/options/recommendation/githubUrl.
  - Nouvelle méthode `answerQuestion({ qid, answer, issue })` : poste via le CLI puis auto-resume.
  - `refreshPrStatus({ runId })` : `gh pr view --json state,...` pour chaque PR du run.
  - `latest()` retombe sur le dernier run du store quand `activeRun` est null.
  - `parseClaudeQuestionBody` exporté.
- `server.mjs` :
  - `/api/questions` corrigé (utilise `node tools/task-questions.mjs list --json`).
  - `/api/questions/answer` corrigé (utilise la nouvelle commande `answer`).
  - Nouveaux : `POST /api/autopilot/answer-question`, `GET /api/autopilot/recent`, `POST /api/autopilot/pr-status`.
  - `/api/autopilot/status` ajoute `isLive` et `stale`.

### Frontend
- `mission.js` : `renderActivityTicker`, `renderQuestionCard(ap, { isLive })`, `renderRecentRuns`, helpers `prStateClass/prStateLabel`, `buildPrLinksText`.
- `app.js` : fetch `/api/autopilot/recent`, gère qid mode live vs stale, soumission de réponse + auto-resume, raccourci clavier, action `refresh-pr-status`.
- `index.html` : containers `activity-ticker`, `mission-question`, `recent-runs`.
- `styles.css` : v20 layer avec aurora hero, ticker pulsé, question card violet/amber, PR pills, recent rows.

### Tests
- `tools/task-questions.test.mjs` : 4 cas pour `parseQuestionPayload`.
- `tools/local-control/autopilot-loop.test.mjs` : capture question payload + parser legacy markers.
- `tools/local-control/tests/cockpit-v20.test.mjs` : ticker idle/live/warn, question card live+stale, recent runs, PR state helpers, mission result avec Refresh PR.

## QA

| Suite | Avant | Après |
|---|---|---|
| `pnpm local:control:test` | 179 | **181** |
| `pnpm local:control:ui:test` | 89 | **99** |
| `pnpm task:test` | 76 | **80** |
| `pnpm typecheck` | green | green |
| `pnpm lint` | green | green |
| `pnpm test` (turbo) | green | green |
| `pnpm build` | green | green |

Smoke réel sur le serveur :
- `/api/autopilot/status` retourne `isLive` + `stale` + `missionReport`.
- `/api/autopilot/recent` filtre les runs actifs et renvoie 8 missions max avec outcome.
- `/api/questions` parse la vraie question existante sur l'issue #42 (qid `q-42-c4386877718`, 2 options, recommendation extraite).
- `/api/autopilot/answer-question` répond `{ ok: false, reason: 'no active run' }` quand pas de run, fonctionne sinon.
- `/api/autopilot/pr-status` retourne `{ ok: true, prs: [...] }`.
- HTML sert les nouveaux containers (5/5).

## Ce qui est maintenant possible

1. **Lancer une mission** : choisir un mode dans le rail, cliquer Start.
2. **Répondre à une human question dans l'UI** : la carte Décision humaine apparaît avec question/options/recommandation. Clic sur une option ou réponse libre + bouton Envoyer → comment posté sur GitHub + run resumed automatiquement. Aucune intégration externe nécessaire.
3. **Voir l'avancement** : ticker live + barre de progression + carte unattended qui montre done/failed/skipped et la PR list en temps réel.
4. **Voir les dernières tasks / PR** : section Derniers runs sous le rapport, badges PR par état.
5. **Reprendre / finir un run** : Resume manuel, Reset, Retry failed, Open all PRs, Copy PR links, Refresh PR status.

## Limites restantes

- L'auto-merge réel n'est pas activé (volontaire — `allowAutoMerge=false` reste le défaut).
- `gh pr view` est synchrone par PR — sur 5+ PR on accepte 1-2s de blocage côté Refresh PR status.
- Le parser de question est tolérant mais sans qid réel le `answer` route via un qid synthétisé `q-{issue}-c{commentId}` ; un humain qui veut répondre directement sur GitHub doit utiliser `<!-- claude-answer qid: q-{issue}-c{commentId} -->`.
- Pas de Playwright visuel ici — Chromium n'est pas installé sur la machine. Les UI tests couvrent les rendus DOM.

## Procédure après merge

1. Si tu utilisais `pnpm task:questions answer` (qui n'existait pas) : c'est désormais `node tools/task-questions.mjs answer --qid <qid> --answer "..."`.
2. Lance le cockpit (`pnpm local:control`), l'activity ticker doit pulser.
3. Ouvre l'issue #42 (déjà en `waiting`) → la carte Décision humaine doit apparaître avec la vraie question, ses 2 options et la recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)